### PR TITLE
implement resize handler - without debounce

### DIFF
--- a/src/components/m-main-navigation/index.scss
+++ b/src/components/m-main-navigation/index.scss
@@ -101,8 +101,9 @@
   // @todo: check if need this here
   @include word-break();
 
-  display: table-cell;
+  position: relative;
 
+  display: table-cell;
   height: $main-navigation-height;
   padding: 0 $main-navigation__list-link-x-padding;
 

--- a/src/components/m-main-navigation/js/stroke.js
+++ b/src/components/m-main-navigation/js/stroke.js
@@ -1,7 +1,7 @@
 import css from '../../../js/css';
 import on from '../../../js/on';
 import ownerWindow from '../../../js/owner-window';
-import { requestAnimationFrame } from '../../../js/request-animation-frame';
+import { requestAnimationFrame, cancelAnimationFrame } from '../../../js/request-animation-frame';
 import { add, remove } from '../../../js/class-list';
 import UiEvents from '../../../js/ui-events';
 
@@ -132,14 +132,21 @@ class Stroke extends UiEvents {
   }
 
   _handleResize() {
-    const { _parentNode: { offsetWidth, offsetLeft } } = this;
-
-    if (offsetWidth && offsetLeft) {
-      css(this._stroke, {
-        width: `${offsetWidth}px`,
-        left: `${offsetLeft}px`,
-      });
+    if (this.resizeTimeout) {
+      cancelAnimationFrame(this.resizeTimeout);
+      this.resizeTimeout = null;
     }
+
+    this.resizeTimeout = requestAnimationFrame(() => {
+      const { _parentNode: { offsetWidth, offsetLeft } } = this;
+
+      if (offsetWidth && offsetLeft) {
+        css(this._stroke, {
+          width: `${offsetWidth}px`,
+          left: `${offsetLeft}px`,
+        });
+      }
+    });
   }
 
   _handleTransitionEnd(e) {

--- a/src/components/m-main-navigation/styles/_stroke.scss
+++ b/src/components/m-main-navigation/styles/_stroke.scss
@@ -23,4 +23,9 @@ $stroke-z-index: 1px !default;
   &.is-move {
     transition: all 0.2s ease;
   }
+
+  &.is-static {
+    left: 0 !important;
+    bottom: 1px;
+  }
 }


### PR DESCRIPTION
fixes #1 **WIP**

# Todo

- [x] listen for `resize`
- [x] add `is-static` state, hence no resize is needed, hence avoid DOM operations at all
- [x] throttle `resize` - reduce DOM operations (if still necessary)