### PR TITLE
start adding simple context implementation

### DIFF
--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -109,6 +109,7 @@ export class BaseComponent extends HTMLElement {
     }
   }
 
+  // @TODO: atm no data can be shared by enabling context, though this could be necessary
   /**
    * Provides an opt-in contextual scope for hierarchy-agnostic child components.
    */

--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -109,10 +109,18 @@ export class BaseComponent extends HTMLElement {
     }
   }
 
+  /**
+   * Provides an opt-in contextual scope for hierarchy-agnostic child components.
+   */
   setContext() {
     this.__isContext = true;
   }
 
+  /**
+   * Returns contextual scope, if defined by any parent component.
+   *
+   * @returns {ContextNode|Boolean} - Returns an associated context node if found, else `false`.
+   */
   getContext() {
     let { parentNode } = this;
 

--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -112,7 +112,7 @@ export class BaseComponent extends HTMLElement {
   /**
    * Provides an opt-in contextual scope for hierarchy-agnostic child components.
    */
-  setContext() {
+  enableContext() {
     this.__isContext = true;
   }
 
@@ -121,7 +121,7 @@ export class BaseComponent extends HTMLElement {
    *
    * @returns {ContextNode|Boolean} - Returns an associated context node if found, else `false`.
    */
-  getContext() {
+  get context() {
     let { parentNode } = this;
 
     while (parentNode && !parentNode.__isContext) {

--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -109,6 +109,21 @@ export class BaseComponent extends HTMLElement {
     }
   }
 
+  setContext() {
+    this.__isContext = true;
+  }
+
+  getContext() {
+    let { parentNode } = this;
+
+    while (parentNode && !parentNode.__isContext) {
+      // eslint-disable-next-line
+      parentNode = parentNode.parentNode;
+    }
+
+    return (parentNode && parentNode.__isContext) ? parentNode : false;
+  }
+
   static uuidv4() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
       let r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8); // eslint-disable-line

--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -121,7 +121,7 @@ export class BaseComponent extends HTMLElement {
    *
    * @returns {ContextNode|Boolean} - Returns an associated context node if found, else `false`.
    */
-  get context() {
+  get contextNode() {
     let { parentNode } = this;
 
     while (parentNode && !parentNode.__isContext) {

--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -125,7 +125,7 @@ export class BaseComponent extends HTMLElement {
     let { parentNode } = this;
 
     while (parentNode && !parentNode.__isContext) {
-      // eslint-disable-next-line
+      // eslint-disable-next-line prefer-destructuring
       parentNode = parentNode.parentNode;
     }
 

--- a/src/js/fire.js
+++ b/src/js/fire.js
@@ -1,13 +1,21 @@
 import CustomEvent from './custom-event';
 
-function fire(node, eventName, eventObject, eventInit = {}) {
+/**
+ * Trigger a custom event on the node element.
+ *
+ * @param {Element|Document|Window|XMLHttpRequest} eventTarget - The event target may be an Element in a document, the Document itself, a Window, or any other object that supports events (such as XMLHttpRequest).
+ * @param {string} eventName -  A string representing the event type to dispatch.
+ * @param {*} eventObject - The data associated with the dispatched event - will be available within `event.detail`.
+ * @param {Object} [eventInit={}] - An object specifying if the event is `cancelable` or `bubbles`.
+ */
+function fire(eventTarget, eventName, eventObject, eventInit = {}) {
   const event = new CustomEvent(eventName, {
     ...eventInit,
     detail: eventObject,
   });
 
   // Dispatch the event.
-  node.dispatchEvent(event);
+  eventTarget.dispatchEvent(event);
 }
 
 export default fire;

--- a/src/js/on.js
+++ b/src/js/on.js
@@ -10,7 +10,7 @@ const eventNameMap = {
 /**
  * Attach an event handler function for one event to the selected element, optionally delegated by given className.
  *
- * @param {Element|Document|Window|XMLHttpRequest} eventTarget - The event target may be an Element in a document, the Document itself, a Window, or any other object that supports events (such as XMLHttpRequest)
+ * @param {Element|Document|Window|XMLHttpRequest} eventTarget - The event target may be an Element in a document, the Document itself, a Window, or any other object that supports events (such as XMLHttpRequest).
  * @param {string} eventName -  A string representing the event type to listen for.
  * @param {string} [className] - A CSS class name upon which the given callback should be executet (without the preceding dot).
  * @param [Function] func - A function which receives a notification when an event of the specified type occurs.

--- a/src/js/pubsub.js
+++ b/src/js/pubsub.js
@@ -4,11 +4,26 @@ import debounce from './debounce';
 
 const cache = {};
 
+/**
+ * Publish a message regarding a given topic.
+ *
+ * @param {String} topic - A string defining the topic to publish to.
+ * @param {*} arg - The data associate with the generated event.
+ * @param {Element} [node=document] - The node to publish message to.
+ */
 export function publish(topic, arg, node = document) {
   // Cycle through topics queue, fire!
   fire(node, topic, arg);
 }
 
+/**
+ * Subscribe to message reagarding a given topic.
+ *
+ * @param {String} topic - A string defining the topic to subscribe to.
+ * @param {Function} func - A callback function to be executed on every published message.
+ * @param {Element} [node=document] - The node to publish message to.
+ * @returns {Function} - Returns a function to unsubscribe.
+ */
 export function subscribe(topic, func, node = document) {
   if (!cache[topic]) {
     cache[topic] = debounce(onsubscribe(topic), 100);

--- a/src/js/pubsub.js
+++ b/src/js/pubsub.js
@@ -12,6 +12,7 @@ const cache = {};
  * @param {Element} [node=document] - The node to publish message to.
  */
 export function publish(topic, arg, node = document) {
+  // @TODO: atm this does not define cancelable nor bubbles
   // Cycle through topics queue, fire!
   fire(node, topic, arg);
 }


### PR DESCRIPTION
improves #31 

This adds simple opt-in methods to support context based actions.
In combination with `pub/sub` this enables contextual intercommunication within components in a hierarchy-agnostic manner.

# Todo

- [x] enable opt-in contextual scope
- [x] has to work with redundant modules