### PR TITLE
Feature/add sticky component

### DIFF
--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -25,6 +25,7 @@ export class BaseComponent extends HTMLElement {
    * @return {type}        description
    */
   _initialise(styles, template = null) {
+    this.initialClassName = this.className;
     this._styles = styles;
     this._template = template;
   }

--- a/src/components/o-header/_preview.html
+++ b/src/components/o-header/_preview.html
@@ -1,200 +1,202 @@
-<axa-header>
-  <axa-top-content-bar type="commercial">
-    <p class="m-top-content-bar__text">commercial <a href="#" class="a-link a-link--white">link</a> stuff</p>
-    <button class="m-button m-button--white m-button--ghost m-top-content-bar__button">get it for free</button>
-  </axa-top-content-bar>
+<axa-sticky-container>
+  <axa-header>
+    <axa-top-content-bar type="commercial">
+      <p class="m-top-content-bar__text">commercial <a href="#" class="a-link a-link--white">link</a> stuff</p>
+      <button class="m-button m-button--white m-button--ghost m-top-content-bar__button">get it for free</button>
+    </axa-top-content-bar>
 
-  <axa-meta-navigation left='[
-      {"name": "individuals", "url": "#"},
-      {"name": "small busineses", "url": "#"},
-      {"name": "businesses", "url": "#"}
+    <axa-sticky>
+    <axa-meta-navigation left='[
+        {"name": "individuals", "url": "#"},
+        {"name": "small busineses", "url": "#"},
+        {"name": "businesses", "url": "#"}
+      ]'>
+    </axa-meta-navigation>
+
+    <axa-main-navigation items='[
+      {
+        "url": "#",
+        "name": "Offers",
+        "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
+        "submenu": [
+          {
+            "col": "3",
+            "column": [
+              {
+                "boxes": [
+                  {"url": "#", "name": "Property insurance"},
+                  {"url": "#", "name": "Engineering insurance"},
+                  {"url": "#", "name": "Third-party liability insurance"},
+                  {"url": "#", "name": "Fidelity insurance"},
+                  {"url": "#", "name": "Companies"},
+                  {"url": "#", "name": "Transportation insurance <br> subline"},
+                  {"url": "#", "name": "Building insurance"},
+                  {"url": "#", "name": "Construction insurance"},
+                  {"url": "#", "name": "Guarantees and bonds"},
+                  {"url": "#", "name": "Credit insurance"},
+                  {"url": "#", "name": "Epidemic insurance"},
+                  {"url": "#", "name": "Cyber insurance"}
+                ],
+                "title": "Liability and property"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "Car insurance"},
+                  {"url": "#", "name": "Watercraft insurance"},
+                  {"url": "#", "name": "Aviation insurance"}
+                ],
+                "title": "Vehicles"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "Daily sickness benefits insurance"},
+                  {"url": "#", "name": "Accident insurance for companies"}
+                ],
+                "title": "Persons"
+              }
+            ]
+          },
+          {
+            "col": "3",
+            "column": [
+              {
+                "boxes": [
+                  {"url": "#", "name": "Solutions for start-ups and SMEs"},
+                  {"url": "#", "name": "Pension fund solutions"}
+                ],
+                "title": "Occupational benefits"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "Smart Fleet"},
+                  {"url": "#", "name": "Pre-finance customer invoices"}
+                ],
+                "title": "AXA & partners"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "Corporate Health Management"},
+                  {"url": "#", "name": "Customer magazine"},
+                  {"url": "#", "name": "Current legislation on Pillar 2 – BVG"}
+                ],
+                "title": "Knowledge"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "#",
+        "name": "your situation",
+        "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
+        "submenu": [
+          {
+            "col": "2",
+            "isWide": true,
+            "column": [
+              {
+                "boxes": [
+                  {"url": "#", "name": "Your company start-up"},
+                  {"url": "#", "name": "Your self-employment"},
+                  {"url": "#", "name": "Your succession planning"},
+                  {"url": "#", "name": "The health of your employees"}
+                ],
+                "title": "You are interested in"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "Company with up to 20 employees"},
+                  {"url": "#", "name": "Company with 20 to 100 employees"},
+                  {"url": "#", "name": "Corporates with 100+ employees"}
+                ],
+                "title": "You are a ..."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "#",
+        "name": "Advice, Contact, Service",
+        "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
+        "submenu": [
+          {
+            "col": "3",
+            "column": [
+              {
+                "boxes": [
+                  {"url": "#", "name": "Corporate customer advisor"},
+                  {"url": "#", "name": "Consultant pension fund"},
+                  {"url": "#", "name": "Insurance check"}
+                ],
+                "title": "Advice"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "General contact"}
+                ],
+                "title": "Contact"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "Download-Center Corporate customers"}
+                ],
+                "title": "Service"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "#",
+        "name": "Report and Update",
+        "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
+        "submenu": [
+          {
+            "col": "2",
+            "column": [
+              {
+                "boxes": [
+                  {"url": "#", "name": "Electronic salary notification"},
+                  {"url": "#", "name": "Report accident / illness"},
+                  {"url": "#", "name": "File a claim"},
+                  {"url": "#", "name": "Online contract administration for BVG"}
+                ],
+                "title": "Notify"
+              },
+              {
+                "boxes": [
+                  {"url": "#", "name": "myAXA customer portal"}
+                ],
+                "title": "Update"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "url": "#",
+        "name": "Blog",
+        "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
+        "submenu": [
+          {
+            "col": "1",
+            "column": [
+              {
+                "boxes": [
+                  {"url": "#", "name": "Link"},
+                  {"url": "#", "name": "Link"},
+                  {"url": "#", "name": "Link"}
+                ],
+                "title": "Category"
+              }
+            ]
+          }
+        ]
+      }
     ]'>
-  </axa-meta-navigation>
-
-  <axa-main-navigation items='[
-    {
-      "url": "#",
-      "name": "Offers",
-      "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
-      "submenu": [
-        {
-          "col": "3",
-          "column": [
-            {
-              "boxes": [
-                {"url": "#", "name": "Property insurance"},
-                {"url": "#", "name": "Engineering insurance"},
-                {"url": "#", "name": "Third-party liability insurance"},
-                {"url": "#", "name": "Fidelity insurance"},
-                {"url": "#", "name": "Companies"},
-                {"url": "#", "name": "Transportation insurance <br> subline"},
-                {"url": "#", "name": "Building insurance"},
-                {"url": "#", "name": "Construction insurance"},
-                {"url": "#", "name": "Guarantees and bonds"},
-                {"url": "#", "name": "Credit insurance"},
-                {"url": "#", "name": "Epidemic insurance"},
-                {"url": "#", "name": "Cyber insurance"}
-              ],
-              "title": "Liability and property"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "Car insurance"},
-                {"url": "#", "name": "Watercraft insurance"},
-                {"url": "#", "name": "Aviation insurance"}
-              ],
-              "title": "Vehicles"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "Daily sickness benefits insurance"},
-                {"url": "#", "name": "Accident insurance for companies"}
-              ],
-              "title": "Persons"
-            }
-          ]
-        },
-        {
-          "col": "3",
-          "column": [
-            {
-              "boxes": [
-                {"url": "#", "name": "Solutions for start-ups and SMEs"},
-                {"url": "#", "name": "Pension fund solutions"}
-              ],
-              "title": "Occupational benefits"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "Smart Fleet"},
-                {"url": "#", "name": "Pre-finance customer invoices"}
-              ],
-              "title": "AXA & partners"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "Corporate Health Management"},
-                {"url": "#", "name": "Customer magazine"},
-                {"url": "#", "name": "Current legislation on Pillar 2 – BVG"}
-              ],
-              "title": "Knowledge"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "url": "#",
-      "name": "your situation",
-      "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
-      "submenu": [
-        {
-          "col": "2",
-          "isWide": true,
-          "column": [
-            {
-              "boxes": [
-                {"url": "#", "name": "Your company start-up"},
-                {"url": "#", "name": "Your self-employment"},
-                {"url": "#", "name": "Your succession planning"},
-                {"url": "#", "name": "The health of your employees"}
-              ],
-              "title": "You are interested in"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "Company with up to 20 employees"},
-                {"url": "#", "name": "Company with 20 to 100 employees"},
-                {"url": "#", "name": "Corporates with 100+ employees"}
-              ],
-              "title": "You are a ..."
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "url": "#",
-      "name": "Advice, Contact, Service",
-      "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
-      "submenu": [
-        {
-          "col": "3",
-          "column": [
-            {
-              "boxes": [
-                {"url": "#", "name": "Corporate customer advisor"},
-                {"url": "#", "name": "Consultant pension fund"},
-                {"url": "#", "name": "Insurance check"}
-              ],
-              "title": "Advice"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "General contact"}
-              ],
-              "title": "Contact"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "Download-Center Corporate customers"}
-              ],
-              "title": "Service"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "url": "#",
-      "name": "Report and Update",
-      "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
-      "submenu": [
-        {
-          "col": "2",
-          "column": [
-            {
-              "boxes": [
-                {"url": "#", "name": "Electronic salary notification"},
-                {"url": "#", "name": "Report accident / illness"},
-                {"url": "#", "name": "File a claim"},
-                {"url": "#", "name": "Online contract administration for BVG"}
-              ],
-              "title": "Notify"
-            },
-            {
-              "boxes": [
-                {"url": "#", "name": "myAXA customer portal"}
-              ],
-              "title": "Update"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "url": "#",
-      "name": "Blog",
-      "subMenuIndexSettings": {"title": "Index Page", "close": "Close" },
-      "submenu": [
-        {
-          "col": "1",
-          "column": [
-            {
-              "boxes": [
-                {"url": "#", "name": "Link"},
-                {"url": "#", "name": "Link"},
-                {"url": "#", "name": "Link"}
-              ],
-              "title": "Category"
-            }
-          ]
-        }
-      ]
-    }
-  ]'>
-  </axa-main-navigation>
-
-
-</axa-header>
-<div style="height: 500px;">Empty space</div>
+    </axa-main-navigation>
+    </axa-sticky>
+  </axa-header>
+  <div style="height: 500px;">Empty space</div>
+</axa-sticky-container>

--- a/src/components/o-sticky/_example.html
+++ b/src/components/o-sticky/_example.html
@@ -1,0 +1,1 @@
+<!--Nothing here yet-->

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -1,6 +1,8 @@
 <h1>Basic</h1>
 
 <axa-sticky-container>
+  Some content before
+
   <axa-sticky>
     Stick me
   </axa-sticky>

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -3,7 +3,7 @@
     Stick me
   </axa-sticky>
 
-  <div style="background: yellow; height: 1200px;"></div>
+  <div style="background: yellow; height: 1200px; opacity: 0.7;"></div>
 
   <axa-sticky>
     Stick me too

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -1,0 +1,3 @@
+<axa-sticky>
+  Stick me
+</axa-sticky>

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -1,9 +1,9 @@
 <h1>Basic</h1>
 
-<axa-sticky-container>
+<axa-sticky-container debug>
   Some content before
 
-  <axa-sticky>
+  <axa-sticky debug>
     Stick me
   </axa-sticky>
 
@@ -12,32 +12,32 @@
 
 <h1>Stacked</h1>
 
-<axa-sticky-container style="height: 300px;">
-  <axa-sticky>
+<axa-sticky-container debug style="height: 300px;">
+  <axa-sticky debug>
     Stick #1
   </axa-sticky>
 
   Sticky Container #1
 </axa-sticky-container>
 
-<axa-sticky-container style="height: 300px;">
-  <axa-sticky>
+<axa-sticky-container debug style="height: 300px;">
+  <axa-sticky debug>
     Stick #2
   </axa-sticky>
 
   Sticky Container #2
 </axa-sticky-container>
 
-<axa-sticky-container style="height: 300px;">
-  <axa-sticky>
+<axa-sticky-container debug style="height: 300px;">
+  <axa-sticky debug>
     Stick #3
   </axa-sticky>
 
   Sticky Container #3
 </axa-sticky-container>
 
-<axa-sticky-container style="height: 300px;">
-  <axa-sticky>
+<axa-sticky-container debug style="height: 300px;">
+  <axa-sticky debug>
     Stick #4
   </axa-sticky>
 

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -1,9 +1,9 @@
 <h1>Basic</h1>
 
-<axa-sticky-container debug>
+<axa-sticky-container debug class="foo">
   Some content before
 
-  <axa-sticky debug>
+  <axa-sticky debug class="bar">
     Stick me
   </axa-sticky>
 

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -1,3 +1,11 @@
-<axa-sticky>
-  Stick me
-</axa-sticky>
+<axa-sticky-container>
+  <axa-sticky>
+    Stick me
+  </axa-sticky>
+
+  <div style="background: yellow; height: 1200px;"></div>
+
+  <axa-sticky>
+    Stick me too
+  </axa-sticky>
+</axa-sticky-container>

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -5,12 +5,12 @@
     Stick me
   </axa-sticky>
 
-  <div style="background: yellow; height: 1200px; opacity: 0.7;"></div>
+  <div style="height: 1200px;"></div>
 </axa-sticky-container>
 
 <h1>Stacked</h1>
 
-<axa-sticky-container style="background: yellow; height: 300px;">
+<axa-sticky-container style="height: 300px;">
   <axa-sticky>
     Stick #1
   </axa-sticky>
@@ -18,7 +18,7 @@
   Sticky Container #1
 </axa-sticky-container>
 
-<axa-sticky-container style="background: yellow; height: 300px;">
+<axa-sticky-container style="height: 300px;">
   <axa-sticky>
     Stick #2
   </axa-sticky>
@@ -26,7 +26,7 @@
   Sticky Container #2
 </axa-sticky-container>
 
-<axa-sticky-container style="background: yellow; height: 300px;">
+<axa-sticky-container style="height: 300px;">
   <axa-sticky>
     Stick #3
   </axa-sticky>
@@ -34,7 +34,7 @@
   Sticky Container #3
 </axa-sticky-container>
 
-<axa-sticky-container style="background: yellow; height: 300px;">
+<axa-sticky-container style="height: 300px;">
   <axa-sticky>
     Stick #4
   </axa-sticky>

--- a/src/components/o-sticky/_preview.html
+++ b/src/components/o-sticky/_preview.html
@@ -1,11 +1,43 @@
+<h1>Basic</h1>
+
 <axa-sticky-container>
   <axa-sticky>
     Stick me
   </axa-sticky>
 
   <div style="background: yellow; height: 1200px; opacity: 0.7;"></div>
+</axa-sticky-container>
 
+<h1>Stacked</h1>
+
+<axa-sticky-container style="background: yellow; height: 300px;">
   <axa-sticky>
-    Stick me too
+    Stick #1
   </axa-sticky>
+
+  Sticky Container #1
+</axa-sticky-container>
+
+<axa-sticky-container style="background: yellow; height: 300px;">
+  <axa-sticky>
+    Stick #2
+  </axa-sticky>
+
+  Sticky Container #2
+</axa-sticky-container>
+
+<axa-sticky-container style="background: yellow; height: 300px;">
+  <axa-sticky>
+    Stick #3
+  </axa-sticky>
+
+  Sticky Container #3
+</axa-sticky-container>
+
+<axa-sticky-container style="background: yellow; height: 300px;">
+  <axa-sticky>
+    Stick #4
+  </axa-sticky>
+
+  Sticky Container #4
 </axa-sticky-container>

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -1,0 +1,19 @@
+import { BaseComponentGlobal } from '../_abstract/component-types';
+import { domready } from '../../js/domready';
+import styles from './index.scss';
+
+class Sticky extends BaseComponentGlobal {
+  constructor() {
+    super(styles);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.className = 'o-sticky';
+  }
+}
+
+domready(() => {
+  window.customElements.define('axa-sticky', Sticky);
+});

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -1,19 +1,53 @@
 import { BaseComponentGlobal } from '../_abstract/component-types';
 import { domready } from '../../js/domready';
-import styles from './index.scss';
+import stylesStickyContainer from './scss/sticky-container.scss';
+import stylesSticky from './scss/sticky.scss';
+import Sticky from './js/sticky';
+import StickyContainer from './js/sticky-container';
 
-class Sticky extends BaseComponentGlobal {
+class AXAStickyContainer extends BaseComponentGlobal {
   constructor() {
-    super(styles);
+    super(stylesStickyContainer);
+
+    this.enableContext();
   }
 
   connectedCallback() {
     super.connectedCallback();
 
-    this.className = 'o-sticky';
+    this.className = 'o-sticky-container js-sticky-container';
+
+    this.stickyContainer = new StickyContainer(this);
+  }
+
+  disconnectedCallback() {
+
+  }
+}
+
+class AXASticky extends BaseComponentGlobal {
+  constructor() {
+    super(stylesSticky);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.className = 'o-sticky js-sticky';
+
+    this.sticky = new Sticky(this);
+  }
+
+  contextCallback(contextNode) {
+    this.sticky.contextNode = contextNode;
+  }
+
+  disconnectedCallback() {
+
   }
 }
 
 domready(() => {
-  window.customElements.define('axa-sticky', Sticky);
+  window.customElements.define('axa-sticky-container', AXAStickyContainer);
+  window.customElements.define('axa-sticky', AXASticky);
 });

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -28,7 +28,8 @@ class AXAStickyContainer extends BaseComponentGlobal {
   }
 
   disconnectedCallback() {
-
+    this.stickyContainer.destroy();
+    delete this.stickyContainer;
   }
 }
 
@@ -56,7 +57,8 @@ class AXASticky extends BaseComponentGlobal {
   }
 
   disconnectedCallback() {
-
+    this.sticky.destroy();
+    delete this.sticky;
   }
 }
 

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -2,6 +2,7 @@ import { BaseComponentGlobal } from '../_abstract/component-types';
 import { domready } from '../../js/domready';
 import stylesStickyContainer from './scss/sticky-container.scss';
 import stylesSticky from './scss/sticky.scss';
+import templateSticky from './sticky.template';
 import Sticky from './js/sticky';
 import StickyContainer from './js/sticky-container';
 
@@ -27,7 +28,7 @@ class AXAStickyContainer extends BaseComponentGlobal {
 
 class AXASticky extends BaseComponentGlobal {
   constructor() {
-    super(stylesSticky);
+    super(stylesSticky, templateSticky);
   }
 
   connectedCallback() {

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -1,5 +1,7 @@
+import classnames from 'classnames';
 import { BaseComponentGlobal } from '../_abstract/component-types';
 import { domready } from '../../js/domready';
+import getAttribute from '../../js/get-attribute';
 import stylesStickyContainer from './scss/sticky-container.scss';
 import stylesSticky from './scss/sticky.scss';
 import templateSticky from './sticky.template';
@@ -16,7 +18,11 @@ class AXAStickyContainer extends BaseComponentGlobal {
   connectedCallback() {
     super.connectedCallback();
 
-    this.className = 'o-sticky-container js-sticky-container';
+    const debug = getAttribute(this, 'debug');
+
+    this.className = classnames('o-sticky-container js-sticky-container', {
+      'o-sticky-container--debug': debug,
+    });
 
     this.stickyContainer = new StickyContainer(this);
   }
@@ -34,7 +40,11 @@ class AXASticky extends BaseComponentGlobal {
   connectedCallback() {
     super.connectedCallback();
 
-    this.className = 'o-sticky js-sticky';
+    const debug = getAttribute(this, 'debug');
+
+    this.className = classnames('o-sticky js-sticky', {
+      'o-sticky--debug': debug,
+    });
 
     this.sticky = new Sticky(this);
   }

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -35,6 +35,8 @@ class AXAStickyContainer extends BaseComponentGlobal {
 class AXASticky extends BaseComponentGlobal {
   constructor() {
     super(stylesSticky, templateSticky);
+
+    this.selectContext('axa-sticky-container');
   }
 
   connectedCallback() {

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -20,7 +20,7 @@ class AXAStickyContainer extends BaseComponentGlobal {
 
     const debug = getAttribute(this, 'debug');
 
-    this.className = classnames('o-sticky-container js-sticky-container', {
+    this.className = classnames(this.initialClassName, 'o-sticky-container js-sticky-container', {
       'o-sticky-container--debug': debug,
     });
 
@@ -45,7 +45,7 @@ class AXASticky extends BaseComponentGlobal {
 
     const debug = getAttribute(this, 'debug');
 
-    this.className = classnames('o-sticky js-sticky', {
+    this.className = classnames(this.initialClassName, 'o-sticky js-sticky', {
       'o-sticky--debug': debug,
     });
 

--- a/src/components/o-sticky/index.scss
+++ b/src/components/o-sticky/index.scss
@@ -1,0 +1,3 @@
+.o-sticky {
+  display: block;
+}

--- a/src/components/o-sticky/index.scss
+++ b/src/components/o-sticky/index.scss
@@ -1,3 +1,0 @@
-.o-sticky {
-  display: block;
-}

--- a/src/components/o-sticky/js/event-manager.js
+++ b/src/components/o-sticky/js/event-manager.js
@@ -44,6 +44,7 @@ class EventManager {
     // the diference between the last scroll position
     const diffTop = scrollTop - this.lastScrollTop;
     // the scroll direction -> -1: top, 0: node, 1: bottom
+    // eslint-disable-next-line no-nested-tenary
     const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
     // width of viewport
     const viewportWidth = getViewportWidth();
@@ -56,17 +57,17 @@ class EventManager {
 
     // enter a sticky container
     const enterContainer = stickyContainerNode && !this.lastStickyContainer;
-    // move between containers
-    const moveContainer = stickyContainerNode && this.lastStickyContainer && stickyContainerNode !== this.lastStickyContainer;
     // leave a sticky container
     const leaveContainer = !stickyContainerNode && this.lastStickyContainer;
+    // move between containers
+    const moveContainer = stickyContainerNode && this.lastStickyContainer && stickyContainerNode !== this.lastStickyContainer;
 
     // enter a sticky node
     const enterSticky = stickyNode && !this.lastStickyNode;
-    // move a sticky node
-    const moveSticky = stickyNode && this.lastStickyNode && stickyNode !== this.lastStickyNode;
     // leave a sticky node
     const leaveSticky = !stickyNode && this.lastStickyNode;
+    // move a sticky node
+    const moveSticky = stickyNode && this.lastStickyNode && stickyNode !== this.lastStickyNode;
 
     if (enterContainer || moveContainer) {
       publish('sticky-container/enter', null, stickyContainerNode);
@@ -75,7 +76,6 @@ class EventManager {
     if (leaveContainer || moveContainer) {
       publish('sticky-container/leave', null, this.lastStickyContainer);
     }
-
 
     console.log(`sticky -> ${event.type}`);
     console.log(`top: ${scrollTop}; diff: ${diffTop}, direction: ${direction}`);

--- a/src/components/o-sticky/js/event-manager.js
+++ b/src/components/o-sticky/js/event-manager.js
@@ -1,5 +1,5 @@
 import on from '../../../js/on';
-import { has } from '../../../js/class-list';
+import closest from '../../../js/closest';
 import throttle from '../../../js/throttle';
 import getScrollTop from '../../../js/get-scroll-top';
 import elementFromPagePoint from '../../../js/element-from-page-point';
@@ -53,20 +53,6 @@ class EventManager {
     this.lastStickyNode = stickyNode;
     this.lastStickyContainer = stickyContainerNode;
   }
-}
-
-function closest(node, className) {
-  let parentNode = node;
-
-  while (parentNode) {
-    if (has(parentNode, className)) {
-      return parentNode;
-    }
-
-    parentNode = parentNode.parentNode;
-  }
-
-  return null;
 }
 
 export default function factory() {

--- a/src/components/o-sticky/js/event-manager.js
+++ b/src/components/o-sticky/js/event-manager.js
@@ -40,9 +40,9 @@ class EventManager {
     const scrollTop = getScrollTop();
     const diffTop = scrollTop - this.lastScrollTop;
     const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
-    const topNode = closest(elementFromPagePoint(0, scrollTop), 'js-sticky');
+    const topNode = elementFromPagePoint(0, scrollTop);
     const stickyNode = closest(topNode, 'js-sticky');
-    const stickyContainerNode = closest(stickyNode, 'js-sticky-container');
+    const stickyContainerNode = closest(stickyNode || topNode, 'js-sticky-container');
 
     console.log(`sticky -> ${event.type}`);
     console.log(`top: ${scrollTop}; diff: ${diffTop}, direction: ${direction}`);

--- a/src/components/o-sticky/js/event-manager.js
+++ b/src/components/o-sticky/js/event-manager.js
@@ -1,0 +1,78 @@
+import on from '../../../js/on';
+import { has } from '../../../js/class-list';
+import throttle from '../../../js/throttle';
+import getScrollTop from '../../../js/get-scroll-top';
+import elementFromPagePoint from '../../../js/element-from-page-point';
+
+let instance;
+const events = [
+  'resize',
+  'scroll',
+  'touchstart',
+  'touchmove',
+  'touchend',
+  'pageshow',
+  'load',
+].join(' ');
+
+class EventManager {
+  constructor() {
+    this.lastScrollTop = 0;
+
+    this._change = throttle(this._change.bind(this), 100);
+
+    this._on();
+  }
+
+  _on() {
+    this._off();
+
+    this._unChange = on(window, events, this._change);
+  }
+
+  _off() {
+    if (this._unChange) {
+      this._unChange();
+    }
+  }
+
+  _change(event) {
+    const scrollTop = getScrollTop();
+    const diffTop = scrollTop - this.lastScrollTop;
+    const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
+    const topNode = closest(elementFromPagePoint(0, scrollTop), 'js-sticky');
+    const stickyNode = closest(topNode, 'js-sticky');
+    const stickyContainerNode = closest(stickyNode, 'js-sticky-container');
+
+    console.log(`sticky -> ${event.type}`);
+    console.log(`top: ${scrollTop}; diff: ${diffTop}, direction: ${direction}`);
+
+    console.log(stickyNode, stickyContainerNode);
+
+    this.lastScrollTop = scrollTop;
+    this.lastStickyNode = stickyNode;
+    this.lastStickyContainer = stickyContainerNode;
+  }
+}
+
+function closest(node, className) {
+  let parentNode = node;
+
+  while (parentNode) {
+    if (has(parentNode, className)) {
+      return parentNode;
+    }
+
+    parentNode = parentNode.parentNode;
+  }
+
+  return null;
+}
+
+export default function factory() {
+  if (!instance) {
+    instance = new EventManager();
+  }
+
+  return instance;
+}

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -1,0 +1,11 @@
+import EventManager from './event-manager';
+
+class StickyContainer {
+  constructor(rootNode) {
+    this.roodNode = rootNode;
+
+    this.eventManagerInstance = EventManager();
+  }
+}
+
+export default StickyContainer;

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -10,10 +10,11 @@ class StickyContainer {
     this.roodNode = rootNode;
     this.state = states.IS_IDLE;
 
-    this._enter = this._enter.bind(this);
-    this._leave = this._leave.bind(this);
+    this._active = this._active.bind(this);
+    this._idle = this._idle.bind(this);
 
     this.spy = StickySpy();
+    this.spy.addContainer(rootNode);
 
     this._on();
   }
@@ -21,21 +22,21 @@ class StickyContainer {
   _on() {
     this._off();
 
-    this._unEnter = subscribe('sticky-container/enter', this._enter, this.roodNode);
-    this._unLeave = subscribe('sticky-container/leave', this._leave, this.roodNode);
+    this._unActive = subscribe('sticky-container/active', this._active, this.roodNode);
+    this._unIdle = subscribe('sticky-container/idle', this._idle, this.roodNode);
   }
 
   _off() {
-    if (this._unEnter) {
-      this._unEnter();
+    if (this._unActive) {
+      this._unActive();
     }
 
-    if (this._unLeave) {
-      this._unLeave();
+    if (this._unIdle) {
+      this._unIdle();
     }
   }
 
-  _enter() {
+  _active() {
     if (this.state === states.IS_ACTIVE) {
       return;
     }
@@ -44,7 +45,7 @@ class StickyContainer {
     add(this.roodNode, 'is-sticky-container-active');
   }
 
-  _leave() {
+  _idle() {
     if (this.state === states.IS_IDLE) {
       return;
     }

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -1,4 +1,4 @@
-import EventManager from './event-manager';
+import StickySpy from './sticky-spy';
 import Enum from '../../../js/enum';
 import { subscribe } from '../../../js/pubsub';
 import { add, remove } from '../../../js/class-list';
@@ -13,7 +13,7 @@ class StickyContainer {
     this._enter = this._enter.bind(this);
     this._leave = this._leave.bind(this);
 
-    this.eventManagerInstance = EventManager();
+    this.spy = StickySpy();
 
     this._on();
   }

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -1,10 +1,56 @@
 import EventManager from './event-manager';
+import Enum from '../../../js/enum';
+import { subscribe } from '../../../js/pubsub';
+import { add, remove } from '../../../js/class-list';
+
+const states = Enum('IS_IDLE', 'IS_ACTIVE');
 
 class StickyContainer {
   constructor(rootNode) {
     this.roodNode = rootNode;
+    this.state = states.IS_IDLE;
+
+    this._enter = this._enter.bind(this);
+    this._leave = this._leave.bind(this);
 
     this.eventManagerInstance = EventManager();
+
+    this._on();
+  }
+
+  _on() {
+    this._off();
+
+    this._unEnter = subscribe('sticky-container/enter', this._enter, this.roodNode);
+    this._unLeave = subscribe('sticky-container/leave', this._leave, this.roodNode);
+  }
+
+  _off() {
+    if (this._unEnter) {
+      this._unEnter();
+    }
+
+    if (this._unLeave) {
+      this._unLeave();
+    }
+  }
+
+  _enter() {
+    if (this.state === states.IS_ACTIVE) {
+      return;
+    }
+    this.state = states.IS_ACTIVE;
+
+    add(this.roodNode, 'is-sticky-container-active');
+  }
+
+  _leave() {
+    if (this.state === states.IS_IDLE) {
+      return;
+    }
+    this.state = states.IS_IDLE;
+
+    remove(this.roodNode, 'is-sticky-container-active');
   }
 }
 

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -6,6 +6,10 @@ import { add, remove } from '../../../js/class-list';
 const states = Enum('IS_IDLE', 'IS_ACTIVE');
 
 class StickyContainer {
+  static DEFAULTS = {
+    isActiveClass: 'is-sticky-container-active',
+  };
+
   constructor(rootNode) {
     this.roodNode = rootNode;
     this.state = states.IS_IDLE;
@@ -42,7 +46,7 @@ class StickyContainer {
     }
     this.state = states.IS_ACTIVE;
 
-    add(this.roodNode, 'is-sticky-container-active');
+    add(this.roodNode, StickyContainer.DEFAULTS.isActiveClass);
   }
 
   _idle() {
@@ -51,7 +55,7 @@ class StickyContainer {
     }
     this.state = states.IS_IDLE;
 
-    remove(this.roodNode, 'is-sticky-container-active');
+    remove(this.roodNode, StickyContainer.DEFAULTS.isActiveClass);
   }
 }
 

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -60,6 +60,14 @@ class StickyContainer {
     add(this.roodNode, StickyContainer.DEFAULTS.isIdleClass);
     remove(this.roodNode, StickyContainer.DEFAULTS.isActiveClass);
   }
+
+  destroy() {
+    this._off();
+
+    this.spy.remove(this.roodNode);
+    delete this.spy;
+    delete this.roodNode;
+  }
 }
 
 export default StickyContainer;

--- a/src/components/o-sticky/js/sticky-container.js
+++ b/src/components/o-sticky/js/sticky-container.js
@@ -8,6 +8,7 @@ const states = Enum('IS_IDLE', 'IS_ACTIVE');
 class StickyContainer {
   static DEFAULTS = {
     isActiveClass: 'is-sticky-container-active',
+    isIdleClass: 'is-sticky-container-idle',
   };
 
   constructor(rootNode) {
@@ -47,6 +48,7 @@ class StickyContainer {
     this.state = states.IS_ACTIVE;
 
     add(this.roodNode, StickyContainer.DEFAULTS.isActiveClass);
+    remove(this.roodNode, StickyContainer.DEFAULTS.isIdleClass);
   }
 
   _idle() {
@@ -55,6 +57,7 @@ class StickyContainer {
     }
     this.state = states.IS_IDLE;
 
+    add(this.roodNode, StickyContainer.DEFAULTS.isIdleClass);
     remove(this.roodNode, StickyContainer.DEFAULTS.isActiveClass);
   }
 }

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -4,12 +4,12 @@ import { publish } from '../../../js/pubsub';
 import { requestAnimationFrame } from '../../../js/request-animation-frame';
 
 let instance;
-const forceRepaint = [
+const criticalEvents = [
   'resize',
   'orientationchange',
 ].join(' ');
 const events = [
-  forceRepaint,
+  criticalEvents,
   'scroll',
   'touchstart',
   'touchmove',
@@ -47,7 +47,7 @@ class StickySpy {
   }
 
   _change({ type }) {
-    if (forceRepaint.indexOf(type) >= 0) {
+    if (criticalEvents.indexOf(type) >= 0) {
       this.forceRepaint = true;
     }
 

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -17,7 +17,7 @@ const events = [
   'load',
 ].join(' ');
 
-class EventManager {
+class StickySpy {
   constructor() {
     this.lastScrollTop = 0;
 
@@ -90,7 +90,7 @@ class EventManager {
 
 export default function factory() {
   if (!instance) {
-    instance = new EventManager();
+    instance = new StickySpy();
   }
 
   return instance;

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -32,6 +32,8 @@ class StickySpy {
 
   addContainer(node) {
     this.containerNodes.push(node);
+
+    this._change();
   }
 
   _on() {
@@ -46,7 +48,7 @@ class StickySpy {
     }
   }
 
-  _change({ type }) {
+  _change({ type } = {}) {
     if (criticalEvents.indexOf(type) >= 0) {
       this.forceRepaint = true;
     }

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -64,7 +64,7 @@ class StickySpy {
       const scrollTop = getScrollTop();
       // the diference between the last scroll position
       const diffTop = scrollTop - this.lastScrollTop;
-      // the scroll direction -> -1: top, 0: node, 1: bottom
+      // the scroll direction -> -1: top, 0: none, 1: bottom
       // eslint-disable-next-line no-nested-ternary
       const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
       // all spied container nodes

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -1,10 +1,10 @@
 import on from '../../../js/on';
 import closest from '../../../js/closest';
-import throttle from '../../../js/throttle';
 import getScrollTop from '../../../js/get-scroll-top';
 import elementFromPagePoint from '../../../js/element-from-page-point';
 import { getViewportWidth, getViewportHeight } from '../../../js/viewport';
 import { publish } from '../../../js/pubsub';
+import { requestAnimationFrame } from '../../../js/request-animation-frame';
 
 let instance;
 const events = [
@@ -19,9 +19,10 @@ const events = [
 
 class StickySpy {
   constructor() {
+    this.framePending = false;
     this.lastScrollTop = 0;
 
-    this._change = throttle(this._change.bind(this), 100);
+    this._change = this._change.bind(this);
 
     this._on();
   }
@@ -39,52 +40,60 @@ class StickySpy {
   }
 
   _change(event) {
-    // the scroll position of the y-axis
-    const scrollTop = getScrollTop();
-    // the diference between the last scroll position
-    const diffTop = scrollTop - this.lastScrollTop;
-    // the scroll direction -> -1: top, 0: node, 1: bottom
-    // eslint-disable-next-line no-nested-tenary
-    const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
-    // width of viewport
-    const viewportWidth = getViewportWidth();
-    // current top most element at the center of the first pixel in viewport
-    const topNode = elementFromPagePoint(viewportWidth / 2, scrollTop);
-    // closest sticky node or null
-    const stickyNode = closest(topNode, 'js-sticky');
-    // closest sticky container node or null
-    const stickyContainerNode = closest(stickyNode || topNode, 'js-sticky-container');
-
-    // enter a sticky container
-    const enterContainer = stickyContainerNode && !this.lastStickyContainer;
-    // leave a sticky container
-    const leaveContainer = !stickyContainerNode && this.lastStickyContainer;
-    // move between containers
-    const moveContainer = stickyContainerNode && this.lastStickyContainer && stickyContainerNode !== this.lastStickyContainer;
-
-    // enter a sticky node
-    const enterSticky = stickyNode && !this.lastStickyNode;
-    // leave a sticky node
-    const leaveSticky = !stickyNode && this.lastStickyNode;
-    // move a sticky node
-    const moveSticky = stickyNode && this.lastStickyNode && stickyNode !== this.lastStickyNode;
-
-    if (enterContainer || moveContainer) {
-      publish('sticky-container/enter', null, stickyContainerNode);
+    if (this.framePending) {
+      return;
     }
 
-    if (leaveContainer || moveContainer) {
-      publish('sticky-container/leave', null, this.lastStickyContainer);
-    }
+    requestAnimationFrame(() => {
+      // the scroll position of the y-axis
+      const scrollTop = getScrollTop();
+      // the diference between the last scroll position
+      const diffTop = scrollTop - this.lastScrollTop;
+      // the scroll direction -> -1: top, 0: node, 1: bottom
+      // eslint-disable-next-line no-nested-tenary
+      const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
+      // width of viewport
+      const viewportWidth = getViewportWidth();
+      // current top most element at the center of the first pixel in viewport
+      const topNode = elementFromPagePoint(viewportWidth / 2, scrollTop);
+      // closest sticky node or null
+      const stickyNode = closest(topNode, 'js-sticky');
+      // closest sticky container node or null
+      const stickyContainerNode = closest(stickyNode || topNode, 'js-sticky-container');
 
-    console.log(`sticky -> ${event.type}`);
-    console.log(`top: ${scrollTop}; diff: ${diffTop}, direction: ${direction}`);
+      // enter a sticky container
+      const enterContainer = stickyContainerNode && !this.lastStickyContainer;
+      // leave a sticky container
+      const leaveContainer = !stickyContainerNode && this.lastStickyContainer;
+      // move between containers
+      const moveContainer = stickyContainerNode && this.lastStickyContainer && stickyContainerNode !== this.lastStickyContainer;
 
-    console.log(stickyNode, stickyContainerNode);
+      // enter a sticky node
+      const enterSticky = stickyNode && !this.lastStickyNode;
+      // leave a sticky node
+      const leaveSticky = !stickyNode && this.lastStickyNode;
+      // move a sticky node
+      const moveSticky = stickyNode && this.lastStickyNode && stickyNode !== this.lastStickyNode;
 
-    this.lastScrollTop = scrollTop;
-    this.lastStickyNode = stickyNode;
-    this.lastStickyContainer = stickyContainerNode;
+      if (enterContainer || moveContainer) {
+        publish('sticky-container/enter', null, stickyContainerNode);
+      }
+
+      if (leaveContainer || moveContainer) {
+        publish('sticky-container/leave', null, this.lastStickyContainer);
+      }
+
+      console.log(`sticky -> ${event.type}`);
+      console.log(`top: ${scrollTop}; diff: ${diffTop}, direction: ${direction}`);
+
+      console.log(stickyNode, stickyContainerNode);
+
+      this.lastScrollTop = scrollTop;
+      this.lastStickyNode = stickyNode;
+      this.lastStickyContainer = stickyContainerNode;
+
+      this.framePending = false;
+    });
   }
 }
 

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -1,9 +1,11 @@
 import on from '../../../js/on';
 import getScrollTop from '../../../js/get-scroll-top';
+import remove from '../../../js/array-remove';
 import { publish } from '../../../js/pubsub';
 import { requestAnimationFrame } from '../../../js/request-animation-frame';
 
 let instance;
+let instanceCount = 0;
 const criticalEvents = [
   'resize',
   'orientationchange',
@@ -88,12 +90,31 @@ class StickySpy {
       this.forceRepaint = false;
     });
   }
+
+  remove(container) {
+    if (container) {
+      remove(this.containerNodes, container);
+    }
+
+    // eslint-disable-next-line no-plusplus
+    instanceCount--;
+
+    if (instanceCount <= 0 && instance) {
+      this._off();
+
+      delete this.containerNodes;
+      instance = null;
+    }
+  }
 }
 
 export default function factory() {
   if (!instance) {
     instance = new StickySpy();
   }
+
+  // eslint-disable-next-line no-plusplus
+  instanceCount++;
 
   return instance;
 }

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -65,7 +65,7 @@ class StickySpy {
       // the diference between the last scroll position
       const diffTop = scrollTop - this.lastScrollTop;
       // the scroll direction -> -1: top, 0: node, 1: bottom
-      // eslint-disable-next-line no-nested-tenary
+      // eslint-disable-next-line no-nested-ternary
       const direction = diffTop > 0 ? 1 : diffTop < 0 ? -1 : 0;
       // all spied container nodes
       const { containerNodes, forceRepaint } = this;

--- a/src/components/o-sticky/js/sticky-spy.js
+++ b/src/components/o-sticky/js/sticky-spy.js
@@ -72,7 +72,12 @@ class StickySpy {
         const isActiveContainer = top <= 0 && bottom >= 0;
         const eventType = isActiveContainer ? 'active' : 'idle';
 
-        publish(`sticky-container/${eventType}`, { containerTop: top, containerBottom: bottom, direction, forceRepaint }, container);
+        publish(`sticky-container/${eventType}`, {
+          containerTop: top,
+          containerBottom: bottom,
+          direction,
+          forceRepaint,
+        }, container);
       }
 
       this.lastScrollTop = scrollTop;

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -4,6 +4,11 @@ import Enum from '../../../js/enum';
 const states = Enum('IS_IN_FLOW', 'IS_STICKY', 'IS_TOP', 'IS_BOTTOM');
 
 class Sticky {
+  static DEFAULTS = {
+    placeholderClass: 'js-sticky__placer',
+    boxClass: 'js-sticky__box',
+  }
+
   constructor(rootNode) {
     this.rootNode = rootNode;
 

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -10,7 +10,9 @@ class Sticky {
   static DEFAULTS = {
     placeholderClass: '.js-sticky__placeholder',
     boxClass: '.js-sticky__box',
-  }
+    isStickyClass: 'is-sticky-sticky',
+    isBottomClass: 'is-sticky-bottom',
+  };
 
   constructor(rootNode) {
     this.rootNode = rootNode;
@@ -60,8 +62,8 @@ class Sticky {
     if (isSticky && (forceRepaint || this.state !== states.IS_STICKY)) {
       this.state = states.IS_STICKY;
 
-      add(rootNode, 'is-sticky');
-      remove(rootNode, 'is-bottom');
+      add(rootNode, Sticky.DEFAULTS.isStickyClass);
+      remove(rootNode, Sticky.DEFAULTS.isBottomClass);
       css(this.placeholder, { height: `${offsetHeight}px` });
       css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
     }
@@ -69,8 +71,8 @@ class Sticky {
     if (isBottom && (forceRepaint || this.state !== states.IS_BOTTOM)) {
       this.state = states.IS_BOTTOM;
 
-      remove(rootNode, 'is-sticky');
-      add(rootNode, 'is-bottom');
+      remove(rootNode, Sticky.DEFAULTS.isStickyClass);
+      add(rootNode, Sticky.DEFAULTS.isBottomClass);
       css(this.placeholder, { height: `${offsetHeight}px` });
       css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
     }
@@ -78,8 +80,8 @@ class Sticky {
     if (isInFlow && (forceRepaint || this.state !== states.IS_IN_FLOW)) {
       this.state = states.IS_IN_FLOW;
 
-      remove(rootNode, 'is-sticky');
-      remove(rootNode, 'is-bottom');
+      remove(rootNode, Sticky.DEFAULTS.isStickyClass);
+      remove(rootNode, Sticky.DEFAULTS.isBottomClass);
 
       css(this.placeholder, { height: '' });
       css(this.box, { left: '', width: '' });

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -87,6 +87,17 @@ class Sticky {
       css(this.box, { left: '', width: '' });
     }
   }
+
+  destroy() {
+    this._off();
+
+    this.spy.remove();
+    delete this.spy;
+    delete this.roodNode;
+    delete this.placeholder;
+    delete this.box;
+    delete this._contextNode;
+  }
 }
 
 export default Sticky;

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -1,4 +1,4 @@
-import EventManager from './event-manager';
+import StickySpy from './sticky-spy';
 import Enum from '../../../js/enum';
 
 const states = Enum('IS_IN_FLOW', 'IS_STICKY', 'IS_TOP', 'IS_BOTTOM');
@@ -8,7 +8,7 @@ class Sticky {
     this.rootNode = rootNode;
 
     this.state = states.IS_IN_FLOW;
-    this.eventManagerInstance = EventManager();
+    this.spy = StickySpy();
   }
 
   set contextNode(value) {

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -4,7 +4,7 @@ import { subscribe } from '../../../js/pubsub';
 import { add, remove } from '../../../js/class-list';
 import css from '../../../js/css';
 
-const states = Enum('IS_IN_FLOW', 'IS_STICKY', 'IS_TOP', 'IS_BOTTOM');
+const states = Enum('IS_IN_FLOW', 'IS_STICKY', 'IS_BOTTOM');
 
 class Sticky {
   static DEFAULTS = {
@@ -51,7 +51,7 @@ class Sticky {
     const { containerTop, containerBottom, direction, forceRepaint } = detail;
     const { rootNode } = this;
     const { offsetHeight, offsetWidth } = rootNode;
-    const { left, top, bottom } = rootNode.getBoundingClientRect();
+    const { left, top } = rootNode.getBoundingClientRect();
     const isInFlow = top > 0;
     const isSticky = top <= 0 && containerBottom >= offsetHeight;
     const isBottom = top <= 0 && containerBottom < offsetHeight;

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -1,9 +1,13 @@
 import EventManager from './event-manager';
+import Enum from '../../../js/enum';
+
+const states = Enum('IS_IN_FLOW', 'IS_STICKY', 'IS_TOP', 'IS_BOTTOM');
 
 class Sticky {
   constructor(rootNode) {
     this.rootNode = rootNode;
 
+    this.state = states.IS_IN_FLOW;
     this.eventManagerInstance = EventManager();
   }
 

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -12,11 +12,14 @@ class Sticky {
     boxClass: '.js-sticky__box',
     isStickyClass: 'is-sticky-sticky',
     isBottomClass: 'is-sticky-bottom',
+    isScrollUp: 'is-sticky-scroll-up',
+    isScrollDown: 'is-sticky-scroll-down',
   };
 
   constructor(rootNode) {
     this.rootNode = rootNode;
     this.state = states.IS_IN_FLOW;
+    this.lastDirection = 0;
 
     this._update = this._update.bind(this);
 
@@ -51,15 +54,23 @@ class Sticky {
 
   _update({ detail }) {
     const { containerTop, containerBottom, direction, forceRepaint } = detail;
-    const { rootNode } = this;
+    const { rootNode, state, lastDirection } = this;
+    const hasDirectionChanged = direction !== lastDirection;
     const { offsetHeight, offsetWidth } = rootNode;
     const { left, top } = rootNode.getBoundingClientRect();
     const isInFlow = top > 0;
     const isSticky = top <= 0 && containerBottom >= offsetHeight;
     const isBottom = top <= 0 && containerBottom < offsetHeight;
 
+    if (hasDirectionChanged && direction === 1) {
+      add(rootNode, Sticky.DEFAULTS.isScrollDown);
+      remove(rootNode, Sticky.DEFAULTS.isScrollUp);
+    } else if (hasDirectionChanged && direction === -1) {
+      add(rootNode, Sticky.DEFAULTS.isScrollUp);
+      remove(rootNode, Sticky.DEFAULTS.isScrollDown);
+    }
 
-    if (isSticky && (forceRepaint || this.state !== states.IS_STICKY)) {
+    if (isSticky && (forceRepaint || state !== states.IS_STICKY)) {
       this.state = states.IS_STICKY;
 
       add(rootNode, Sticky.DEFAULTS.isStickyClass);
@@ -68,7 +79,7 @@ class Sticky {
       css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
     }
 
-    if (isBottom && (forceRepaint || this.state !== states.IS_BOTTOM)) {
+    if (isBottom && (forceRepaint || state !== states.IS_BOTTOM)) {
       this.state = states.IS_BOTTOM;
 
       remove(rootNode, Sticky.DEFAULTS.isStickyClass);
@@ -77,7 +88,7 @@ class Sticky {
       css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
     }
 
-    if (isInFlow && (forceRepaint || this.state !== states.IS_IN_FLOW)) {
+    if (isInFlow && (forceRepaint || state !== states.IS_IN_FLOW)) {
       this.state = states.IS_IN_FLOW;
 
       remove(rootNode, Sticky.DEFAULTS.isStickyClass);

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -1,0 +1,15 @@
+import EventManager from './event-manager';
+
+class Sticky {
+  constructor(rootNode) {
+    this.rootNode = rootNode;
+
+    this.eventManagerInstance = EventManager();
+  }
+
+  set contextNode(value) {
+    this._contextNode = value;
+  }
+}
+
+export default Sticky;

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -48,7 +48,7 @@ class Sticky {
   }
 
   _update({ detail }) {
-    const { containerTop, containerBottom, direction } = detail;
+    const { containerTop, containerBottom, direction, forceRepaint } = detail;
     const { rootNode } = this;
     const { offsetHeight, offsetWidth } = rootNode;
     const { left, top, bottom } = rootNode.getBoundingClientRect();
@@ -57,7 +57,7 @@ class Sticky {
     const isBottom = top <= 0 && containerBottom < offsetHeight;
 
 
-    if (isSticky && this.state !== states.IS_STICKY) {
+    if (isSticky && (forceRepaint || this.state !== states.IS_STICKY)) {
       this.state = states.IS_STICKY;
 
       add(rootNode, 'is-sticky');
@@ -66,7 +66,7 @@ class Sticky {
       css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
     }
 
-    if (isBottom && this.state !== states.IS_BOTTOM) {
+    if (isBottom && (forceRepaint || this.state !== states.IS_BOTTOM)) {
       this.state = states.IS_BOTTOM;
 
       remove(rootNode, 'is-sticky');
@@ -75,7 +75,7 @@ class Sticky {
       css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
     }
 
-    if (isInFlow && this.state !== states.IS_IN_FLOW) {
+    if (isInFlow && (forceRepaint || this.state !== states.IS_IN_FLOW)) {
       this.state = states.IS_IN_FLOW;
 
       remove(rootNode, 'is-sticky');

--- a/src/components/o-sticky/js/sticky.js
+++ b/src/components/o-sticky/js/sticky.js
@@ -1,23 +1,89 @@
 import StickySpy from './sticky-spy';
 import Enum from '../../../js/enum';
+import { subscribe } from '../../../js/pubsub';
+import { add, remove } from '../../../js/class-list';
+import css from '../../../js/css';
 
 const states = Enum('IS_IN_FLOW', 'IS_STICKY', 'IS_TOP', 'IS_BOTTOM');
 
 class Sticky {
   static DEFAULTS = {
-    placeholderClass: 'js-sticky__placer',
-    boxClass: 'js-sticky__box',
+    placeholderClass: '.js-sticky__placeholder',
+    boxClass: '.js-sticky__box',
   }
 
   constructor(rootNode) {
     this.rootNode = rootNode;
-
     this.state = states.IS_IN_FLOW;
+
+    this._update = this._update.bind(this);
+
+    this.placeholder = rootNode.querySelector(Sticky.DEFAULTS.placeholderClass);
+    this.box = rootNode.querySelector(Sticky.DEFAULTS.boxClass);
+
     this.spy = StickySpy();
   }
 
   set contextNode(value) {
     this._contextNode = value;
+
+    this._on();
+  }
+
+  _on() {
+    this._off();
+
+    this._unActive = subscribe('sticky-container/active', this._update, this._contextNode);
+    this._unIdle = subscribe('sticky-container/idle', this._update, this._contextNode);
+  }
+
+  _off() {
+    if (this._unActive) {
+      this._unActive();
+    }
+
+    if (this._unIdle) {
+      this._unIdle();
+    }
+  }
+
+  _update({ detail }) {
+    const { containerTop, containerBottom, direction } = detail;
+    const { rootNode } = this;
+    const { offsetHeight, offsetWidth } = rootNode;
+    const { left, top, bottom } = rootNode.getBoundingClientRect();
+    const isInFlow = top > 0;
+    const isSticky = top <= 0 && containerBottom >= offsetHeight;
+    const isBottom = top <= 0 && containerBottom < offsetHeight;
+
+
+    if (isSticky && this.state !== states.IS_STICKY) {
+      this.state = states.IS_STICKY;
+
+      add(rootNode, 'is-sticky');
+      remove(rootNode, 'is-bottom');
+      css(this.placeholder, { height: `${offsetHeight}px` });
+      css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
+    }
+
+    if (isBottom && this.state !== states.IS_BOTTOM) {
+      this.state = states.IS_BOTTOM;
+
+      remove(rootNode, 'is-sticky');
+      add(rootNode, 'is-bottom');
+      css(this.placeholder, { height: `${offsetHeight}px` });
+      css(this.box, { left: `${left}px`, width: `${offsetWidth}px` });
+    }
+
+    if (isInFlow && this.state !== states.IS_IN_FLOW) {
+      this.state = states.IS_IN_FLOW;
+
+      remove(rootNode, 'is-sticky');
+      remove(rootNode, 'is-bottom');
+
+      css(this.placeholder, { height: '' });
+      css(this.box, { left: '', width: '' });
+    }
   }
 }
 

--- a/src/components/o-sticky/scss/sticky-container.scss
+++ b/src/components/o-sticky/scss/sticky-container.scss
@@ -2,7 +2,9 @@
   position: relative;
 
   display: block;
+}
 
+.o-sticky-container--debug {
   background: rgba(yellow, 0.5);
 
   &::before {

--- a/src/components/o-sticky/scss/sticky-container.scss
+++ b/src/components/o-sticky/scss/sticky-container.scss
@@ -3,6 +3,8 @@
 
   display: block;
 
+  background: rgba(yellow, 0.5);
+
   &.is-sticky-container-active {
     background: green;
   }

--- a/src/components/o-sticky/scss/sticky-container.scss
+++ b/src/components/o-sticky/scss/sticky-container.scss
@@ -8,4 +8,6 @@
   &.is-sticky-container-active {
     background: green;
   }
+
+  &.is-sticky-container-idle {}
 }

--- a/src/components/o-sticky/scss/sticky-container.scss
+++ b/src/components/o-sticky/scss/sticky-container.scss
@@ -5,9 +5,21 @@
 
   background: rgba(yellow, 0.5);
 
-  &.is-sticky-container-active {
-    background: green;
+  &::before {
+    content: '';
   }
 
-  &.is-sticky-container-idle {}
+  &.is-sticky-container-active {
+    background: green;
+
+    &::before {
+      content: 'is-active';
+    }
+  }
+
+  &.is-sticky-container-idle {
+    &::before {
+      content: 'is-idle';
+    }
+  }
 }

--- a/src/components/o-sticky/scss/sticky-container.scss
+++ b/src/components/o-sticky/scss/sticky-container.scss
@@ -1,0 +1,5 @@
+.o-sticky-container {
+  position: relative;
+
+  display: block;
+}

--- a/src/components/o-sticky/scss/sticky-container.scss
+++ b/src/components/o-sticky/scss/sticky-container.scss
@@ -2,4 +2,8 @@
   position: relative;
 
   display: block;
+
+  &.is-sticky-container-active {
+    background: green;
+  }
 }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -1,0 +1,26 @@
+.o-sticky {
+  display: block;
+
+  &.is-sticky {
+    position: fixed;
+
+    top: 0;
+  }
+
+  &.is-top,
+  &.is-bottom {
+    position: absolute;
+  }
+
+  &.is-top {
+    top: 0;
+  }
+
+  &.is-bottom {
+    bottom: 0;
+  }
+
+  &.is-in-flow {
+    position: static;
+  }
+}

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -1,5 +1,14 @@
 .o-sticky {
   display: block;
+}
+
+.o-sticky__placeholder {
+  display: block;
+  height: 0;
+}
+
+.o-sticky__box {
+  display: block;
 
   &.is-sticky {
     position: fixed;

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -13,21 +13,21 @@
   background: rgba(blue, 0.5);
   color: white;
 
-  .is-sticky > & {
+  .is-sticky-sticky > & {
     position: fixed;
     top: 0;
 
     background: rgba(red, 0.7);
   }
 
-  .is-bottom > & {
+  .is-sticky-bottom > & {
     position: absolute;
     bottom: 0;
 
     background: rgba(orange, 0.7);
   }
 
-  .is-in-flow > & {
+  .is-sticky-in-flow > & {
     position: static;
   }
 }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -13,11 +13,20 @@
   background: rgba(blue, 0.5);
   color: white;
 
+  &::before {
+    content: '';
+    color: yellow;
+  }
+
   .is-sticky-sticky > & {
     position: fixed;
     top: 0;
 
     background: rgba(red, 0.7);
+
+    &::before {
+      content: 'is-sticky';
+    }
   }
 
   .is-sticky-bottom > & {
@@ -25,9 +34,17 @@
     bottom: 0;
 
     background: rgba(orange, 0.7);
+
+    &::before {
+      content: 'is-bottom';
+    }
   }
 
   .is-sticky-in-flow > & {
     position: static;
+
+    &::before {
+      content: 'is-in-flow';
+    }
   }
 }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -10,26 +10,24 @@
 .o-sticky__box {
   display: block;
 
-  &.is-sticky {
+  background: rgba(blue, 0.5);
+  color: white;
+
+  .is-sticky > & {
     position: fixed;
-
     top: 0;
+
+    background: rgba(red, 0.7);
   }
 
-  &.is-top,
-  &.is-bottom {
+  .is-bottom > & {
     position: absolute;
-  }
-
-  &.is-top {
-    top: 0;
-  }
-
-  &.is-bottom {
     bottom: 0;
+
+    background: rgba(orange, 0.7);
   }
 
-  &.is-in-flow {
+  .is-in-flow > & {
     position: static;
   }
 }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -1,3 +1,5 @@
+@import "../../../styles/settings/zindex";
+
 .o-sticky {
   display: block;
 }
@@ -13,11 +15,13 @@
   .is-sticky-sticky > & {
     position: fixed;
     top: 0;
+    z-index: $zindex-sticky;
   }
 
   .is-sticky-bottom > & {
     position: absolute;
     bottom: 0;
+    z-index: $zindex-sticky;
   }
 
   .is-sticky-in-flow > & {

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -34,6 +34,7 @@
 
       @at-root {
         #{$o-sticky--debug} > #{$o-sticky__box} {
+          background: rgba(blue, 0.5);
           color: white;
 
           &::before {
@@ -43,6 +44,8 @@
         }
 
         #{$o-sticky--debug}.is-sticky-sticky > #{$o-sticky__box} {
+          background: rgba(red, 0.7);
+
           &::before {
             content: 'is-sticky';
           }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -28,41 +28,39 @@
 .o-sticky--debug {
   $o-sticky--debug: &;
 
-  @at-root {
-    .o-sticky__box {
-      $o-sticky__box: &;
+  @at-root .o-sticky__box {
+    $o-sticky__box: &;
 
-      @at-root {
-        #{$o-sticky--debug} > #{$o-sticky__box} {
-          background: rgba(blue, 0.5);
-          color: white;
+    @at-root {
+      #{$o-sticky--debug} > #{$o-sticky__box} {
+        background: rgba(blue, 0.5);
+        color: white;
 
-          &::before {
-            content: '';
-            color: yellow;
-          }
+        &::before {
+          content: '';
+          color: yellow;
         }
+      }
 
-        #{$o-sticky--debug}.is-sticky-sticky > #{$o-sticky__box} {
-          background: rgba(red, 0.7);
+      #{$o-sticky--debug}.is-sticky-sticky > #{$o-sticky__box} {
+        background: rgba(red, 0.7);
 
-          &::before {
-            content: 'is-sticky';
-          }
+        &::before {
+          content: 'is-sticky';
         }
+      }
 
-        #{$o-sticky--debug}.is-sticky-bottom > #{$o-sticky__box} {
-          background: rgba(orange, 0.7);
+      #{$o-sticky--debug}.is-sticky-bottom > #{$o-sticky__box} {
+        background: rgba(orange, 0.7);
 
-          &::before {
-            content: 'is-bottom';
-          }
+        &::before {
+          content: 'is-bottom';
         }
+      }
 
-        #{$o-sticky--debug}.is-sticky-in-flow > #{$o-sticky__box} {
-          &::before {
-            content: 'is-in-flow';
-          }
+      #{$o-sticky--debug}.is-sticky-in-flow > #{$o-sticky__box} {
+        &::before {
+          content: 'is-in-flow';
         }
       }
     }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -10,41 +10,58 @@
 .o-sticky__box {
   display: block;
 
-  background: rgba(blue, 0.5);
-  color: white;
-
-  &::before {
-    content: '';
-    color: yellow;
-  }
-
   .is-sticky-sticky > & {
     position: fixed;
     top: 0;
-
-    background: rgba(red, 0.7);
-
-    &::before {
-      content: 'is-sticky';
-    }
   }
 
   .is-sticky-bottom > & {
     position: absolute;
     bottom: 0;
-
-    background: rgba(orange, 0.7);
-
-    &::before {
-      content: 'is-bottom';
-    }
   }
 
   .is-sticky-in-flow > & {
     position: static;
+  }
+}
 
-    &::before {
-      content: 'is-in-flow';
+.o-sticky--debug {
+  $o-sticky--debug: &;
+
+  @at-root {
+    .o-sticky__box {
+      $o-sticky__box: &;
+
+      @at-root {
+        #{$o-sticky--debug} > #{$o-sticky__box} {
+          color: white;
+
+          &::before {
+            content: '';
+            color: yellow;
+          }
+        }
+
+        #{$o-sticky--debug}.is-sticky-sticky > #{$o-sticky__box} {
+          &::before {
+            content: 'is-sticky';
+          }
+        }
+
+        #{$o-sticky--debug}.is-sticky-bottom > #{$o-sticky__box} {
+          background: rgba(orange, 0.7);
+
+          &::before {
+            content: 'is-bottom';
+          }
+        }
+
+        #{$o-sticky--debug}.is-sticky-in-flow > #{$o-sticky__box} {
+          &::before {
+            content: 'is-in-flow';
+          }
+        }
+      }
     }
   }
 }

--- a/src/components/o-sticky/scss/sticky.scss
+++ b/src/components/o-sticky/scss/sticky.scss
@@ -40,7 +40,8 @@
         background: rgba(blue, 0.5);
         color: white;
 
-        &::before {
+        &::before,
+        &::after {
           content: '';
           color: yellow;
         }
@@ -65,6 +66,18 @@
       #{$o-sticky--debug}.is-sticky-in-flow > #{$o-sticky__box} {
         &::before {
           content: 'is-in-flow';
+        }
+      }
+
+      #{$o-sticky--debug}.is-sticky-scroll-up > #{$o-sticky__box} {
+        &::after {
+          content: 'is-scroll-up';
+        }
+      }
+
+      #{$o-sticky--debug}.is-sticky-scroll-down > #{$o-sticky__box} {
+        &::after {
+          content: 'is-scroll-down';
         }
       }
     }

--- a/src/components/o-sticky/sticky.template.js
+++ b/src/components/o-sticky/sticky.template.js
@@ -1,0 +1,8 @@
+import bel from 'bel';
+
+export default function sticky(props, children) {
+  return [
+    bel`<div class="o-sticky__placeholder"></div>`,
+    bel`<div class="o-sticky__box">${children}</div>`,
+  ];
+}

--- a/src/components/o-sticky/sticky.template.js
+++ b/src/components/o-sticky/sticky.template.js
@@ -2,7 +2,7 @@ import bel from 'bel';
 
 export default function sticky(props, children) {
   return [
-    bel`<div class="o-sticky__placeholder"></div>`,
-    bel`<div class="o-sticky__box">${children}</div>`,
+    bel`<div class="o-sticky__placeholder js-sticky__placeholder"></div>`,
+    bel`<div class="o-sticky__box js-sticky__box">${children}</div>`,
   ];
 }

--- a/src/js/array-remove.js
+++ b/src/js/array-remove.js
@@ -1,0 +1,7 @@
+export default function remove(array, element) {
+  const index = array.indexOf(element);
+
+  if (index > -1) {
+    array.splice(index, 1);
+  }
+}

--- a/src/js/closest.js
+++ b/src/js/closest.js
@@ -1,0 +1,16 @@
+import { has } from './class-list';
+
+export default function closest(node, className) {
+  let parentNode = node;
+
+  while (parentNode) {
+    if (has(parentNode, className)) {
+      return parentNode;
+    }
+
+    // eslint-disable-next-line prefer-destructuring
+    parentNode = parentNode.parentNode;
+  }
+
+  return null;
+}

--- a/src/js/element-from-page-point.js
+++ b/src/js/element-from-page-point.js
@@ -1,10 +1,11 @@
 import getScrollTop from './get-scroll-top';
 import getScrollLeft from './get-scroll-left';
+import { getViewportWidth, getViewportHeight } from './viewport';
 
 // Test with a point larger than the viewport. If it returns an element,
 // then that means elementFromPoint takes page coordinates.
 const elementFromPagePoint = ('pageYOffset' in window
-  && document.elementFromPoint(getScrollLeft() + window.innerHeight, getScrollTop() + window.innerHeight)) ?
+  && document.elementFromPoint(getScrollLeft() + getViewportHeight(), getScrollTop() + getViewportWidth())) ?
   document.elementFromPoint.bind(document) :
   elementFromPoint;
 

--- a/src/js/element-from-page-point.js
+++ b/src/js/element-from-page-point.js
@@ -1,0 +1,15 @@
+import getScrollTop from './get-scroll-top';
+import getScrollLeft from './get-scroll-left';
+
+// Test with a point larger than the viewport. If it returns an element,
+// then that means elementFromPoint takes page coordinates.
+const elementFromPagePoint = ('pageYOffset' in window
+  && document.elementFromPoint(getScrollLeft() + window.innerHeight, getScrollTop() + window.innerHeight)) ?
+  document.elementFromPoint.bind(document) :
+  elementFromPoint;
+
+function elementFromPoint(x, y) {
+  return document.elementFromPoint(x - getScrollLeft(), y - getScrollTop());
+}
+
+export default elementFromPagePoint;

--- a/src/js/get-scroll-left.js
+++ b/src/js/get-scroll-left.js
@@ -1,0 +1,13 @@
+const getScrollLeft = 'pageXOffset' in window ? pageXOffset : scrollLeft;
+
+function pageXOffset() {
+  return window.pageXOffset;
+}
+
+function scrollLeft() {
+  const { body, documentElement } = document;
+
+  return documentElement.scrollLeft || body.scrollLeft || 0;
+}
+
+export default getScrollLeft;

--- a/src/js/get-scroll-top.js
+++ b/src/js/get-scroll-top.js
@@ -1,0 +1,13 @@
+const getScrollTop = 'pageYOffset' in window ? pageYOffset : scrollTop;
+
+function pageYOffset() {
+  return window.pageYOffset;
+}
+
+function scrollTop() {
+  const { body, documentElement } = document;
+
+  return documentElement.scrollTop || body.scrollTop || 0;
+}
+
+export default getScrollTop;

--- a/src/js/viewport.js
+++ b/src/js/viewport.js
@@ -1,0 +1,12 @@
+export function getViewportWidth() {
+  return Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+}
+
+export function getViewportHeight() {
+  return Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+}
+
+export default {
+  getViewportWidth,
+  getViewportHeight,
+};


### PR DESCRIPTION
Fixes #47 

**Goals:**

- [x] Avoid DOM operations as much as possible
- [x] provide sticky container `axa-sticky-container` with `is-active` or `is-idle` state
- [x] provide sticky element `axa-sticky` being `is-in-flow`, `is-sticky` or at `is-bottom` of above container
- [x] provide `is-scroll-up` and `is-scroll-down` state classes
- [x] always repaint for critical events like `resize` and `orientation` change
- [x] swap `placeholder` node in to make up with lost height of out of flow sticky nodes
- [x] allow for custom classes -> needs #35 to be fixed
- [x] ~~allow for conditional stickiness, like through breakpoints~~ not needed according to https://design.axa.com/web-guidelines/header#sticky-behavior

**Possible Issues**

- [x] Initial trigger needed?
- [ ] custom lay-outing desired? (atm. inline `width` and `left` styles are set - can be overwritten with `!important`)
- [x] Context collisions/interferences

Inspired by https://github.com/captivationsoftware/react-sticky