### PR TITLE
refactored all templates

### DIFF
--- a/src/components/_abstract/component-types.js
+++ b/src/components/_abstract/component-types.js
@@ -87,13 +87,13 @@ export class BaseComponent extends HTMLElement {
 
     if (template) {
       try {
-        const children = document.createDocumentFragment();
+        const childrenFragment = document.createDocumentFragment();
 
         while (this.firstChild) {
-          children.appendChild(this.firstChild);
+          childrenFragment.appendChild(this.firstChild);
         }
 
-        const items = template(getAttributes(this), children);
+        const items = template(getAttributes(this), childrenFragment);
 
         if (Array.isArray(items)) {
           items.forEach((item) => {

--- a/src/components/a-link/_template.js
+++ b/src/components/a-link/_template.js
@@ -7,7 +7,7 @@ export default function ({
   motion,
   arrow,
   listed,
-}, children) {
+}, childrenFragment) {
   const classes = classnames('a-link', {
     [`a-link--${color}`]: color,
     [`a-link--${size}`]: size,
@@ -18,7 +18,7 @@ export default function ({
 
   return bel`<a href="#" class="${classes}">
       ${listed && bel`<axa-icon id="arrow" classes="a-link__listed"></axa-icon>`}
-      ${children}
+      ${childrenFragment}
       ${arrow && bel`<axa-icon id="arrow" classes="a-link__arrow"></axa-icon>`}
     </a>`;
 }

--- a/src/components/m-button/_template.js
+++ b/src/components/m-button/_template.js
@@ -11,7 +11,7 @@ export default function ({
   classes,
   motion,
   arrow,
-}, children) {
+}, childrenFragment) {
   const buttonClasses = classnames('m-button', classes, {
     [`m-button--${color}`]: color,
     [`m-button--${size}`]: size,
@@ -24,13 +24,13 @@ export default function ({
 
   if (tag.toLowerCase() === 'a') {
     return bel`<a href="${url}" class="${buttonClasses}">
-      ${children}
+      ${childrenFragment}
       ${arrow && arrowIcon}
     </a>`;
   }
 
   return bel`<button type="button" class="${buttonClasses}">
-      ${children}
+      ${childrenFragment}
       ${arrow && arrowIcon}
     </button>`;
 }

--- a/src/components/m-footer-main/_template.js
+++ b/src/components/m-footer-main/_template.js
@@ -1,7 +1,7 @@
 import bel from 'bel';
 
-export default function (props, children) {
+export default function (props, childrenFragment) {
   return bel`<div class="m-footer-main__box">
-    <div class="m-footer-main__row">${children}</div>
+    <div class="m-footer-main__row">${childrenFragment}</div>
   </div>`;
 }

--- a/src/components/m-footer-sub/_template.js
+++ b/src/components/m-footer-sub/_template.js
@@ -1,7 +1,7 @@
 import bel from 'bel';
 
-export default function (props, children) {
+export default function (props, childrenFragment) {
   return bel`<div class="m-footer-sub__box">
-    <div class="m-footer-sub__row">${children}</div>
+    <div class="m-footer-sub__row">${childrenFragment}</div>
   </div>`;
 }

--- a/src/components/m-header-main/_template.js
+++ b/src/components/m-header-main/_template.js
@@ -1,5 +1,5 @@
 import bel from 'bel';
 
-export default (props, children) => bel`
-  <div class="m-header-main__box">${children}</div>
+export default (props, childrenFragment) => bel`
+  <div class="m-header-main__box">${childrenFragment}</div>
 `;

--- a/src/components/m-header-meta-right/_template.js
+++ b/src/components/m-header-meta-right/_template.js
@@ -1,8 +1,8 @@
 import bel from 'bel';
 
-export default (props, fragment) => bel`
+export default (props, { children }) => bel`
   <ul class="m-header-meta-right__list">
-    ${Array.from(fragment.children).map(child => bel`
+    ${Array.from(children).map(child => bel`
       <li class="m-header-meta-right__list-item">${child}</li>
     `)}
   </ul>

--- a/src/components/m-header-meta/_template.js
+++ b/src/components/m-header-meta/_template.js
@@ -1,9 +1,9 @@
 import bel from 'bel';
 
-export default (props, children) => bel`
+export default (props, childrenFragment) => bel`
   <div class="m-header-meta__box">
     <div class="m-header-meta__row">
-      ${children}
+      ${childrenFragment}
     </div>
   </div>
 `;

--- a/src/components/m-header-mobile/_template.js
+++ b/src/components/m-header-mobile/_template.js
@@ -1,12 +1,12 @@
 import bel from 'bel';
 import classnames from 'classnames';
 
-export default ({ offcanvas }, children) => [bel`<div class="m-header-mobile__backdrop js-header-mobile__backdrop"></div>`,
+export default ({ offcanvas }, childrenFragment) => [bel`<div class="m-header-mobile__backdrop js-header-mobile__backdrop"></div>`,
   bel`<div class="m-header-mobile__canvas js-header-mobile__canvas ${classnames({
     'm-header-mobile__canvas--off-canvas': !offcanvas,
   })}">
     <div class="m-header-mobile__box">
-      ${children}
+      ${childrenFragment}
     </div>
   </div>
 `];

--- a/src/components/m-header-top-content-bar/_template.js
+++ b/src/components/m-header-top-content-bar/_template.js
@@ -1,5 +1,5 @@
 import bel from 'bel';
 
-export default function (props, children) {
-  return bel`<div class="m-header-top-content-bar__box">${children}</div>`;
+export default function (props, childrenFragment) {
+  return bel`<div class="m-header-top-content-bar__box">${childrenFragment}</div>`;
 }

--- a/src/components/o-sticky/sticky.template.js
+++ b/src/components/o-sticky/sticky.template.js
@@ -1,8 +1,8 @@
 import bel from 'bel';
 
-export default function sticky(props, children) {
+export default function sticky(props, childrenFragment) {
   return [
     bel`<div class="o-sticky__placeholder js-sticky__placeholder"></div>`,
-    bel`<div class="o-sticky__box js-sticky__box">${children}</div>`,
+    bel`<div class="o-sticky__box js-sticky__box">${childrenFragment}</div>`,
   ];
 }


### PR DESCRIPTION
fixes #107 

@LucaMele 
What do think about this change, regarding variable naming. I think it should say that this object are the `children` of Web Components root node and that they are of type `DocumentFragment`.
So I went for `childrenFragment`, though just `fragment` or `children` as before would be shorter...