### PR TITLE
added missing babelrc conf as mentioned in the docs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,9 @@
     }]
   ],
   "plugins": [
+    ["nanohtml", {
+      "useImport": true
+    }],
     "external-helpers",
     "transform-custom-element-classes",
     "transform-class-properties",

--- a/src/components/a-icon/_template.js
+++ b/src/components/a-icon/_template.js
@@ -2,6 +2,6 @@ import html from 'nanohtml';
 
 export default ({ id, classes }) => html`
   <svg class="${classes}">
-    <use xlink:href="#src--assets--icons--${id}" />
+    <use xlink:href="#src--assets--icons--${id}" href="#src--assets--icons--${id}" />
   </svg>
 `;


### PR DESCRIPTION
Fixes #339 #350 .

Changes proposed in this pull request:

 - Added `nanohtml` plugin to babel as suggested here https://github.com/choojs/nanohtml#babel--parcel
- Fixes missing `href` attributes of `<axa-icon>`'s SVG `<use />`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
 
 # How Has This Been Tested?
 
Locally
 
 # Checklist:
 
all done
