### PR TITLE
crazy fix for edge 16 ohoooo

### DIFF
--- a/src/components/m-header-navigation/js/header-navigation.js
+++ b/src/components/m-header-navigation/js/header-navigation.js
@@ -44,6 +44,12 @@ class HeaderNavigation extends UiEvents {
       // Edge 16 won't repaint -> force it
       // see https://github.com/axa-ch/patterns-library/issues/304
       forceRepaint(parentNode.querySelector(this.options.subNavi));
+
+      requestAnimationFrame(() => {
+        // Edge 16 won't repaint -> force it again!
+        // see https://github.com/axa-ch/patterns-library/issues/367
+        forceRepaint(parentNode.querySelector(this.options.subNavi));
+      });
     });
   }
 

--- a/src/components/m-header-navigation/js/header-navigation.js
+++ b/src/components/m-header-navigation/js/header-navigation.js
@@ -40,6 +40,7 @@ class HeaderNavigation extends UiEvents {
 
     add(parentNode, this.options.openClass);
 
+    // @todo: can we fix this Edge problem better?
     requestAnimationFrame(() => {
       // Edge 16 won't repaint -> force it
       // see https://github.com/axa-ch/patterns-library/issues/304


### PR DESCRIPTION
improves #367.

Changes proposed in this pull request:

 - **EDGE 16** does not repaint and does even not react to `forceRepaint` in first place.
   So I call it a second time...

**Note:** During debugging I realised, that our `webcomponents-polyfill-light` does a lot of magic, stuff like overwriting `querySelector` and other hot API's like `style` I guess.
May it's actually the polyfill who breaks EDGE 🤔 

Do we really want to merge such crap?

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
 
 # How Has This Been Tested?
 
Browserstack localhost of patterns-lib app.
 
 # Checklist:
 
all done
