### PR TITLE
added possible iOS double tab fix

### DIFF
--- a/src/components/m-button/mixins/_button.scss
+++ b/src/components/m-button/mixins/_button.scss
@@ -67,21 +67,21 @@
 
   color: $color-button-text;
 
-  background: $color-button-bg;
+  background-color: $color-button-bg;
   border-color: $color-button-bg;
   border-bottom-color: $color-button-bg--hover;
 
   &:hover,
   &:active,
   &:focus {
-    background: $color-button-bg--hover;
+    background-color: $color-button-bg--hover;
     border-color: $color-button-bg--hover;
     color: $color-button-text;
   }
 
   &:disabled,
   &[disabled] {
-    background: $color-button-bg--disabled !important;
+    background-color: $color-button-bg--disabled !important;
     border-color: $color-button-bg--disabled !important;
   }
 }
@@ -96,14 +96,14 @@
 
   color: $color-button-text--ghost;
 
-  background: $color-button-bg--ghost;
+  background-color: $color-button-bg--ghost;
   border-color: $color-button-bg;
 
   &:hover,
   &:active,
   &:focus {
     color: $color-button-text--ghost--hover;
-    background: $color-button-bg--ghost--hover;
+    background-color: $color-button-bg--ghost--hover;
 
     @if $color-button-bg--ghost--hover != transparent {
       border-color: $color-button-bg--ghost--hover;
@@ -203,6 +203,12 @@
 
     width: 0;
     height: 550px;
+
+    // fix iOS double tap for :hover
+    // 1. always make element visible by transparent border
+    // 2. never fill borders with the background color (important: never use short hand background, cause it will override the clipping)
+    border: 1px solid transparent;
+    background-clip: padding-box;
     content: '';
 
     transform: translateX(-50%) translateY(-50%) rotate(45deg);
@@ -224,19 +230,19 @@
   $color-button-text--motion--hover: get-color($button-color, $style, text--motion--hover);
 
   &::after {
-    background: $color-button-bg--motion;
+    background-color: $color-button-bg--motion;
   }
 
   &:hover,
   &:focus {
-    background: $color-button-bg;
+    background-color: $color-button-bg;
 
     @if $color-button-text--motion--hover {
       color: $color-button-text--motion--hover;
     }
 
     &::after {
-      background: $color-button-bg--motion--hover;
+      background-color: $color-button-bg--motion--hover;
     }
   }
 }

--- a/src/components/m-button/mixins/_button.scss
+++ b/src/components/m-button/mixins/_button.scss
@@ -67,21 +67,21 @@
 
   color: $color-button-text;
 
-  background-color: $color-button-bg;
+  background: $color-button-bg;
   border-color: $color-button-bg;
   border-bottom-color: $color-button-bg--hover;
 
   &:hover,
   &:active,
   &:focus {
-    background-color: $color-button-bg--hover;
+    background: $color-button-bg--hover;
     border-color: $color-button-bg--hover;
     color: $color-button-text;
   }
 
   &:disabled,
   &[disabled] {
-    background-color: $color-button-bg--disabled !important;
+    background: $color-button-bg--disabled !important;
     border-color: $color-button-bg--disabled !important;
   }
 }
@@ -96,14 +96,14 @@
 
   color: $color-button-text--ghost;
 
-  background-color: $color-button-bg--ghost;
+  background: $color-button-bg--ghost;
   border-color: $color-button-bg;
 
   &:hover,
   &:active,
   &:focus {
     color: $color-button-text--ghost--hover;
-    background-color: $color-button-bg--ghost--hover;
+    background: $color-button-bg--ghost--hover;
 
     @if $color-button-bg--ghost--hover != transparent {
       border-color: $color-button-bg--ghost--hover;
@@ -226,19 +226,19 @@
   $color-button-text--motion--hover: get-color($button-color, $style, text--motion--hover);
 
   &::after {
-    background-color: $color-button-bg--motion;
+    background: $color-button-bg--motion;
   }
 
   &:hover,
   &:focus {
-    background-color: $color-button-bg;
+    background: $color-button-bg;
 
     @if $color-button-text--motion--hover {
       color: $color-button-text--motion--hover;
     }
 
     &::after {
-      background-color: $color-button-bg--motion--hover;
+      background: $color-button-bg--motion--hover;
     }
   }
 }

--- a/src/components/m-button/mixins/_button.scss
+++ b/src/components/m-button/mixins/_button.scss
@@ -201,14 +201,10 @@
 
     display: block;
 
-    width: 0;
-    height: 550px;
-
     // fix iOS double tap for :hover
-    // 1. always make element visible by transparent border
-    // 2. never fill borders with the background color (important: never use short hand background, cause it will override the clipping)
-    border: 1px solid transparent;
-    background-clip: padding-box;
+    // zero width is considered hidden
+    width: 0.001px;
+    height: 550px;
     content: '';
 
     transform: translateX(-50%) translateY(-50%) rotate(45deg);


### PR DESCRIPTION
Fixes #385 .

Changes proposed in this pull request:

 - Fixes iOS double tab issue for `:hover`

~~I hope this CSS-Solution will work, another reliable fix would be using `tap` events implemented by~~ #290

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Tested the **Expandable Container** at local axa.ch mock server at browserstack on:
- iPhones and iPad from iOS 7+ up to 11
- Edge 16, 14, IE 11
- Lastest and random desktop browsers at windows, macOS
- Android 5, 7 Samsung Galaxies
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
