### PR TITLE
Add the same typography to native dropdown as in enhanced dropdown

### DIFF
--- a/src/components/m-dropdown/index.scss
+++ b/src/components/m-dropdown/index.scss
@@ -28,6 +28,7 @@
 
 .m-dropdown__select {
   @include dropdown-select();
+  @include typo-text-longer();
 }
 
 .m-dropdown__select--sm {


### PR DESCRIPTION
Related to  PR #436.

Changes proposed in this pull request:

 - Add the same sass mixin `type-text-longer` to native dropdown as in enhanced dropdown

## Type of change

- [x] New feature (non-breaking change which adds functionality)
 
 # How Has This Been Tested?
 
 Tested just in Chrome and Firefox on Mac
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
