### PR TITLE
Bugfix/with react invalid constructor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ We stick to the [Custom Elements V1 spec](https://html.spec.whatwg.org/multipage
 
 There are a few key principles you have to know:
 - Custom Elements are **asynchronous**, which means
-   - they only render if their definition (JS) is ready
+   - they only render if their definition (JS) is ready - [CustomElementRegistry API](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry)
    - a child could render before it's parent
    - this leads to [**FOUC** (flash of unstyled content)](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)
    - in short - order of rendering is **non-deterministic**
@@ -234,7 +234,7 @@ The render loop makes sure that upon each [`attributeChangedCallback()`](#attrib
 
 ## Integration
 
-The goal is that custom elements can be shared across frameworks and libraries like Angular, React, Vue, you name it. To ease this process we provide generic wrapper functions.
+The goal is that custom elements can be shared across frameworks and libraries like Angular, React, Vue, you name it. To ease this process we set a static `tagName` property for each custom element and provide generic wrapper functions.
 
 ### `withReact()`
 

--- a/src/components/a-checkbox/index.js
+++ b/src/components/a-checkbox/index.js
@@ -7,6 +7,8 @@ import styles from './index.scss';
 import template from './_template';
 
 class AXACheckbox extends BaseComponentGlobal {
+  static tagName = 'axa-checkbox'
+
   static get observedAttributes() {
     return ['input-id', 'error', 'value', 'name', 'checked', 'disabled'];
   }
@@ -27,7 +29,7 @@ class AXACheckbox extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-checkbox', AXACheckbox);
+  window.customElements.define(AXACheckbox.tagName, AXACheckbox);
 });
 
 export default AXACheckbox;

--- a/src/components/a-choice/index.js
+++ b/src/components/a-choice/index.js
@@ -7,6 +7,8 @@ import styles from './index.scss';
 import template from './_template';
 
 class AXAChoice extends BaseComponentGlobal {
+  static tagName = 'axa-choice'
+
   static get observedAttributes() {
     return ['input-id', 'error', 'value', 'name', 'checked', 'disabled'];
   }
@@ -27,7 +29,7 @@ class AXAChoice extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-choice', AXAChoice);
+  window.customElements.define(AXAChoice.tagName, AXAChoice);
 });
 
 export default AXAChoice;

--- a/src/components/a-icon/index.js
+++ b/src/components/a-icon/index.js
@@ -4,6 +4,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAIcon extends BaseComponentGlobal {
+  static tagName = 'axa-icon'
+
   // Specify observed attributes so that
   // attributeChangedCallback will work
   static get observedAttributes() { return ['icon', 'classes']; }
@@ -14,7 +16,7 @@ class AXAIcon extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-icon', AXAIcon);
+  window.customElements.define(AXAIcon.tagName, AXAIcon);
 });
 
 export default AXAIcon;

--- a/src/components/a-input/index.js
+++ b/src/components/a-input/index.js
@@ -7,6 +7,8 @@ import styles from './index.scss';
 import template from './_template';
 
 class AXAInput extends BaseComponentGlobal {
+  static tagName = 'axa-input'
+
   static get observedAttributes() {
     return ['valid', 'inline', 'error', 'disabled', 'input-id', 'type', 'placeholder', 'value', 'name'];
   }
@@ -28,7 +30,7 @@ class AXAInput extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-input', AXAInput);
+  window.customElements.define(AXAInput.tagName, AXAInput);
 });
 
 export default AXAInput;

--- a/src/components/a-radio/index.js
+++ b/src/components/a-radio/index.js
@@ -7,6 +7,8 @@ import styles from './index.scss';
 import template from './_template';
 
 class AXARadio extends BaseComponentGlobal {
+  static tagName = 'axa-radio'
+
   static get observedAttributes() { return ['input-id', 'error', 'value', 'name', 'checked', 'disabled']; }
 
   constructor() {
@@ -25,7 +27,7 @@ class AXARadio extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-radio', AXARadio);
+  window.customElements.define(AXARadio.tagName, AXARadio);
 });
 
 export default AXARadio;

--- a/src/components/a-typo/index.js
+++ b/src/components/a-typo/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXATypo extends BaseComponentGlobal {
+  static tagName = 'axa-typo'
+
   constructor() {
     super(styles, template);
   }
@@ -21,7 +23,7 @@ class AXATypo extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-typo', AXATypo);
+  window.customElements.define(AXATypo.tagName, AXATypo);
 });
 
 export default AXATypo;

--- a/src/components/a-vertical-rhythm/index.js
+++ b/src/components/a-vertical-rhythm/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAVerticalRhythm extends BaseComponentGlobal {
+  static tagName = 'axa-vertical-rhythm'
+
   constructor() {
     super(styles, template);
   }
@@ -18,7 +20,7 @@ class AXAVerticalRhythm extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-vertical-rhythm', AXAVerticalRhythm);
+  window.customElements.define(AXAVerticalRhythm.tagName, AXAVerticalRhythm);
 });
 
 export default AXAVerticalRhythm;

--- a/src/components/core/index.js
+++ b/src/components/core/index.js
@@ -1,6 +1,8 @@
 import wcdomready from '../../js/wcdomready';
 
 class AXACore extends HTMLElement {
+  static tagName = 'axa-core'
+
   connectedCallback() {
     const iconPath = this.getAttribute('icons-path');
     if (iconPath) {
@@ -18,7 +20,7 @@ class AXACore extends HTMLElement {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-core', AXACore);
+  window.customElements.define(AXACore.tagName, AXACore);
 });
 
 export default AXACore;

--- a/src/components/m-accordion-item/index.js
+++ b/src/components/m-accordion-item/index.js
@@ -5,6 +5,8 @@ import styles from './index.scss';
 import AccordionItem from './js/accordion-item';
 
 class AXAAccordionItem extends BaseComponentGlobal {
+  static tagName = 'axa-accordion-item'
+
   static get observedAttributes() { return ['icon', 'header', 'header-secondary', 'header-color', 'multiple']; }
 
   constructor() {
@@ -34,7 +36,7 @@ class AXAAccordionItem extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-accordion-item', AXAAccordionItem);
+  window.customElements.define(AXAAccordionItem.tagName, AXAAccordionItem);
 });
 
 export default AXAAccordionItem;

--- a/src/components/m-button/index.js
+++ b/src/components/m-button/index.js
@@ -5,6 +5,8 @@ import wcdomready from '../../js/wcdomready';
 import Button from './js/button';
 
 class AXAButton extends BaseComponentGlobal {
+  static tagName = 'axa-button'
+
   static get observedAttributes() { return ['arrow', 'classes', 'color', 'ghost', 'motion', 'size', 'tag', 'href', 'icon']; }
 
   constructor() {
@@ -28,7 +30,7 @@ class AXAButton extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-button', AXAButton);
+  window.customElements.define(AXAButton.tagName, AXAButton);
 
   BaseComponentGlobal.appendGlobalStyles(styles);
 });

--- a/src/components/m-dropdown/index.js
+++ b/src/components/m-dropdown/index.js
@@ -6,6 +6,8 @@ import DropDown from './js/drop-down';
 import wcdomready from '../../js/wcdomready';
 
 class AXADropdown extends BaseComponentGlobal {
+  static tagName = 'axa-dropdown'
+
   static get observedAttributes() { return ['in-flow', 'items', 'native', 'size', 'title', 'value']; }
 
   constructor() {
@@ -41,7 +43,7 @@ class AXADropdown extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-dropdown', AXADropdown);
+  window.customElements.define(AXADropdown.tagName, AXADropdown);
 
   BaseComponentGlobal.appendGlobalStyles(styles);
 });

--- a/src/components/m-footer-languages/index.js
+++ b/src/components/m-footer-languages/index.js
@@ -5,6 +5,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAFooterLanguages extends BaseComponentGlobal {
+  static tagName = 'axa-footer-languages'
+
   static get observedAttributes() { return ['inline', 'items', 'short', 'title']; }
 
   constructor() {
@@ -21,7 +23,7 @@ class AXAFooterLanguages extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer-languages', AXAFooterLanguages);
+  window.customElements.define(AXAFooterLanguages.tagName, AXAFooterLanguages);
 });
 
 export default AXAFooterLanguages;

--- a/src/components/m-footer-legals/index.js
+++ b/src/components/m-footer-legals/index.js
@@ -5,6 +5,8 @@ import styles from './index.scss';
 import wcdomready from '../../js/wcdomready';
 
 class AXAFooterLegals extends BaseComponentGlobal {
+  static tagName = 'axa-footer-legals'
+
   static get observedAttributes() { return ['bottom']; }
 
   constructor() {
@@ -31,7 +33,7 @@ class AXAFooterLegals extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer-legals', AXAFooterLegals);
+  window.customElements.define(AXAFooterLegals.tagName, AXAFooterLegals);
 });
 
 export default AXAFooterLegals;

--- a/src/components/m-footer-links/index.js
+++ b/src/components/m-footer-links/index.js
@@ -6,6 +6,8 @@ import wcdomready from '../../js/wcdomready';
 import FooterLinks from './js/footer-links';
 
 class AXAFooterLinks extends BaseComponentGlobal {
+  static tagName = 'axa-footer-links'
+
   static get observedAttributes() { return ['cols', 'items', 'title']; }
 
   constructor() {
@@ -42,7 +44,7 @@ class AXAFooterLinks extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer-links', AXAFooterLinks);
+  window.customElements.define(AXAFooterLinks.tagName, AXAFooterLinks);
 });
 
 export default AXAFooterLinks;

--- a/src/components/m-footer-main/index.js
+++ b/src/components/m-footer-main/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAFooterMain extends BaseComponentGlobal {
+  static tagName = 'axa-footer-main'
+
   static get observedAttributes() { return ['light']; }
 
   constructor() {
@@ -32,7 +34,7 @@ class AXAFooterMain extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer-main', AXAFooterMain);
+  window.customElements.define(AXAFooterMain.tagName, AXAFooterMain);
 });
 
 export default AXAFooterMain;

--- a/src/components/m-footer-social/index.js
+++ b/src/components/m-footer-social/index.js
@@ -5,6 +5,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAFooterSocial extends BaseComponentGlobal {
+  static tagName = 'axa-footer-social'
+
   static get observedAttributes() { return ['inline', 'items', 'light', 'title']; }
 
   constructor() {
@@ -22,7 +24,7 @@ class AXAFooterSocial extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer-social', AXAFooterSocial);
+  window.customElements.define(AXAFooterSocial.tagName, AXAFooterSocial);
 });
 
 export default AXAFooterSocial;

--- a/src/components/m-footer-sub/index.js
+++ b/src/components/m-footer-sub/index.js
@@ -4,6 +4,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAFooterSub extends BaseComponentGlobal {
+  static tagName = 'axa-footer-sub'
+
   constructor() {
     super(styles, template);
   }
@@ -16,7 +18,7 @@ class AXAFooterSub extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer-sub', AXAFooterSub);
+  window.customElements.define(AXAFooterSub.tagName, AXAFooterSub);
 });
 
 export default AXAFooterSub;

--- a/src/components/m-form-group/index.js
+++ b/src/components/m-form-group/index.js
@@ -9,6 +9,8 @@ import styles from './index.scss';
 import template from './_template';
 
 class AXAFormGroup extends BaseComponentGlobal {
+  static tagName = 'axa-form-group'
+
   static get observedAttributes() {
     return ['label', 'info', 'error'];
   }
@@ -43,7 +45,7 @@ class AXAFormGroup extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-form-group', AXAFormGroup);
+  window.customElements.define(AXAFormGroup.tagName, AXAFormGroup);
 });
 
 export default AXAFormGroup;

--- a/src/components/m-header-burger/index.js
+++ b/src/components/m-header-burger/index.js
@@ -7,6 +7,8 @@ import wcdomready from '../../js/wcdomready';
 import Burger from './js/burger';
 
 class AXAHeaderBurger extends BaseComponentGlobal {
+  static tagName = 'axa-header-burger'
+
   constructor() {
     super(styles, template);
 
@@ -33,7 +35,7 @@ class AXAHeaderBurger extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-burger', AXAHeaderBurger);
+  window.customElements.define(AXAHeaderBurger.tagName, AXAHeaderBurger);
 });
 
 export default AXAHeaderBurger;

--- a/src/components/m-header-languages/index.js
+++ b/src/components/m-header-languages/index.js
@@ -7,6 +7,8 @@ import DropDown from '../m-dropdown/js/drop-down';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderLanguages extends BaseComponentGlobal {
+  static tagName = 'axa-header-languages'
+
   static get observedAttributes() { return ['items']; }
 
   constructor() {
@@ -38,7 +40,7 @@ class AXAHeaderLanguages extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-languages', AXAHeaderLanguages);
+  window.customElements.define(AXAHeaderLanguages.tagName, AXAHeaderLanguages);
 });
 
 export default AXAHeaderLanguages;

--- a/src/components/m-header-logo/index.js
+++ b/src/components/m-header-logo/index.js
@@ -7,6 +7,8 @@ import wcdomready from '../../js/wcdomready';
 import HeaderLogo from './js/header-logo';
 
 class AXAHeaderLogo extends BaseComponentGlobal {
+  static tagName = 'axa-header-logo'
+
   static get observedAttributes() { return ['alt', 'href', 'src']; }
 
   constructor() {
@@ -36,7 +38,7 @@ class AXAHeaderLogo extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-logo', AXAHeaderLogo);
+  window.customElements.define(AXAHeaderLogo.tagName, AXAHeaderLogo);
 });
 
 export default AXAHeaderLogo;

--- a/src/components/m-header-main/index.js
+++ b/src/components/m-header-main/index.js
@@ -7,6 +7,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderMain extends BaseComponentGlobal {
+  static tagName = 'axa-header-main'
+
   static get observedAttributes() { return ['first-left']; }
 
   constructor() {
@@ -25,7 +27,7 @@ class AXAHeaderMain extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-main', AXAHeaderMain);
+  window.customElements.define(AXAHeaderMain.tagName, AXAHeaderMain);
 });
 
 export default AXAHeaderMain;

--- a/src/components/m-header-meta-right/index.js
+++ b/src/components/m-header-meta-right/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderMetaRight extends BaseComponentGlobal {
+  static tagName = 'axa-header-meta-right'
+
   constructor() {
     super(styles, template);
   }
@@ -18,7 +20,7 @@ class AXAHeaderMetaRight extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-meta-right', AXAHeaderMetaRight);
+  window.customElements.define(AXAHeaderMetaRight.tagName, AXAHeaderMetaRight);
 });
 
 export default AXAHeaderMetaRight;

--- a/src/components/m-header-meta/index.js
+++ b/src/components/m-header-meta/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderMeta extends BaseComponentGlobal {
+  static tagName = 'axa-header-meta'
+
   constructor() {
     super(styles, template);
   }
@@ -18,7 +20,7 @@ class AXAHeaderMeta extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-meta', AXAHeaderMeta);
+  window.customElements.define(AXAHeaderMeta.tagName, AXAHeaderMeta);
 });
 
 export default AXAHeaderMeta;

--- a/src/components/m-header-mobile-languages/index.js
+++ b/src/components/m-header-mobile-languages/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderMobileLanguages extends BaseComponentGlobal {
+  static tagName = 'axa-header-mobile-languages'
+
   static get observedAttributes() { return ['items']; }
 
   constructor() {
@@ -20,7 +22,7 @@ class AXAHeaderMobileLanguages extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-mobile-languages', AXAHeaderMobileLanguages);
+  window.customElements.define(AXAHeaderMobileLanguages.tagName, AXAHeaderMobileLanguages);
 });
 
 export default AXAHeaderMobileLanguages;

--- a/src/components/m-header-mobile-navigation/index.js
+++ b/src/components/m-header-mobile-navigation/index.js
@@ -6,6 +6,8 @@ import HeaderMobileNavigation from './js/header-mobile-navigation';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderMobileNavigation extends BaseComponentGlobal {
+  static tagName = 'axa-header-mobile-navigation'
+
   static get observedAttributes() { return ['items', 'relative']; }
 
   constructor() {
@@ -52,7 +54,7 @@ class AXAHeaderMobileNavigation extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-mobile-navigation', AXAHeaderMobileNavigation);
+  window.customElements.define(AXAHeaderMobileNavigation.tagName, AXAHeaderMobileNavigation);
 });
 
 export default AXAHeaderMobileNavigation;

--- a/src/components/m-header-mobile-others/index.js
+++ b/src/components/m-header-mobile-others/index.js
@@ -4,6 +4,8 @@ import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderMobileOthers extends BaseComponentGlobal {
+  static tagName = 'axa-header-mobile-others'
+
   static get observedAttributes() { return ['items']; }
 
   constructor() {
@@ -18,7 +20,7 @@ class AXAHeaderMobileOthers extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-mobile-others', AXAHeaderMobileOthers);
+  window.customElements.define(AXAHeaderMobileOthers.tagName, AXAHeaderMobileOthers);
 });
 
 export default AXAHeaderMobileOthers;

--- a/src/components/m-header-mobile/index.js
+++ b/src/components/m-header-mobile/index.js
@@ -7,6 +7,8 @@ import wcdomready from '../../js/wcdomready';
 import HeaderMobile from './js/header-mobile';
 
 class AXAHeaderMobile extends BaseComponentGlobal {
+  static tagName = 'axa-header-mobile'
+
   static get observedAttributes() { return ['offcanvas']; }
 
   constructor() {
@@ -55,7 +57,7 @@ class AXAHeaderMobile extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-mobile', AXAHeaderMobile);
+  window.customElements.define(AXAHeaderMobile.tagName, AXAHeaderMobile);
 });
 
 export default AXAHeaderMobile;

--- a/src/components/m-header-navigation/index.js
+++ b/src/components/m-header-navigation/index.js
@@ -7,6 +7,8 @@ import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderNavigation extends BaseComponentGlobal {
+  static tagName = 'axa-header-navigation'
+
   static get observedAttributes() { return ['hyphenate', 'items', 'simplemenu']; }
 
   constructor() {
@@ -70,7 +72,7 @@ class AXAHeaderNavigation extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-navigation', AXAHeaderNavigation);
+  window.customElements.define(AXAHeaderNavigation.tagName, AXAHeaderNavigation);
 });
 
 export default AXAHeaderNavigation;

--- a/src/components/m-header-others/index.js
+++ b/src/components/m-header-others/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderOthers extends BaseComponentGlobal {
+  static tagName = 'axa-header-others'
+
   static get observedAttributes() { return ['items']; }
 
   constructor() {
@@ -20,7 +22,7 @@ class AXAHeaderOthers extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-others', AXAHeaderOthers);
+  window.customElements.define(AXAHeaderOthers.tagName, AXAHeaderOthers);
 });
 
 export default AXAHeaderOthers;

--- a/src/components/m-header-search/index.js
+++ b/src/components/m-header-search/index.js
@@ -6,6 +6,8 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeaderSearch extends BaseComponentGlobal {
+  static tagName = 'axa-header-search'
+
   static get observedAttributes() { return ['action', 'href', 'method']; }
 
   constructor() {
@@ -23,7 +25,7 @@ class AXAHeaderSearch extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-search', AXAHeaderSearch);
+  window.customElements.define(AXAHeaderSearch.tagName, AXAHeaderSearch);
 });
 
 export default AXAHeaderSearch;

--- a/src/components/m-header-sub-navigation/index.js
+++ b/src/components/m-header-sub-navigation/index.js
@@ -5,6 +5,8 @@ import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
 class AXASubNavigation extends BaseComponentGlobal {
+  static tagName = 'axa-header-sub-navigation'
+
   static get observedAttributes() { return ['flyout', 'index-title', 'index-url', 'items']; }
 
   constructor() {
@@ -21,7 +23,7 @@ class AXASubNavigation extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-sub-navigation', AXASubNavigation);
+  window.customElements.define(AXASubNavigation.tagName, AXASubNavigation);
 });
 
 export default AXASubNavigation;

--- a/src/components/m-header-top-content-bar/index.js
+++ b/src/components/m-header-top-content-bar/index.js
@@ -3,7 +3,9 @@ import template from './_template';
 import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
-class AXATopContentBar extends BaseComponentGlobal {
+class AXAHeaderTopContentBar extends BaseComponentGlobal {
+  static tagName = 'axa-header-top-content-bar'
+
   static get observedAttributes() { return ['type']; }
 
   constructor() {
@@ -18,7 +20,7 @@ class AXATopContentBar extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header-top-content-bar', AXATopContentBar);
+  window.customElements.define(AXAHeaderTopContentBar.tagName, AXAHeaderTopContentBar);
 });
 
-export default AXATopContentBar;
+export default AXAHeaderTopContentBar;

--- a/src/components/m-link/index.js
+++ b/src/components/m-link/index.js
@@ -4,6 +4,8 @@ import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
 class AXALink extends BaseComponentGlobal {
+  static tagName = 'axa-link'
+
   static get observedAttributes() { return ['color', 'size', 'motion', 'arrow', 'href', 'listed', 'icon', 'deco']; }
 
   constructor() {
@@ -12,7 +14,7 @@ class AXALink extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-link', AXALink);
+  window.customElements.define(AXALink.tagName, AXALink);
 
   BaseComponentGlobal.appendGlobalStyles(styles);
 });

--- a/src/components/o-accordion/index.js
+++ b/src/components/o-accordion/index.js
@@ -4,6 +4,8 @@ import template from './_template';
 import styles from './index.scss';
 
 class AXAAccordion extends BaseComponentGlobal {
+  static tagName = 'axa-accordion'
+
   constructor() {
     super(styles, template);
 
@@ -25,7 +27,7 @@ class AXAAccordion extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-accordion', AXAAccordion);
+  window.customElements.define(AXAAccordion.tagName, AXAAccordion);
 });
 
 export default AXAAccordion;

--- a/src/components/o-container/index.js
+++ b/src/components/o-container/index.js
@@ -6,13 +6,15 @@ import template from './_template';
 import wcdomready from '../../js/wcdomready';
 
 class AXAContainer extends BaseComponentGlobal {
+  static tagName = 'axa-container'
+
   constructor() {
     super(styles, template);
   }
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-container', AXAContainer);
+  window.customElements.define(AXAContainer.tagName, AXAContainer);
 });
 
 export default AXAContainer;

--- a/src/components/o-footer/index.js
+++ b/src/components/o-footer/index.js
@@ -2,6 +2,8 @@ import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
 class AXAFooter extends BaseComponentGlobal {
+  static tagName = 'axa-footer'
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -10,7 +12,7 @@ class AXAFooter extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-footer', AXAFooter);
+  window.customElements.define(AXAFooter.tagName, AXAFooter);
 });
 
 export default AXAFooter;

--- a/src/components/o-header/index.js
+++ b/src/components/o-header/index.js
@@ -3,6 +3,8 @@ import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import wcdomready from '../../js/wcdomready';
 
 class AXAHeader extends BaseComponentGlobal {
+  static tagName = 'axa-header'
+
   constructor() {
     super(styles);
 
@@ -17,7 +19,7 @@ class AXAHeader extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-header', AXAHeader);
+  window.customElements.define(AXAHeader.tagName, AXAHeader);
 });
 
 export default AXAHeader;

--- a/src/components/o-sticky/index.js
+++ b/src/components/o-sticky/index.js
@@ -8,6 +8,8 @@ import Sticky from './js/sticky';
 import StickyContainer from './js/sticky-container';
 
 class AXAStickyContainer extends BaseComponentGlobal {
+  static tagName = 'axa-sticky-container'
+
   static get observedAttributes() { return ['debug']; }
 
   constructor() {
@@ -37,6 +39,8 @@ class AXAStickyContainer extends BaseComponentGlobal {
 }
 
 class AXASticky extends BaseComponentGlobal {
+  static tagName = 'axa-sticky'
+
   static get observedAttributes() { return ['debug']; }
 
   constructor() {
@@ -82,8 +86,8 @@ class AXASticky extends BaseComponentGlobal {
 }
 
 wcdomready(() => {
-  window.customElements.define('axa-sticky-container', AXAStickyContainer);
-  window.customElements.define('axa-sticky', AXASticky);
+  window.customElements.define(AXAStickyContainer.tagName, AXAStickyContainer);
+  window.customElements.define(AXASticky.tagName, AXASticky);
 });
 
 export default {

--- a/src/demos/demo.react.jsx
+++ b/src/demos/demo.react.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import withReact from '../js/with-react';
 import AXAButton from '../components/m-button';
-import wcdomready from '../js/wcdomready';
 
 import './todomvc/app';
 
@@ -42,6 +41,6 @@ class MyEventDemoReact extends React.Component {
   }
 }
 
-wcdomready(() => {
+document.addEventListener('DOMContentLoaded', () => {
   ReactDOM.render(<MyEventDemoReact />, document.querySelector('.my-event-demo-react'));
 });

--- a/src/demos/todomvc/todo-item.jsx
+++ b/src/demos/todomvc/todo-item.jsx
@@ -119,7 +119,7 @@ class TodoItem extends Component {
     return (
       <li className="m-todo__item">
         <div className="m-todo__wrap">
-          <AXACheckboxReact checked={completed} name="completed" />
+          <AXACheckboxReact checked={completed} name="completed" onChange={() => onToggle(todo)} />
 
           <input
             className="m-todo__toggle"

--- a/src/demos/todomvc/todo-item.jsx
+++ b/src/demos/todomvc/todo-item.jsx
@@ -3,9 +3,11 @@ import classnames from 'classnames';
 import withReact from '../../js/with-react';
 import AXAButton from '../../components/m-button';
 import AXAIcon from '../../components/a-icon';
+import AXACheckbox from '../../components/a-checkbox';
 
 const AXAButtonReact = withReact(AXAButton);
 const AXAIconReact = withReact(AXAIcon);
+const AXACheckboxReact = withReact(AXACheckbox);
 
 const ESCAPE_KEY = 27;
 const ENTER_KEY = 13;
@@ -117,9 +119,12 @@ class TodoItem extends Component {
     return (
       <li className="m-todo__item">
         <div className="m-todo__wrap">
+          <AXACheckboxReact checked={completed} name="completed" />
+
           <input
             className="m-todo__toggle"
             type="checkbox"
+            name="completed"
             checked={completed}
             onChange={() => onToggle(todo)}
           />

--- a/src/js/with-react.js
+++ b/src/js/with-react.js
@@ -40,8 +40,14 @@ const isEventFilter = (key) => {
  * );
  */
 const withReact = (WebComponent, { pure = true, passive = false } = {}) => {
-  let displayName = '';
-  let WCTagName;
+  // IMPORTANT:
+  // the Custom Element can only be instantiated as soon as it is registered in CustomElementRegistry
+  // which in turn is deferred after DOMReady
+  // hence it's tagName could only be resolved lazily
+  // ref: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry
+  // therefor we don't instantiate it, but rather use a statically defined tagName property
+  const { tagName } = WebComponent;
+  const displayName = `${camelize(tagName)}React`;
   const Component = pure ? React.PureComponent : React.Component;
 
   return class WebComponentWrapper extends Component {
@@ -109,20 +115,7 @@ const withReact = (WebComponent, { pure = true, passive = false } = {}) => {
       // eslint-disable-next-line react/prop-types
       const { props: { children }, handleRef } = this;
 
-      // IMPORTANT:
-      // the Custom Element can only be instantiated as soon as it is registered in CustomElementRegistry
-      // which in turn is deferred after DOMReady
-      // hence it's tagName can only be resolved lazily
-      // ref: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry
-      if (!WCTagName) {
-        const node = new WebComponent();
-        const tagName = node.tagName.toLowerCase();
-
-        displayName = `${camelize(tagName)}React`;
-        WCTagName = tagName;
-      }
-
-      return createElement(WCTagName, { ref: handleRef }, children);
+      return createElement(tagName, { ref: handleRef }, children);
     }
   };
 };

--- a/stack/tasks/create-a-m-o.js
+++ b/stack/tasks/create-a-m-o.js
@@ -70,6 +70,8 @@ const writeIndexJs = (path, _name) => {
       import wcdomready from '../../js/wcdomready';
 
       class ${className} extends BaseComponentGlobal {
+        static tagName = 'axa-${_name}'
+
         // Specify observed attributes so that attributeChangedCallback will work,
         // this is essential for external re-rendering trigger.
         static get observedAttributes() { return []; }
@@ -122,7 +124,7 @@ const writeIndexJs = (path, _name) => {
       }
 
       wcdomready(() => {
-        window.customElements.define('axa-${_name}', ${className});
+        window.customElements.define(${className}.tagName, ${className});
       });
 
       export default ${className};


### PR DESCRIPTION
Fixes #445 
Fixes #430 

Changes proposed in this pull request:

 - add static `tagName` to each custom element
 - refactored `create-a-m-o.js` script accordingly
 - refactored `withReact` to stop instantiating custom elements, but rather use the new static `tagName` property
- refactored react Demo to drop `wcdomready` and use `<axa-checkbox />`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
