### PR TITLE
skip children belongs to rendering

### DIFF
--- a/src/js/abstract/hocs/with-render.js
+++ b/src/js/abstract/hocs/with-render.js
@@ -145,6 +145,15 @@ const withRender = Base =>
     }
 
     /**
+     * Only morph children of current custom element, not any other custom element.
+     *
+     * @returns {boolean}
+     */
+    skipChildren() {
+      return !this._isMorphing;
+    }
+
+    /**
      * Optionally overwrite this public method, it get's triggered as soon as your component will render.
      * Here you will cleanup your lost DOM references or their associated events or stuff like that.
      *

--- a/src/js/abstract/hocs/with-update.js
+++ b/src/js/abstract/hocs/with-update.js
@@ -217,15 +217,6 @@ const withUpdate = Base =>
     }
 
     /**
-     * Only morph children of current custom element, not any other custom element.
-     *
-     * @returns {boolean}
-     */
-    skipChildren() {
-      return !this._isMorphing;
-    }
-
-    /**
      * disconnectedCallback - description
      *
      * @return {type}  description


### PR DESCRIPTION
Fixes #482 

Changes proposed in this pull request:

 - `shipChildren` belongs to `withRender` HOC
 -
 -

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
