### PR TITLE
start adding error pages

### DIFF
--- a/src/components/o-error-page/_example.html
+++ b/src/components/o-error-page/_example.html
@@ -1,0 +1,1 @@
+<!--Please create here a HTML example by using just default HTML tags-->

--- a/src/components/o-error-page/_preview.html
+++ b/src/components/o-error-page/_preview.html
@@ -55,3 +55,14 @@
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"
 ></axa-error-page>
+
+<hr/>
+
+<axa-error-page
+  status="Error"
+  title="Your navigator is obsolete"
+  message="Your currently used browser is outdated and may cause display errors on this website.
+     Please install Google Chrome X, Mozilla Firefox 9.2, or rather Edge 10.0.2 version."
+  cta-href="https://www.axa.ch"
+  cta-title="Go to login page"
+>You can also discover our last contents on <a href="https://www.axa.ch">www.axa.ch</a> page</axa-error-page>

--- a/src/components/o-error-page/_preview.html
+++ b/src/components/o-error-page/_preview.html
@@ -23,6 +23,7 @@
   ]'
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"
+  background="pacific"
 ></axa-error-page>
 
 <hr/>
@@ -35,6 +36,7 @@
     Try to reload the page, or, if you have a few minutes, have a look to our last contents."
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"
+  background="teal"
 ></axa-error-page>
 
 <hr/>

--- a/src/components/o-error-page/_preview.html
+++ b/src/components/o-error-page/_preview.html
@@ -7,7 +7,7 @@
     You may also clear your site cache, check your logs for errors or try to log again."
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"
-></axa-error-page>
+>You can also discover our last contents on <a href="https://www.axa.ch">www.axa.ch</a> page</axa-error-page>
 
 <hr/>
 
@@ -37,7 +37,7 @@
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"
   background="teal"
-></axa-error-page>
+>You can also discover our last contents on <a href="https://www.axa.ch">www.axa.ch</a> page</axa-error-page>
 
 <hr/>
 

--- a/src/components/o-error-page/_preview.html
+++ b/src/components/o-error-page/_preview.html
@@ -1,0 +1,55 @@
+<axa-error-page
+  code="401"
+  status="401 Error"
+  title="Authorization required"
+  message="You are not authorized to access the page without being logged-in. 
+    Please, go to login page and use your credentials.
+    You may also clear your site cache, check your logs for errors or try to log again."
+  cta-href="https://www.axa.ch"
+  cta-title="Go to login page"
+></axa-error-page>
+
+<hr/>
+
+<axa-error-page
+  code="403"
+  status="403 Error"
+  title="Access forbidden"
+  message="You don't have access on this server. It is either read-protected or not readable by the server.
+We suggest you to try one of these:"
+  items='[
+    "Check the URL for errors",
+    "Check the credentials you supplied"
+  ]'
+  cta-href="https://www.axa.ch"
+  cta-title="Go to login page"
+></axa-error-page>
+
+<hr/>
+
+<axa-error-page
+  code="404"
+  status="404 Error"
+  title="Page was not found"
+  message="The page you are looking for is not available or no longer exists.
+Try to reload the page, or, if you have a few minutes, have a look to our last contents."
+  cta-href="https://www.axa.ch"
+  cta-title="Go to login page"
+></axa-error-page>
+
+<hr/>
+
+<axa-error-page
+  code="500"
+  status="500 - Internal Server Error"
+  title="Oops, something went wrong!"
+  message="lt seems like the server encountered a problem. We suggest you to try one of these:"
+  items='[
+    "Refresh your page",
+    "Check if your internet connexion is working. If not, restart it and try loading  this page again.",
+    "Check the Service Status page: https://example.com",
+    "Contact your IT department:  example@gmail.com"
+  ]'
+  cta-href="https://www.axa.ch"
+  cta-title="Go to login page"
+></axa-error-page>

--- a/src/components/o-error-page/_preview.html
+++ b/src/components/o-error-page/_preview.html
@@ -16,7 +16,7 @@
   status="403 Error"
   title="Access forbidden"
   message="You don't have access on this server. It is either read-protected or not readable by the server.
-We suggest you to try one of these:"
+    We suggest you to try one of these:"
   items='[
     "Check the URL for errors",
     "Check the credentials you supplied"
@@ -32,7 +32,7 @@ We suggest you to try one of these:"
   status="404 Error"
   title="Page was not found"
   message="The page you are looking for is not available or no longer exists.
-Try to reload the page, or, if you have a few minutes, have a look to our last contents."
+    Try to reload the page, or, if you have a few minutes, have a look to our last contents."
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"
 ></axa-error-page>
@@ -48,7 +48,7 @@ Try to reload the page, or, if you have a few minutes, have a look to our last c
     "Refresh your page",
     "Check if your internet connexion is working. If not, restart it and try loading  this page again.",
     "Check the Service Status page: https://example.com",
-    "Contact your IT department:  example@gmail.com"
+    "Contact your IT department: example@gmail.com"
   ]'
   cta-href="https://www.axa.ch"
   cta-title="Go to login page"

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import html from 'nanohtml';
+import raw from 'nanohtml/raw';
 
 export default ({
   code,
@@ -12,12 +13,15 @@ export default ({
 }) => {
   const hasItems = Array.isArray(items) && items.length;
 
+  console.log(typeof items, hasItems);
+  console.log(items);
+
   return html`
     <article class='o-error-page__container'>
       <h4 class="o-error-page__status">${status}</h4>
       <h1 class="o-error-page__title">${title}</h1>
   
-      <p class="${classnames('o-error-page__message', { 'o-error-page__message--semibold': hasItems })}">${message}</p>
+      <p class="${classnames('o-error-page__message', { 'o-error-page__message--semibold': hasItems })}">${raw(message)}</p>
       
       ${(hasItems && html`
         <ul class="o-error-page__list">

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -3,7 +3,7 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 
 export default ({
-  code,
+  code, // eslint-disable-line
   status,
   title,
   message,

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -10,11 +10,12 @@ export default ({
   items,
   ctaHref,
   ctaTitle,
-}) => {
+}, childrenFragment) => {
   const hasItems = Array.isArray(items) && items.length;
+  const hasChildren = childrenFragment && childrenFragment.childElementCount;
 
-  return html`
-    <article class='o-error-page__container'>
+  const errorPage = html`
+    <article class="o-error-page__container">
       <h4 class="o-error-page__status">${status}</h4>
       <h1 class="o-error-page__title">${title}</h1>
   
@@ -31,4 +32,15 @@ export default ({
       `) || null}
     </article>
   `;
+
+  if (!hasChildren) {
+    return errorPage;
+  }
+
+  return [
+    errorPage,
+    html`<arcticle class="o-error-page__discover">
+      <p class="o-error-page__discover-text">${childrenFragment}</p>
+    </arcticle>`,
+  ];
 };

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -26,7 +26,7 @@ export default ({
       `) || null}
       
       ${(ctaHref && ctaTitle && html`
-        <axa-button href="${ctaHref}" tag="a" color="white" ghost motion>${ctaTitle}</axa-button>
+        <axa-button class="o-error-page__cta" href="${ctaHref}" tag="a" color="white" ghost motion>${ctaTitle}</axa-button>
       `) || null}
     </article>
   `;

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -13,9 +13,6 @@ export default ({
 }) => {
   const hasItems = Array.isArray(items) && items.length;
 
-  console.log(typeof items, hasItems);
-  console.log(items);
-
   return html`
     <article class='o-error-page__container'>
       <h4 class="o-error-page__status">${status}</h4>

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -1,0 +1,33 @@
+import classnames from 'classnames';
+import html from 'nanohtml';
+
+export default ({
+  code,
+  status,
+  title,
+  message,
+  items,
+  ctaHref,
+  ctaTitle,
+}) => {
+  const hasItems = Array.isArray(items) && items.length;
+
+  return html`
+    <article class='o-error-page__container'>
+      <h4 class="o-error-page__status">${status}</h4>
+      <h1 class="o-error-page__title">${title}</h1>
+  
+      <p class="${classnames('o-error-page__message', { 'o-error-page__message--semibold': hasItems })}">${message}</p>
+      
+      ${(hasItems && html`
+        <ul class="o-error-page__list">
+          ${items.map(item => html`<li class="o-error-page__list-item">${item}</li>`)}
+        </ul>
+      `) || null}
+      
+      ${(ctaHref && ctaTitle && html`
+        <axa-button href="${ctaHref}" tag="a" color="white" ghost motion>${ctaTitle}</axa-button>
+      `) || null}
+    </article>
+  `;
+};

--- a/src/components/o-error-page/index.js
+++ b/src/components/o-error-page/index.js
@@ -1,0 +1,66 @@
+import BaseComponentGlobal from '../../js/abstract/base-component-global';
+// import the styles used for this component
+import styles from './index.scss';
+// import the template used for this component
+import template from './_template';
+import wcdomready from '../../js/wcdomready';
+
+class AXAErrorPage extends BaseComponentGlobal {
+  static tagName = 'axa-error-page'
+
+  // Specify observed attributes so that attributeChangedCallback will work,
+  // this is essential for external re-rendering trigger.
+  static get observedAttributes() { return ['code', 'status', 'title', 'message', 'items', 'cta-href', 'cta-title', 'background']; }
+
+  constructor() {
+    super({ styles, template });
+
+    // does this provide context (See docs for context) ?
+    // this.provideContext()
+
+    // or do you want to consume a specific context
+    // this.consumeContext('axa-context-provider');
+  }
+
+  /**
+   * REF: https://www.w3.org/TR/custom-elements/#custom-element-conformance
+   */
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.className = `${this.initialClassName} o-error-page`;
+    // Your DOM interaction here, but keep it decoupled.
+    // If you don't have any, just remove this function
+  }
+
+  // You have some special logic? Or need to update the web-components DOM node itself?
+  // Then don't forget to make sure that incremental rendering works properly.
+  // attributeChangedCallback(name, oldValue, newValue) {
+  //   super.attributeChangedCallback(name, oldValue, newValue);
+  // }
+
+  // You may want to update stuff before rendering.
+  // willRenderCallback(initial) {
+  // }
+
+  // You may want to update staff after rendering
+  // didRenderCallback(initial) {
+  // }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    // Don't forget to cleanup :)
+  }
+
+  // Do you consume context?
+  // contextCallback(contextNode) {
+  //   contextNode is now available.
+  // }
+}
+
+wcdomready(() => {
+  window.customElements.define(AXAErrorPage.tagName, AXAErrorPage);
+});
+
+export default AXAErrorPage;

--- a/src/components/o-error-page/index.js
+++ b/src/components/o-error-page/index.js
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import BaseComponentGlobal from '../../js/abstract/base-component-global';
 // import the styles used for this component
 import styles from './index.scss';
@@ -14,49 +15,18 @@ class AXAErrorPage extends BaseComponentGlobal {
 
   constructor() {
     super({ styles, template });
-
-    // does this provide context (See docs for context) ?
-    // this.provideContext()
-
-    // or do you want to consume a specific context
-    // this.consumeContext('axa-context-provider');
   }
 
   /**
    * REF: https://www.w3.org/TR/custom-elements/#custom-element-conformance
    */
-  connectedCallback() {
-    super.connectedCallback();
+  willRenderCallback() {
+    const { background } = this;
 
-    this.className = `${this.initialClassName} o-error-page`;
-    // Your DOM interaction here, but keep it decoupled.
-    // If you don't have any, just remove this function
+    this.className = classnames(this.initialClassName, 'o-error-page', {
+      [`o-error-page--${background}`]: background,
+    });
   }
-
-  // You have some special logic? Or need to update the web-components DOM node itself?
-  // Then don't forget to make sure that incremental rendering works properly.
-  // attributeChangedCallback(name, oldValue, newValue) {
-  //   super.attributeChangedCallback(name, oldValue, newValue);
-  // }
-
-  // You may want to update stuff before rendering.
-  // willRenderCallback(initial) {
-  // }
-
-  // You may want to update staff after rendering
-  // didRenderCallback(initial) {
-  // }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    // Don't forget to cleanup :)
-  }
-
-  // Do you consume context?
-  // contextCallback(contextNode) {
-  //   contextNode is now available.
-  // }
 }
 
 wcdomready(() => {

--- a/src/components/o-error-page/index.scss
+++ b/src/components/o-error-page/index.scss
@@ -104,3 +104,17 @@
     margin-top: 25px;
   }
 }
+
+.o-error-page__discover {
+  display: block;
+  padding-top: 20px;
+  padding-bottom: 20px;
+
+  color: $color-prim-gray-mine-shaft;
+  background: $color-prim-white;
+}
+
+.o-error-page__discover-text {
+  @include make-container();
+  @include make-container-max-widths();
+}

--- a/src/components/o-error-page/index.scss
+++ b/src/components/o-error-page/index.scss
@@ -54,3 +54,21 @@
   @include unstyle-list();
   @include typo-text-longer();
 }
+
+.o-error-page__cta {
+  display: block;
+
+  margin-top: 30px;
+
+  @include respond-up(sm) {
+    margin-top: 40px;
+  }
+
+  @include respond-up(md) {
+    margin-top: 20px;
+  }
+
+  @include respond-up(lg) {
+    margin-top: 25px;
+  }
+}

--- a/src/components/o-error-page/index.scss
+++ b/src/components/o-error-page/index.scss
@@ -12,6 +12,14 @@
   text-align: center;
 }
 
+.o-error-page--pacific {
+  background: $color-sec-blue-pacific;
+}
+
+.o-error-page--teal {
+  background: $color-sec-blue-teal;
+}
+
 .o-error-page__container {
   @include make-container();
   @include make-container-max-widths();

--- a/src/components/o-error-page/index.scss
+++ b/src/components/o-error-page/index.scss
@@ -2,6 +2,7 @@
 @import "../../styles/mixins/unstyle-list";
 @import "../../styles/grid/grid-mixins";
 @import "../../styles/typo/typo-mixins";
+@import "../../styles/vertical-rhythm/vertical-rhythm-mixins";
 
 .o-error-page {
   display: block;
@@ -14,6 +15,7 @@
 .o-error-page__container {
   @include make-container();
   @include make-container-max-widths();
+  @include vr-pad-items();
 }
 
 .o-error-page__status {
@@ -22,10 +24,26 @@
 
 .o-error-page__title {
   @include typo-slice-title--publico();
+
+  margin-top: 5px;
+
+  @include respond-up(sm) {
+    margin-top: 0;
+  }
 }
 
 .o-error-page__message {
   @include typo-text();
+
+  margin-top: 40px;
+
+  @include respond-up(sm) {
+    margin-top: 50px;
+  }
+
+  @include respond-up(md) {
+    margin-top: 40px;
+  }
 }
 
 .o-error-page__message--semibold {

--- a/src/components/o-error-page/index.scss
+++ b/src/components/o-error-page/index.scss
@@ -1,0 +1,38 @@
+@import "../../styles/settings/colors";
+@import "../../styles/mixins/unstyle-list";
+@import "../../styles/grid/grid-mixins";
+@import "../../styles/typo/typo-mixins";
+
+.o-error-page {
+  display: block;
+
+  color: $color-prim-white;
+  background: $color-prim-blue-dark-indigo;
+  text-align: center;
+}
+
+.o-error-page__container {
+  @include make-container();
+  @include make-container-max-widths();
+}
+
+.o-error-page__status {
+  @include typo-secondary-text();
+}
+
+.o-error-page__title {
+  @include typo-slice-title--publico();
+}
+
+.o-error-page__message {
+  @include typo-text();
+}
+
+.o-error-page__message--semibold {
+  @include typo-text--semibold();
+}
+
+.o-error-page__list {
+  @include unstyle-list();
+  @include typo-text-longer();
+}

--- a/src/components/o-error-page/index.scss
+++ b/src/components/o-error-page/index.scss
@@ -18,6 +18,16 @@
   @include vr-pad-items();
 }
 
+.o-error-page__status,
+.o-error-page__title,
+.o-error-page__message {
+  @include respond-up(md) {
+    @include make-col-ready();
+    @include make-col(10);
+    @include make-col-offset(1);
+  }
+}
+
 .o-error-page__status {
   @include typo-secondary-text();
 }
@@ -36,6 +46,7 @@
   @include typo-text();
 
   margin-top: 40px;
+  white-space: pre-line;
 
   @include respond-up(sm) {
     margin-top: 50px;
@@ -51,8 +62,21 @@
 }
 
 .o-error-page__list {
-  @include unstyle-list();
   @include typo-text-longer();
+
+  text-align: left;
+
+  @include respond-up(md) {
+    @include make-col-ready();
+    @include make-col(8);
+    @include make-col-offset(2);
+  }
+}
+
+.o-error-page__list-item {
+  @include vr-reset-item();
+
+  margin-top: 16px;
 }
 
 .o-error-page__cta {

--- a/src/js/to-prop.js
+++ b/src/js/to-prop.js
@@ -1,4 +1,4 @@
-const regexJson = /^\s*(?:true|false|null|undefined|-?[0-9]+\.?[0-9]*|[[{](?:.|[\r\n])*[\]}])\s*$/;
+const regexJson = /^\s*(?:true|false|null|undefined|-?[0-9]+\.?[0-9]*|[[{](?:.|[\s])*[\]}])\s*$/;
 
 /**
  * Try to parse a string value by `JSON.parse`.


### PR DESCRIPTION
improves #500 
Changes proposed in this pull request:

 - https://design.axa.com/web-guidelines/error-pages
 - it implements the simple error page (there is still a fancy one and a login mask)
 - fixes regex of `toProp` does not detect all JSON with special white space

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
