### PR TITLE
move script of core after app

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,6 @@
   </head>
   <body class="a-device-state a-device-state--debug">
 
-    <script src="components/u-core/index.js"></script>
     <axa-core only-load="true" icons-path="./assets/icons/icons.svg"></axa-core>
 
     <header class="sg-header">
@@ -135,6 +134,7 @@
     <!-- {CUT AND INJECT PREVIEWS HERE} -->
 
     <script src="./app/app.js"></script>
+    <script src="components/u-core/index.js"></script>
     <!-- {CUT AND INJECT IMPORTS HERE} -->
   </body>
 </html>


### PR DESCRIPTION
Fixes `u-core` script loaded before `app.js` (which loads the needed polyfill)

Changes proposed in this pull request:

 -
 -
 -

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
