### PR TITLE
removed those annoying outdated warnings

### DIFF
--- a/src/styles/typo/_typo-functions.scss
+++ b/src/styles/typo/_typo-functions.scss
@@ -108,10 +108,6 @@
     $weight: nth($allowedWeights, 1);
   }
 
-  @if index($allowedWeights, $weight) == null {
-    @warn "$weight #{$weight} not suggested for current typo";
-  }
-
   @if not map-has-key($font-weight-map, $weight) {
     @error "$weight #{$weight} not found in $font-weight-map.";
   }


### PR DESCRIPTION
Just removed the sass warnings for typography...

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
