### PR TITLE
AEM-3795: icons: support both img by url and svg from child element

### DIFF
--- a/src/components/m-policy-feature-item/index.scss
+++ b/src/components/m-policy-feature-item/index.scss
@@ -17,6 +17,8 @@ $policy-feature-item-content-width-lg: 255px;
   height: $policy-feature-item-icon-height-sm;
   display: block;
   margin: $policy-feature-item-margin-50 auto 0 auto;
+  max-width: 100%;
+  color: $color-prim-white;
 
   @include respond-up(md) {
     height: $policy-feature-item-icon-height-md;

--- a/src/components/o-policy-features/_preview.html
+++ b/src/components/o-policy-features/_preview.html
@@ -7,9 +7,14 @@
   </axa-policy-feature-item>
 
   <axa-policy-feature-item title="24/7 assistance"
-                           src="https://d5cplpsrt2s33.cloudfront.net/m/79774b901be10a5b/original/tick_white_web.svg"
                            alt="Assistance Svg Icon"
-                           description="We reward safe drivers : 75% no claims discount + an extra 10% off if you get a quote online">
+                           description="This svg is way too wide">
+    <svg class="js-m-policy-features-icon m-policy-feature-item__icon" xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+      <g fill="none" stroke="currentColor" stroke-width="42.596" stroke-linejoin="round" stroke-miterlimit="10">
+        <path d="M1001.65 627.12c12.313-278.946-210.815-511.14-489.292-511.14-278.325 0-501.62 232.028-489.265 511.14 0 0-.583-85.19 105.907-85.19 106.488 0 127.786 85.19 127.786 85.19s21.298-85.19 127.786-85.19 127.786 85.19 127.786 85.19 42.58-85.19 127.77-85.19c85.193 0 127.788 85.19 127.788 85.19s42.595-85.19 127.785-85.19c85.195 0 105.95 85.19 105.95 85.19z"></path>
+        <path stroke-linecap="round" d="M512.317 115.98V30.788M618.79 946.587c0 63.893-106.473 63.893-106.473 0V627.12"></path>
+      </g>
+    </svg>
   </axa-policy-feature-item>
 
   <axa-policy-feature-item title="Discount partners"


### PR DESCRIPTION
Fixes #556  (issue).

Changes proposed in this pull request:

 - limit svg width
 - set color to white for svgs
 

## Type of change

<!-- Please delete options that a, tested locallyre not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
 
 # How Has This Been Tested?

added new example with a wide svg
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
