### PR TITLE
fix month index in parseLocalisedDateIfValid()

### DIFF
--- a/src/demos/todomvc/todos.jsx
+++ b/src/demos/todomvc/todos.jsx
@@ -40,7 +40,7 @@ class Todos extends Component {
     const date = new Date(event.detail);
     console.log(date, event);
     // eslint-disable-next-line
-    alert(`${date.getFullYear()}/${date.getMonth()}/${date.getDate()}`);
+    alert(`${date.getFullYear()}/${date.getMonth()+1}/${date.getDate()}`);
   }
 
   handleNewTodoKeyDown(event) {

--- a/src/js/date.js
+++ b/src/js/date.js
@@ -134,7 +134,7 @@ export const parseLocalisedDateIfValid = (locale = 'en-uk', inputValue = '') => 
   const dayIndex = splittedBlueprint.indexOf('23');
   const yearIndex = splittedBlueprint.indexOf('2017');
 
-  const dateUnderValidation = new Date(splittedValue[yearIndex], splittedValue[monthIndex], splittedValue[dayIndex]);
+  const dateUnderValidation = new Date(splittedValue[yearIndex], splittedValue[monthIndex] - 1, splittedValue[dayIndex]);
 
   // eslint-disable-next-line no-restricted-globals
   if (dateUnderValidation instanceof Date && !isNaN(dateUnderValidation)) {


### PR DESCRIPTION
Fixes #608 

Changes proposed in this pull request:

 - update parseLocalisedDateIfValid() to pass 0-based month to Date constructor
 - update react example to alert correct month number


## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
 
 # How Has This Been Tested?
 
- npm run bundle-demos-dev
- npm run server
- http://localhost:3000/react.html
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
