### PR TITLE
fix month index when opening axa-m-datepicker in axa-datepicker

### DIFF
--- a/src/components/m-datepicker/_template.js
+++ b/src/components/m-datepicker/_template.js
@@ -7,6 +7,9 @@ import {
   TODAY,
 } from '../../js/date';
 
+/**
+ * @param startMonth zero-based
+ */
 const getStartDate = (yearsRange, startYear = TODAY, startMonth = TODAY) => {
   let { lowerEndYear, higherEndYear } = yearsRange;
   const date = new Date();
@@ -23,7 +26,7 @@ const getStartDate = (yearsRange, startYear = TODAY, startMonth = TODAY) => {
   }
 
   if (startMonth !== TODAY) {
-    date.setMonth(startMonth);
+    date.setMonth(startMonth); // zero-based
   }
 
   if (startYear !== TODAY) {
@@ -58,7 +61,7 @@ export default ({
   buttonCancel,
   locale = 'en-uk',
   startYear = TODAY,
-  startMonth = TODAY,
+  startMonth = TODAY, // zero-based
   selectedDay = null,
   lowerEndYear,
   higherEndYear,

--- a/src/components/m-datepicker/_template.js
+++ b/src/components/m-datepicker/_template.js
@@ -8,7 +8,10 @@ import {
 } from '../../js/date';
 
 /**
- * @param startMonth zero-based
+ * @param yearsRange object with keys: lowerEndYear, higherEndYear
+ * @param startYear number|string year number, or 'TODAY' string
+ * @param startMonth number|string zero-based month number, or 'TODAY' string
+ * @return object with keys: year, month (zero-based)
  */
 const getStartDate = (yearsRange, startYear = TODAY, startMonth = TODAY) => {
   let { lowerEndYear, higherEndYear } = yearsRange;

--- a/src/components/m-datepicker/index.js
+++ b/src/components/m-datepicker/index.js
@@ -27,7 +27,7 @@ class AXADatepicker extends BaseComponentGlobal {
     locale: localePropType,
     value: PropTypes.string,
     startYear: startType,
-    startMonth: startType,
+    startMonth: startType, // zero-based
     selectedDay: PropTypes.number,
     lowerEndYear: PropTypes.number,
     higherEndYear: PropTypes.number,

--- a/src/components/o-datepicker/_template.js
+++ b/src/components/o-datepicker/_template.js
@@ -18,7 +18,7 @@ export default ({
     :
         html`<axa-input class="o-datepicker__input js-datepicker__input" placeholder="${getLocaleDayMonthYear(locale)}" name="get-local-day-month-year" icon="datepicker" inline></axa-input>`
       }
-      ${open ? html`<axa-m-datepicker higher-end-year="${higherEndYear}" lower-end-year="${lowerEndYear}" output-iso="${outputIso}" selected-day="${value ? value.getDate() : false}" start-month="${value ? value.getMonth() - 1 : TODAY}" start-year="${value ? value.getFullYear() : TODAY}" class="o-datepicker__calender js-datepicker__calender" locale="${locale}" button-ok="bestätigen" button-cancel="abbrechen"></axa-m-datepicker>` : ''}
+      ${open ? html`<axa-m-datepicker higher-end-year="${higherEndYear}" lower-end-year="${lowerEndYear}" output-iso="${outputIso}" selected-day="${value ? value.getDate() : false}" start-month="${value ? value.getMonth() : TODAY}" start-year="${value ? value.getFullYear() : TODAY}" class="o-datepicker__calender js-datepicker__calender" locale="${locale}" button-ok="bestätigen" button-cancel="abbrechen"></axa-m-datepicker>` : ''}
     </article>
   `;
 };


### PR DESCRIPTION
Changes proposed in this pull request:

 - after the  #608 fix, wrong month (-1) was selected in the calendar dropdown

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 
 # How Has This Been Tested?

- npm run build-html-dev
- npm http://localhost:3000/organisms.html#o-datepicker
 
 # Checklist:
 
 - [x] I have performed a self-review of my own code
