### PR TITLE
Datepicker: fix value reset when confirming without day change

### DIFF
--- a/src/components/m-datepicker/js/datepicker.js
+++ b/src/components/m-datepicker/js/datepicker.js
@@ -89,7 +89,12 @@ export default class Datepicker {
     this.unOkButtonListenerEnd = on(this.wcNode.querySelector('.js-datepicker__button__Ok'), EVENTS.CLICK, () => {
       const year = this.datepickerBody.getAttribute('year');
       const month = this.datepickerBody.getAttribute('month');
-      const day = this.datepickerBody.getAttribute('value');
+      const dayAsValue = this.datepickerBody.getAttribute('value'); // new value - after click on a day
+      let dayAsDay = this.datepickerBody.getAttribute('day'); // prev value - prior click on a day
+      if ('false' === dayAsDay) {
+        dayAsDay = false
+      }
+      const day = dayAsValue || dayAsDay
 
       if (day) {
         const choosenDate = new Date(year, month, day);

--- a/src/components/m-datepicker/js/datepicker.js
+++ b/src/components/m-datepicker/js/datepicker.js
@@ -91,10 +91,10 @@ export default class Datepicker {
       const month = this.datepickerBody.getAttribute('month');
       const dayAsValue = this.datepickerBody.getAttribute('value'); // new value - after click on a day
       let dayAsDay = this.datepickerBody.getAttribute('day'); // prev value - prior click on a day
-      if ('false' === dayAsDay) {
-        dayAsDay = false
+      if (dayAsDay === 'false') {
+        dayAsDay = false;
       }
-      const day = dayAsValue || dayAsDay
+      const day = dayAsValue || dayAsDay;
 
       if (day) {
         const choosenDate = new Date(year, month, day);


### PR DESCRIPTION
Without a day change (click on day) the m-datepicker-body doesn't have
a "value" attribute. It does have "day" attribute.
So this change uses the "day" attribute in case the "value" is falsy.

Fixes #620 .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 
 # How Has This Been Tested?
 
locally
 
 # Checklist:
 
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] My changes generate no new warnings
