### PR TITLE
fix(Datepicker): fix "output-iso" being always on problem

### DIFF
--- a/src/components/m-datepicker/index.js
+++ b/src/components/m-datepicker/index.js
@@ -31,7 +31,7 @@ class AXADatepicker extends BaseComponentGlobal {
     selectedDay: PropTypes.number,
     lowerEndYear: PropTypes.number,
     higherEndYear: PropTypes.number,
-    outputIso: PropTypes.string,
+    outputIso: PropTypes.bool,
   }
 
   // Specify observed attributes so that attributeChangedCallback will work,

--- a/src/components/o-datepicker/_template.js
+++ b/src/components/o-datepicker/_template.js
@@ -12,6 +12,7 @@ export default ({
 }, documentFragment, wcNode) => {
   wcNode.datepicker.locale = locale;
   const { localeValue, value } = wcNode.datepicker;
+  // when falsy, leave out the output-iso attr., otherwise the "false" string value means true within <axa-m-datepicker>
   return html`
     <article class=${classes}>
       ${localeValue ?

--- a/src/components/o-datepicker/_template.js
+++ b/src/components/o-datepicker/_template.js
@@ -1,4 +1,5 @@
 import html from 'nanohtml';
+import raw from 'nanohtml/raw';
 import { getLocaleDayMonthYear, TODAY } from '../../js/date';
 
 export default ({
@@ -18,7 +19,19 @@ export default ({
     :
         html`<axa-input class="o-datepicker__input js-datepicker__input" placeholder="${getLocaleDayMonthYear(locale)}" name="get-local-day-month-year" icon="datepicker" inline></axa-input>`
       }
-      ${open ? html`<axa-m-datepicker higher-end-year="${higherEndYear}" lower-end-year="${lowerEndYear}" output-iso="${outputIso}" selected-day="${value ? value.getDate() : false}" start-month="${value ? value.getMonth() : TODAY}" start-year="${value ? value.getFullYear() : TODAY}" class="o-datepicker__calender js-datepicker__calender" locale="${locale}" button-ok="bestätigen" button-cancel="abbrechen"></axa-m-datepicker>` : ''}
+      ${open
+        ? raw(`<axa-m-datepicker
+            ${higherEndYear ? `higher-end-year="${higherEndYear}"` : ''}
+            ${lowerEndYear ? `lower-end-year="${lowerEndYear}"` : ''}
+            ${outputIso ? 'output-iso' : ''}
+            ${value ? `selected-day="${value.getDate()}"` : ''}
+            start-month="${value ? value.getMonth() : TODAY}"
+            start-year="${value ? value.getFullYear() : TODAY}"
+            class="o-datepicker__calender js-datepicker__calender"
+            locale="${locale}"
+            button-ok="bestätigen"
+            button-cancel="abbrechen"></axa-m-datepicker>`)
+        : ''}
     </article>
   `;
 };


### PR DESCRIPTION
**See my comment from 13:49 first.**

After the merge of #628 from axa-ch/bugfix/some-dropdown-issues in
version 2.0.1-beta.202, the Datepicker was always outputing number
of seconds (as with the output-iso option) instead of normal date.

This commit removes "output-iso" attribute from `<axa-m-datepicker>`
element when it has falsy value. Bacause otherwise this did lead into
"false" string value which was evaluated as true, causing this problem.

Also these other attributes are now left out when falsy:
higher-end-year, lower-end-year, selected-day

![image](https://user-images.githubusercontent.com/43809369/47427860-e52d9680-d791-11e8-9c35-06b4b72914d6.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
