### PR TITLE
feat(m-header-languages): set node value to selected language name

### DIFF
--- a/src/components/m-footer-languages/_template.js
+++ b/src/components/m-footer-languages/_template.js
@@ -10,7 +10,7 @@ export default function ({ title, items, short }) {
         <li class="m-footer-languages__list-item">
           <a class="${classnames('m-footer-languages__link', {
             'is-footer-languages-active': isActive,
-          })}" href="${url}" lang="${code}">${short ? code : name}</a>
+          })}" href="${url}" lang="${code}" data-language="${code}">${short ? code : name}</a>
         </li>
       `)}
     </ul>

--- a/src/components/m-footer-languages/index.js
+++ b/src/components/m-footer-languages/index.js
@@ -6,6 +6,9 @@ import defineOnce from '../../js/define-once';
 import urlPropType from '../../js/prop-types/url-prop-type';
 import styles from './index.scss';
 import template from './_template';
+import valuePropType from "../../js/prop-types/value-prop-type";
+import on from "../../js/on";
+import {EVENTS} from "../../js/ui-events";
 
 class AXAFooterLanguages extends BaseComponentGlobal {
   static tagName = 'axa-footer-languages'
@@ -19,10 +22,31 @@ class AXAFooterLanguages extends BaseComponentGlobal {
     })),
     short: PropTypes.bool,
     title: PropTypes.string,
+    value: valuePropType,
   }
+
+  unClickEnd
 
   constructor() {
     super({ styles, template });
+  }
+
+  handleClick = (e) => {
+    if (e.target && e.target.dataset && e.target.dataset.language) {
+      e.stopPropagation();
+      this.setAttribute('value', e.target.dataset.language);
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.unClickEnd = on(
+      this, EVENTS.CLICK, 'm-footer-languages__link',
+      this.handleClick, {
+        capture: true, passive: false,
+      },
+    );
   }
 
   willRenderCallback() {
@@ -32,6 +56,11 @@ class AXAFooterLanguages extends BaseComponentGlobal {
       'm-footer-languages--inline': inline,
     });
   }
+
+  disconnectedCallback() {
+    this.unClickEnd && this.unClickEnd();
+  }
+
 }
 
 defineOnce(AXAFooterLanguages.tagName, AXAFooterLanguages);

--- a/src/components/m-footer-languages/index.js
+++ b/src/components/m-footer-languages/index.js
@@ -6,9 +6,9 @@ import defineOnce from '../../js/define-once';
 import urlPropType from '../../js/prop-types/url-prop-type';
 import styles from './index.scss';
 import template from './_template';
-import valuePropType from "../../js/prop-types/value-prop-type";
-import on from "../../js/on";
-import {EVENTS} from "../../js/ui-events";
+import valuePropType from '../../js/prop-types/value-prop-type';
+import on from '../../js/on';
+import { EVENTS } from '../../js/ui-events';
 
 class AXAFooterLanguages extends BaseComponentGlobal {
   static tagName = 'axa-footer-languages'
@@ -58,9 +58,10 @@ class AXAFooterLanguages extends BaseComponentGlobal {
   }
 
   disconnectedCallback() {
-    this.unClickEnd && this.unClickEnd();
+    if (this.unClickEnd) {
+      this.unClickEnd();
+    }
   }
-
 }
 
 defineOnce(AXAFooterLanguages.tagName, AXAFooterLanguages);

--- a/src/components/m-header-languages/_template.js
+++ b/src/components/m-header-languages/_template.js
@@ -6,7 +6,7 @@ const getSelectedName = (value, items) => {
   if (!items || !Array.isArray(items) || !items.length) {
     return '';
   }
-  const selectedItem = items.find(item => item.name === value);
+  const selectedItem = items.filter(item => item.name === value)[0];
   return selectedItem ? selectedItem.name : items[0].name;
 };
 

--- a/src/components/m-header-languages/_template.js
+++ b/src/components/m-header-languages/_template.js
@@ -2,18 +2,31 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import classnames from 'classnames';
 
-export default ({ items }) => [html`
+const getSelectedName = (value, items) => {
+  if (!items || !Array.isArray(items) || !items.length) {
+    return '';
+  }
+  const selectedItem = items.find(item => item.name === value);
+  return selectedItem ? selectedItem.name : items[0].name;
+};
+
+export default ({ value, items }) => [html`
   <button type="button" class="m-header-languages__drop-down-toggle js-dropdown__toggle">
-    ${Array.isArray(items) && items[0].name}
+    ${getSelectedName(value, items)}
     <axa-icon icon="angle-bracket-down" classes="m-header-languages__drop-down-icon"></axa-icon>
   </button>
 `, html`
-  <ul class="m-header-languages__list">
+  <ul class="m-header-languages__list js-dropdown__content">
     ${Array.isArray(items) && items.map(({ url = '', name, isActive }) => html`
       <li class="m-header-languages__list-item">
-        <a class="${classnames('m-header-languages__list-link', {
-          'is-header-languages-active': isActive,
-        })}" href="${url}">
+        <a
+          data-index="${name}"
+          data-selected="${name === value ? 'true' : 'false'}"
+          class="${classnames('m-header-languages__list-link', {
+            'is-header-languages-active': isActive,
+          })}"
+          href="${url}"
+        >
           ${raw(name)}
         </a>
       </li>

--- a/src/components/m-header-languages/index.js
+++ b/src/components/m-header-languages/index.js
@@ -3,6 +3,7 @@ import PropTypes from '../../js/prop-types'; // eslint-disable-next-line import/
 import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import defineOnce from '../../js/define-once';
 import urlPropType from '../../js/prop-types/url-prop-type';
+import valuePropType from "../../js/prop-types/value-prop-type";
 // import the styles used for this component
 import styles from './index.scss';
 // import the template used for this component
@@ -17,15 +18,14 @@ class AXAHeaderLanguages extends BaseComponentGlobal {
       name: PropTypes.string,
       isActive: PropTypes.bool,
     })),
+    value: valuePropType,
   }
 
   constructor() {
     super({ styles, template });
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-
+  willRenderCallback() {
     this.className = `${this.initialClassName} m-header-languages js-dropdown`;
   }
 
@@ -41,9 +41,10 @@ class AXAHeaderLanguages extends BaseComponentGlobal {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-
-    this.dropDown.destroy();
-    delete this.dropDown;
+    if (this.dropDown) {
+      this.dropDown.destroy();
+      delete this.dropDown;
+    }
   }
 }
 

--- a/src/components/m-header-languages/index.js
+++ b/src/components/m-header-languages/index.js
@@ -3,7 +3,7 @@ import PropTypes from '../../js/prop-types'; // eslint-disable-next-line import/
 import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import defineOnce from '../../js/define-once';
 import urlPropType from '../../js/prop-types/url-prop-type';
-import valuePropType from "../../js/prop-types/value-prop-type";
+import valuePropType from '../../js/prop-types/value-prop-type';
 // import the styles used for this component
 import styles from './index.scss';
 // import the template used for this component

--- a/src/components/m-header-mobile-languages/_template.js
+++ b/src/components/m-header-mobile-languages/_template.js
@@ -2,7 +2,7 @@ import html from 'nanohtml';
 import classnames from 'classnames';
 
 export default ({ items }) => Array.isArray(items) && items.map(({ code, url, isActive }) => html`
-  <a href="${url}" class="${classnames('m-header-mobile-languages__link', 'js-header-mobile-close', {
+  <a href="${url}" data-language="${code}" class="${classnames('m-header-mobile-languages__link', 'js-header-mobile-close', {
     'is-header-mobile-languages-active': isActive,
   })}">${code}</a>
 `);

--- a/src/components/m-header-mobile-languages/index.js
+++ b/src/components/m-header-mobile-languages/index.js
@@ -3,10 +3,13 @@ import PropTypes from '../../js/prop-types'; // eslint-disable-next-line import/
 import BaseComponentGlobal from '../../js/abstract/base-component-global';
 import defineOnce from '../../js/define-once';
 import urlPropType from '../../js/prop-types/url-prop-type';
+import { EVENTS } from '../../js/ui-events';
+import on from '../../js/on';
 // import the styles used for this component
 import styles from './index.scss';
 // import the template used for this component
 import template from './_template';
+import valuePropType from '../../js/prop-types/value-prop-type';
 
 class AXAHeaderMobileLanguages extends BaseComponentGlobal {
   static tagName = 'axa-header-mobile-languages'
@@ -16,17 +19,39 @@ class AXAHeaderMobileLanguages extends BaseComponentGlobal {
       code: PropTypes.string,
       isActive: PropTypes.bool,
     })),
+    value: valuePropType,
   }
+
+  unClickEnd
 
   constructor() {
     super({ styles, template });
+  }
+
+  handleClick = (e) => {
+    if (e.target && e.target.dataset && e.target.dataset.language) {
+      e.stopPropagation();
+      this.setAttribute('value', e.target.dataset.language);
+    }
   }
 
   connectedCallback() {
     super.connectedCallback();
 
     this.className = `${this.initialClassName} m-header-mobile-languages`;
+
+    this.unClickEnd = on(
+      this, EVENTS.CLICK, 'm-header-mobile-languages__link',
+      this.handleClick, {
+        capture: true, passive: false,
+      },
+    );
   }
+
+  disconnectedCallback() {
+    this.unClickEnd && this.unClickEnd();
+  }
+
 }
 
 defineOnce(AXAHeaderMobileLanguages.tagName, AXAHeaderMobileLanguages);

--- a/src/components/m-header-mobile-languages/index.js
+++ b/src/components/m-header-mobile-languages/index.js
@@ -49,9 +49,10 @@ class AXAHeaderMobileLanguages extends BaseComponentGlobal {
   }
 
   disconnectedCallback() {
-    this.unClickEnd && this.unClickEnd();
+    if (this.unClickEnd) {
+      this.unClickEnd();
+    }
   }
-
 }
 
 defineOnce(AXAHeaderMobileLanguages.tagName, AXAHeaderMobileLanguages);


### PR DESCRIPTION
Before this commit, the wcNode value was not modified when language was
selected, thus the axa-change event was not fired.

Fixes #662

Proposed changes:
- add "value" propType, so that the value attr. is observed for changes
- add "js-dropdown__content" classname, so that click events are captured
- use willRenderCallback() instead connectedCallback() lifecycle method,
  so that the component gets rerendered and dropdown closed, otherwise
  the dropdown would stay opened.
- use language name as the "value"
- show the selected language name within the button

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?

```
<axa-header-meta>
    <axa-header-languages
      id="hl"
      items='[
    {"name": "de", "url": "#de", "isActive": true},
    {"name": "en", "url": "#en"},
    {"name": "fr", "url": "#fr"},
    {"name": "it", "url": "#it"}
  ]'></axa-header-languages>
  </axa-header-meta>
<script>
  document.getElementById("hl").addEventListener("axa-change", function (e) {
    console.log('axa-change', e.detail);
  });
</script>
```
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
