### PR TITLE
fix(with-react): broken built-ins

### DIFF
--- a/src/js/with-react.js
+++ b/src/js/with-react.js
@@ -53,7 +53,8 @@ const withReact = (WebComponent, { pure = true, passive = false } = {}) => {
   // ref: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry
   // therefor we don't instantiate it, but rather use a statically defined tagName property
   const { tagName, builtInTagName } = WebComponent;
-  const displayName = `${camelize(builtInTagName || tagName)}React`;
+  const componentName = builtInTagName || tagName;
+  const displayName = `${camelize(componentName)}React`;
   const Component = pure ? React.PureComponent : React.Component;
 
   return class WebComponentWrapper extends Component {
@@ -156,7 +157,7 @@ const withReact = (WebComponent, { pure = true, passive = false } = {}) => {
         props.is = tagName;
       }
 
-      return createElement(tagName, props, children);
+      return createElement(componentName, props, children);
     }
   };
 };


### PR DESCRIPTION
Fixes #684 
Changes proposed in this pull request:

 - with-react did not consider `builtInTagName`
 -
 -

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
