### PR TITLE
fix(built-in): broken safari, never use constructor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,17 +222,20 @@ A [custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/U
 
 We never use the ~~constructor~~ directly, instead we call [`init()`](#init) for you with the proper context!
 
-**Note:** It's a caveat of Babel 6, please see [proper context upgrading within the constructor](https://github.com/WebReflection/document-register-element#v1-caveat) for more details.
+**Note:** It's a caveat of Babel 6 and support for extended built-in elements polyfill (Safari/webkit only), please see [proper context upgrading within the constructor](https://github.com/WebReflection/document-register-element#v1-caveat) and [You cannot use the constructor in any meaningful way](https://github.com/ungap/custom-elements-builtin#constructor-caveat) for more details.
 
 #### `init()`
 The `init()` method can be used to setup stuff like, establishing contexts, event handlers, observers, defining a shadow root, but never for DOM manipulation.
 It always starts by calling `super.init(?options)` so that the correct prototype chain is established.
 
-**Note:** It's a caveat of Babel 6, please see [proper context upgrading within the constructor](https://github.com/WebReflection/document-register-element#v1-caveat) for more details.
+**Note:** This method is invoked lazily for you upon first `connectedCallback` or `attributeChangedCallback`.
+It's a caveat of Babel 6 and support for extended built-in elements polyfill (Safari/webkit only), please see [proper context upgrading within the constructor](https://github.com/WebReflection/document-register-element#v1-caveat) and [You cannot use the constructor in any meaningful way](https://github.com/ungap/custom-elements-builtin#constructor-caveat) for more details.
+
 
 #### `connectedCallback()`
 
 Invoked when the custom element is first connected to the document's DOM.
+It always starts by calling `super.connectedCallback()` conditionally.
 
 #### `contextCallback(contextNode)`
 
@@ -241,6 +244,7 @@ In case your custom element needs to communicate with a child or parent you are 
 #### `attributeChangedCallback(name, oldValue, newValue)`
 
 Invoked when one of the custom element's attributes is added, removed, or changed.
+It always starts by calling `super.attributeChangedCallback(name, oldValue, newValue)` conditionally.
 
 **IMPORTANT:**
 - attributes are always of type `'string'` and have to be parsed by `JSON.parse()` to provide proper [first class props](#first-class-props)
@@ -316,6 +320,7 @@ Invoked after the custom element's [flattened DOM](#flattened-dom) has rendered.
 #### `disconnectedCallback()`
 
 Invoked when the custom element is disconnected from the document's DOM.
+It always starts by calling `super.disconnectedCallback()` conditionally.
 
 #### Render Loop
 

--- a/src/js/abstract/hocs/with-base.js
+++ b/src/js/abstract/hocs/with-base.js
@@ -9,18 +9,15 @@ const withBase = HTMLElement =>
    * @link https://github.com/WebReflection/document-register-element#v1-caveat
    */
   class WithBase extends HTMLElement {
-    constructor(self) {
-      // eslint-disable-next-line no-param-reassign
-      self = super(self);
-
-      self.init();
-
-      return self;
-    }
-
     init() {
       this._id = getId(this.nodeName);
       this._initialised = true;
+    }
+
+    connectedCallback() {
+      if (this.init && !this._initialised) {
+        this.init();
+      }
     }
 
     static uuidv4() {

--- a/src/js/abstract/hocs/with-base.js
+++ b/src/js/abstract/hocs/with-base.js
@@ -3,7 +3,7 @@ import getId from '../utils/get-id';
 const withBase = HTMLElement =>
   /**
    * Base class {BaseComponent}.
-   * This class handles proper context upgrading fir init(),
+   * This class handles proper context upgrading for init(),
    * it adds a unique `_id` and provides a static UUID generator.
    *
    * **IMPORTANT:** To make extended built-in elements and polyfilled browser working properly,

--- a/src/js/abstract/hocs/with-base.js
+++ b/src/js/abstract/hocs/with-base.js
@@ -3,10 +3,14 @@ import getId from '../utils/get-id';
 const withBase = HTMLElement =>
   /**
    * Base class {BaseComponent}.
-   * This class handles proper context upgrading within the constructor,
+   * This class handles proper context upgrading fir init(),
    * it adds a unique `_id` and provides a static UUID generator.
    *
+   * **IMPORTANT:** To make extended built-in elements and polyfilled browser working properly,
+   * we can't rely on constructor(), due to context issues.
+   *
    * @link https://github.com/WebReflection/document-register-element#v1-caveat
+   * @link: https://github.com/ungap/custom-elements-builtin#constructor-caveat
    */
   class WithBase extends HTMLElement {
     init() {
@@ -14,8 +18,17 @@ const withBase = HTMLElement =>
       this._initialised = true;
     }
 
+    // super important lazy initialize only once as need,
+    // either upon connection
     connectedCallback() {
-      if (this.init && !this._initialised) {
+      if (!this._initialised) {
+        this.init();
+      }
+    }
+
+    // of upon attribute change (can happen before connection if not live)
+    attributeChangedCallback() {
+      if (!this._initialised) {
         this.init();
       }
     }

--- a/src/js/abstract/hocs/with-update.js
+++ b/src/js/abstract/hocs/with-update.js
@@ -97,6 +97,11 @@ const withUpdate = Base =>
      * Default behaviour is to update on attribute addition, change or removal.
      */
     attributeChangedCallback(name, oldValue, newValue) {
+      // super important to call throuth the prototype chain, so that lazy initialisation can happen
+      if (super.attributeChangedCallback) {
+        super.attributeChangedCallback(name, oldValue, newValue);
+      }
+
       if (ENV !== PROD) {
         lifecycleLogger(this.logLifecycle)(`+++ attributeChangedCallback -> ${this.nodeName}#${this._id} | ${name} from ${oldValue} to ${newValue}\n`);
       }


### PR DESCRIPTION
Fixes #691 

Changes proposed in this pull request:

 - `constructor` caveat even worse for `built-in`s https://github.com/ungap/custom-elements-builtin#constructor-caveat

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
