### PR TITLE
fix(built-in): added missing polyfills for IE11

### DIFF
--- a/src/app/es6-polyfills.js
+++ b/src/app/es6-polyfills.js
@@ -4,6 +4,11 @@ import 'core-js/es6/reflect';
 import 'core-js/es6/promise';
 // IE11 does not support Array.from
 import 'core-js/fn/array/from';
+// IE11 does not support Object.* which is needed for built-in element polyfill
+import 'core-js/fn/object/assign';
+import 'core-js/fn/object/create';
+import 'core-js/fn/object/define-properties';
+import 'core-js/fn/object/set-prototype-of';
 import 'innersvg-polyfill/innersvg';
 // Needed for url-prop-type check
 import 'url-polyfill';


### PR DESCRIPTION
Fixes #698 Blocked by #717 

Changes proposed in this pull request:

 - Adds needed `Object.*` polyfill for built-in polyfill in IE11

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
