### PR TITLE
feat(script): defer script loading

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -20,6 +20,8 @@
     <link rel="stylesheet" href="./index.css">
     <link rel="stylesheet" href="./sg.css">
 
+    <!-- {CUT AND INJECT IMPORTS HERE} -->
+
   </head>
   <body class="js-device-state a-device-state a-device-state--debug">
 
@@ -139,7 +141,6 @@
     <script src="components/u-core/index.js"></script>
     <!-- {CUT AND INJECT INDEX HTML HERE} -->
     <!-- {CUT AND INJECT PREVIEWS HERE} -->
-    <!-- {CUT AND INJECT IMPORTS HERE} -->
 
   </body>
 </html>

--- a/src/app/single-component.html
+++ b/src/app/single-component.html
@@ -21,6 +21,8 @@
     <link rel="stylesheet" href="../../index.css">
     <link rel="stylesheet" href="../../sg.css">
 
+    <!-- {CUT AND INJECT IMPORTS HERE} -->
+
   </head>
   <body class="js-device-state a-device-state a-device-state--debug">
     <!-- {CUT AND INJECT HEADER HTML HERE} -->
@@ -35,8 +37,6 @@
 
     <script src="../../app/app.js"></script>
     <script src="../../components/u-core/index.js"></script>
-
-    <!-- {CUT AND INJECT IMPORTS HERE} -->
 
   </body>
 </html>

--- a/stack/tasks/build-examples.js
+++ b/stack/tasks/build-examples.js
@@ -194,7 +194,7 @@ dir.files(`${CWD}/src/components`, (err, allFiles) => {
 
   const scriptTags = filesJavascript.map((item) => {
     const distPath = path.relative(path.resolve(process.cwd(), 'src'), item);
-    return `<script src="${ENV === constants.ENV.PROD ? '/patterns-library' : ''}/${distPath}"></script>`;
+    return `<script defer src="${ENV === constants.ENV.PROD ? '/patterns-library' : ''}/${distPath}"></script>`;
   });
 
   const getPreviewName = (componentPreviewPath) => {


### PR DESCRIPTION
mitigates #720 

Changes proposed in this pull request:

 - Move `<script>`s to head and applied `defer`
 - Not ideal, depends on browser support - https://caniuse.com/#feat=script-defer
 - We should really use a sophisticated bundler/loader

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
