### PR TITLE
fix(table): added used custom elements as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "autoprefixer": "^7.2.3",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.2.1",
+    "babel-plugin-discard-module-references": "^1.1.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-inline-replace-variables": "^1.3.1",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/src/components/m-accordion-item/_template.js
+++ b/src/components/m-accordion-item/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import classnames from 'classnames';
 
+import '../a-icon';
+
 export default ({ header, headerSecondary, headerColor, icon = '' }, childrenFragment) => {
   const headerPrimaryClasses = classnames('m-accordion-item__heading', 'm-accordion-item__heading--primary', {
     [`m-accordion-item__heading--${headerColor}`]: headerColor,

--- a/src/components/m-button/_template.js
+++ b/src/components/m-button/_template.js
@@ -3,6 +3,8 @@ import raw from 'nanohtml/raw';
 import classnames from 'classnames';
 import isEmptyFragment from '../../js/is-empty-fragment';
 
+import '../a-icon';
+
 const DISABLED = 'disabled';
 const ARIA_DISABLED = 'aria-disabled';
 

--- a/src/components/m-datepicker/_template.js
+++ b/src/components/m-datepicker/_template.js
@@ -7,6 +7,9 @@ import {
   TODAY,
 } from '../../js/date';
 
+import '../m-dropdown';
+import '../m-datepicker-body';
+
 /**
  * @param yearsRange object with keys: lowerEndYear, higherEndYear
  * @param startYear number|string year number, or 'TODAY' string

--- a/src/components/m-dropdown/_template.js
+++ b/src/components/m-dropdown/_template.js
@@ -2,6 +2,8 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import classnames from 'classnames';
 
+import '../a-icon';
+
 const arrowIcon = '<axa-icon icon="angle-bracket-down" classes="m-dropdown__icon"></axa-icon>';
 
 const getItemValue = (itemValue, index) => itemValue === null || itemValue === undefined ? index : itemValue;

--- a/src/components/m-footer-links/_template.js
+++ b/src/components/m-footer-links/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 
+import '../a-icon';
+
 const arrowIcon = '<axa-icon icon="angle-bracket-down" classes="m-footer-links__category__icon"></axa-icon>';
 
 export default function ({ title, items }) {

--- a/src/components/m-footer-social/_template.js
+++ b/src/components/m-footer-social/_template.js
@@ -1,5 +1,7 @@
 import html from 'nanohtml';
 
+import '../a-icon';
+
 export default function ({ title, items = [] }) {
   return html`<aside class="m-footer-social__box">
     ${title && html`<strong class="m-footer-social__title">${title}</strong>`}

--- a/src/components/m-header-burger/_template.js
+++ b/src/components/m-header-burger/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 
+import '../a-icon';
+
 export default () => html`
   <button type="button" class="m-header-burger__button js-header-burger__button">
     ${raw('<axa-icon icon="menu" classes="m-header-burger__icon"></axa-icon>')}

--- a/src/components/m-header-languages/_template.js
+++ b/src/components/m-header-languages/_template.js
@@ -2,6 +2,8 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import classnames from 'classnames';
 
+import '../a-icon';
+
 const getSelectedName = (value, items) => {
   if (!items || !Array.isArray(items) || !items.length) {
     return '';

--- a/src/components/m-header-logo/_template.js
+++ b/src/components/m-header-logo/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 
+import '../a-icon';
+
 export default ({ src, alt = 'AXA Logo', href = '#' } = {}) => html`
   <a href="${href}" class="m-header-logo__link js-header-logo__link">
     ${src ? html`

--- a/src/components/m-header-mobile-navigation/_template.js
+++ b/src/components/m-header-mobile-navigation/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import classnames from 'classnames';
 
+import '../a-icon';
+
 function mobileNavItem(item) {
   const { name, url = '', isActive, items } = item;
   const hasItems = !!items;

--- a/src/components/m-header-navigation/_template.js
+++ b/src/components/m-header-navigation/_template.js
@@ -2,6 +2,8 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import classnames from 'classnames';
 
+import '../m-header-sub-navigation';
+
 const submenuItem = ({ url = '', name = '', items, classes, isActive, simplemenu, hyphenate = false, historyApi }) => html`
     <li class="m-header-navigation__list-item">
       <a data-prevent-default class="${classnames('m-header-navigation__list-link', classes, {

--- a/src/components/m-header-search/_template.js
+++ b/src/components/m-header-search/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 
+import '../a-icon';
+
 export default ({ action, href, method = 'POST' } = {}) => html`
   <form class="m-header-search__form" action="${action}" method="${method}">
     <a class="m-header-search__page-link" href="${href}">

--- a/src/components/m-header-sub-navigation/_template.js
+++ b/src/components/m-header-sub-navigation/_template.js
@@ -2,6 +2,8 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import classnames from 'classnames';
 
+import '../a-icon';
+
 const linkItem = ({ url = '', name, isActive, preventDefault = 'false' }) => html`
   <li class="m-header-sub-navigation__list-item">
     <a data-prevent-default="${preventDefault}" class="${classnames('m-header-sub-navigation__link', 'js-header-navigation-close', {

--- a/src/components/m-link/_template.js
+++ b/src/components/m-link/_template.js
@@ -1,6 +1,8 @@
 import html from 'nanohtml';
 import classnames from 'classnames';
 
+import '../a-icon';
+
 export default function ({
   color,
   size,

--- a/src/components/m-tbody/_template.js
+++ b/src/components/m-tbody/_template.js
@@ -1,5 +1,7 @@
 import html from 'nanohtml';
 
+import '../m-tr';
+import '../a-td';
 import expandTableData from '../../js/expand-table-data';
 
 export default ({ items }, fragmentChildren) => {

--- a/src/components/m-tfoot/_template.js
+++ b/src/components/m-tfoot/_template.js
@@ -1,5 +1,7 @@
 import html from 'nanohtml';
 
+import '../m-tr';
+import '../a-td';
 import expandTableData from '../../js/expand-table-data';
 
 export default ({ items }, fragmentChildren) => {

--- a/src/components/m-thead/_template.js
+++ b/src/components/m-thead/_template.js
@@ -1,5 +1,7 @@
 import html from 'nanohtml';
 
+import '../m-tr';
+import '../a-th';
 import expandTableData from '../../js/expand-table-data';
 
 export default ({ items }, fragmentChildren) => {

--- a/src/components/o-commercial-hero-cover/_template.js
+++ b/src/components/o-commercial-hero-cover/_template.js
@@ -1,5 +1,9 @@
 import html from 'nanohtml';
 
+import '../m-row';
+import '../m-col';
+import '../o-container';
+
 export default ({
   src,
   alt = 'Commercial Hero cover',

--- a/src/components/o-cookie-disclaimer/_template.js
+++ b/src/components/o-cookie-disclaimer/_template.js
@@ -1,5 +1,8 @@
 import html from 'nanohtml';
 
+import '../m-button';
+import '../o-container';
+
 export default ({
   classes,
   buttonName,

--- a/src/components/o-datepicker/_template.js
+++ b/src/components/o-datepicker/_template.js
@@ -2,6 +2,9 @@ import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import { getLocaleDayMonthYear, TODAY } from '../../js/date';
 
+import '../a-input';
+import '../m-datepicker';
+
 export default ({
   classes,
   locale = 'en-uk',

--- a/src/components/o-error-page/_template.js
+++ b/src/components/o-error-page/_template.js
@@ -2,6 +2,8 @@ import classnames from 'classnames';
 import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 
+import '../m-button';
+
 export default ({
   code, // eslint-disable-line
   status,

--- a/src/components/o-table/_template.js
+++ b/src/components/o-table/_template.js
@@ -1,5 +1,10 @@
 import html from 'nanohtml';
 
+import '../a-caption';
+import '../m-thead';
+import '../m-tfoot';
+import '../m-tbody';
+
 export default ({
   cap,
   capAlign,


### PR DESCRIPTION
**Blocked** by not using a module bundler, chunk optimiser.

Fixes #723 and paves the way for #720 

Changes proposed in this pull request:

 - Each component `import`s all custom elements used within it's template
   **Note:** all components passed as children, still have to be loaded manually, e.g. contents of `preview.html`
 - This paves the way for our new **Single Component View** to reduce script load water fall #720 and just load one script instead of all of them

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
