### PR TITLE
fix(polyfills): fixed es6 polyfills not in lib

### DIFF
--- a/src/app/es6-polyfills.js
+++ b/src/app/es6-polyfills.js
@@ -1,14 +1,1 @@
-// Reflect is needed to make Custom Element ES6 Classes working and for IE11
-import 'core-js/es6/reflect';
-// Promise is needed for IE11 and if withReact is used
-import 'core-js/es6/promise';
-// IE11 does not support Array.from
-import 'core-js/fn/array/from';
-// IE11 does not support Object.* which is needed for built-in element polyfill
-import 'core-js/fn/object/assign';
-import 'core-js/fn/object/create';
-import 'core-js/fn/object/define-properties';
-import 'core-js/fn/object/set-prototype-of';
-import 'innersvg-polyfill/innersvg';
-// Needed for url-prop-type check
-import 'url-polyfill';
+import '../js/es6-polyfills';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import './app/es6-polyfills.js';
+import './js/es6-polyfills.js';
 // ES2015 Custom Element Polyfill
 import 'document-register-element';
 // load this for browsers which support customElements without builtin (webkit)

--- a/src/js/es6-polyfills.js
+++ b/src/js/es6-polyfills.js
@@ -1,0 +1,14 @@
+// Reflect is needed to make Custom Element ES6 Classes working and for IE11
+import 'core-js/es6/reflect';
+// Promise is needed for IE11 and if withReact is used
+import 'core-js/es6/promise';
+// IE11 does not support Array.from
+import 'core-js/fn/array/from';
+// IE11 does not support Object.* which is needed for built-in element polyfill
+import 'core-js/fn/object/assign';
+import 'core-js/fn/object/create';
+import 'core-js/fn/object/define-properties';
+import 'core-js/fn/object/set-prototype-of';
+import 'innersvg-polyfill/innersvg';
+// Needed for url-prop-type check
+import 'url-polyfill';

--- a/src/js/react-exports.js
+++ b/src/js/react-exports.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import '../app/es6-polyfills';
+import './es6-polyfills';
 import 'document-register-element';
 // load this for browsers which support customElements without builtin (webkit)
 import '@ungap/custom-elements-builtin';


### PR DESCRIPTION
Fixes polyfills not in `lib/`

> Module not found: Can't resolve '../app/es6-polyfills' in '/Users/axawinterthur/dev/patterns-library-examples/react/node_modules/@axa-ch/patterns-library/lib/js'

Changes proposed in this pull request:

 -
 -
 -

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
