### PR TITLE
breakes built-in ie but fixes with-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,12 +154,12 @@
   },
   "dependencies": {
     "@ungap/custom-elements-builtin": "^0.1.1",
+    "@webcomponents/webcomponentsjs": "^2.2.1",
     "babel-plugin-transform-builtin-classes": "^0.6.1",
     "babel-runtime": "^6.26.0",
     "classnames": "^2.2.5",
     "connect-slow": "^0.4.0",
     "core-js": "~2.5.1",
-    "document-register-element": "^1.12.0",
     "innersvg-polyfill": "0.0.2",
     "nanohtml": "^1.3.0",
     "objectFitPolyfill": "^2.0.5",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,5 @@
 // better to load this only if it's needed
-import 'document-register-element'; // ES2015
+import '@webcomponents/webcomponentsjs/bundles/webcomponents-ce'
 // load this for browsers which support customElements without builtin (webkit)
 import '@ungap/custom-elements-builtin';
 

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,5 @@
 // better to load this only if it's needed
-import '@webcomponents/webcomponentsjs/bundles/webcomponents-ce'
+import '@webcomponents/webcomponentsjs/bundles/webcomponents-ce';
 // load this for browsers which support customElements without builtin (webkit)
 import '@ungap/custom-elements-builtin';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import './js/es6-polyfills.js';
 // ES2015 Custom Element Polyfill
-import 'document-register-element';
+import '@webcomponents/webcomponentsjs/bundles/webcomponents-ce';
 // load this for browsers which support customElements without builtin (webkit)
 import '@ungap/custom-elements-builtin';
 

--- a/src/js/react-exports.js
+++ b/src/js/react-exports.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import './es6-polyfills';
-import 'document-register-element';
+import '@webcomponents/webcomponentsjs/bundles/webcomponents-ce'
 // load this for browsers which support customElements without builtin (webkit)
 import '@ungap/custom-elements-builtin';
 


### PR DESCRIPTION
Fixes https://github.com/axa-ch/patterns-library-examples/issues/12.

Changes proposed in this pull request:
@AndyOGo this PR fixes `with-react` in IE for AEM, Patterns-Library and Patterns-Library-Examples.
@AndyOGo it brakes built-in ONLY on IE (Safari, EDGE, FF and Chrome worked with built-ins).

