### PR TITLE
fix(with-react): don't mutate this.props

### DIFF
--- a/src/js/with-react.js
+++ b/src/js/with-react.js
@@ -152,28 +152,30 @@ const withReact = (WebComponent, { pure = true, passive = false } = {}) => {
       // eslint-disable-next-line react/prop-types
       const { props: { children, ...props }, handleRef } = this;
       const { observedAttributes } = WebComponent;
+      // super important: don't mutate this.props
+      const jsxProps = { ...props };
 
       // important: set non-observed attributes to keep native built-in features working
       if (Array.isArray(observedAttributes)) {
         observedAttributes.forEach((name) => {
-          delete props[camelize(name)];
+          delete jsxProps[camelize(name)];
         });
       }
 
-      const propsKeys = Object.keys(props);
+      const propsKeys = Object.keys(jsxProps);
 
       // remove events from props
       propsKeys.filter(isEventFilter).forEach((key) => {
-        delete props[key];
+        delete jsxProps[key];
       });
 
-      props.ref = handleRef;
+      jsxProps.ref = handleRef;
 
       if (builtInTagName) {
-        props.is = tagName;
+        jsxProps.is = tagName;
       }
 
-      return createElement(componentName, props, children);
+      return createElement(componentName, jsxProps, children);
     }
   };
 };


### PR DESCRIPTION
Fixes with-react mutates `this.props`

Changes proposed in this pull request:

 -
 -
 -

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
