### PR TITLE
fix(inner-svg): imported twice

### DIFF
--- a/src/demos/todomvc/todos.jsx
+++ b/src/demos/todomvc/todos.jsx
@@ -4,7 +4,10 @@ import TodosList from './todos-list';
 import TodoFooter from './todo-footer';
 import { ALL_TODOS, ACTIVE_TODOS, COMPLETED_TODOS } from './utils';
 
-import { AXADatepicker } from '../../js/react-exports';
+import withReact from '../../js/with-react';
+import AXADatepicker from '../../components/o-datepicker';
+
+const AXADatepickerReact = withReact(AXADatepicker);
 
 const ENTER_KEY = 13;
 
@@ -136,7 +139,7 @@ class Todos extends Component {
           key={1}
         />
 
-        <AXADatepicker onAxaChange={this.handleDatepickerChange} />
+        <AXADatepickerReact onAxaChange={this.handleDatepickerChange} />
 
         <TodoFooter count={activeTodoCount} completedCount={completedCount} nowShowing={state.nowShowing} onClearCompleted={this.clearCompleted} onNowShowing={this.nowShowing} key={2} />
       </div>


### PR DESCRIPTION
Fixes #751 

Changes proposed in this pull request:

 - fixes `innerSVG` polyfill imported twice

This happens because we still bundle same modules more than once...

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
