### PR TITLE
dropdown

### DIFF
--- a/src/components/m-dropdown/js/drop-down.js
+++ b/src/components/m-dropdown/js/drop-down.js
@@ -11,7 +11,6 @@ class DropDown extends UiEvents {
     isOpenClass: 'is-dropdown-open',
     isAnimatingClass: 'is-dropdown-animating',
     selectClass: 'js-dropdown__content',
-    selectedItemSelector: 'option[selected=selected]',
   }
 
   constructor(wcNode, options) {

--- a/src/components/m-dropdown/js/drop-down.js
+++ b/src/components/m-dropdown/js/drop-down.js
@@ -11,6 +11,7 @@ class DropDown extends UiEvents {
     isOpenClass: 'is-dropdown-open',
     isAnimatingClass: 'is-dropdown-animating',
     selectClass: 'js-dropdown__content',
+    selectedItemSelector: 'option[selected=selected]',
   }
 
   constructor(wcNode, options) {
@@ -147,6 +148,17 @@ class DropDown extends UiEvents {
 
       lastElementChild.style.height = '';
       remove(node, this.options.isOpenClass);
+    }
+    const select = this.wcNode.querySelector(`.${this.options.nativeSelectClass}`);
+    if (select) {
+      const selectedOption = this.wcNode.querySelector(this.options.selectedItemSelector);
+      if (selectedOption) {
+        if (selectedOption.index !== select.selectedIndex) {
+          select.selectedIndex = selectedOption.index;
+        }
+      } else {
+        select.selectedIndex = 0;
+      }
     }
   }
 

--- a/src/components/m-dropdown/js/drop-down.js
+++ b/src/components/m-dropdown/js/drop-down.js
@@ -149,17 +149,6 @@ class DropDown extends UiEvents {
       lastElementChild.style.height = '';
       remove(node, this.options.isOpenClass);
     }
-    const select = this.wcNode.querySelector(`.${this.options.nativeSelectClass}`);
-    if (select) {
-      const selectedOption = this.wcNode.querySelector(this.options.selectedItemSelector);
-      if (selectedOption) {
-        if (selectedOption.index !== select.selectedIndex) {
-          select.selectedIndex = selectedOption.index;
-        }
-      } else {
-        select.selectedIndex = 0;
-      }
-    }
   }
 
   destroy() {

--- a/src/js/abstract/utils/component-morph.js
+++ b/src/js/abstract/utils/component-morph.js
@@ -1,4 +1,5 @@
 import morph from './morph';
+import specialElHandlers from './special-el-handlers';
 
 const TEXT_NODE = 3;
 // var DEBUG = false
@@ -63,6 +64,8 @@ function walk(newNode, oldNode) {
   if (!oldNode.skipChildren || !oldNode.skipChildren()) {
     updateChildren(newNode, oldNode);
   }
+  // at this point the children nodes have already been morphed and it is safe to apply special el handlers.
+  specialElHandlers(newNode, oldNode);
 
   return oldNode;
 }

--- a/src/js/abstract/utils/morph.js
+++ b/src/js/abstract/utils/morph.js
@@ -7,7 +7,7 @@ export default morph;
 // diff elements and apply the resulting patch to the old node
 // (obj, obj) -> null
 function morph(newNode, oldNode) {
-  const { nodeType, nodeName } = newNode;
+  const { nodeType } = newNode;
 
   if (nodeType === ELEMENT_NODE) {
     copyAttrs(newNode, oldNode);
@@ -15,16 +15,6 @@ function morph(newNode, oldNode) {
 
   if ((nodeType === TEXT_NODE || nodeType === COMMENT_NODE) && oldNode.nodeValue !== newNode.nodeValue) {
     oldNode.nodeValue = newNode.nodeValue;
-  }
-
-  // Some DOM nodes are weird
-  // https://github.com/patrick-steele-idem/morphdom/blob/master/src/specialElHandlers.js
-  if (nodeName === 'INPUT') {
-    updateInput(newNode, oldNode);
-  } else if (nodeName === 'OPTION') {
-    updateOption(newNode, oldNode);
-  } else if (nodeName === 'TEXTAREA') {
-    updateTextarea(newNode, oldNode);
   }
 }
 
@@ -105,69 +95,6 @@ function copyAttrs(newNode, oldNode) {
       } else if (!newNode.hasAttributeNS(null, attrName)) {
         oldNode.removeAttribute(attrName);
       }
-    }
-  }
-}
-
-function updateOption(newNode, oldNode) {
-  updateAttribute(newNode, oldNode, 'selected');
-}
-
-// The "value" attribute is special for the <input> element since it sets the
-// initial value. Changing the "value" attribute without changing the "value"
-// property will have no effect since it is only used to the set the initial
-// value. Similar for the "checked" attribute, and "disabled".
-function updateInput(newNode, oldNode) {
-  const { value: newValue } = newNode;
-  const { value: oldValue } = oldNode;
-
-  updateAttribute(newNode, oldNode, 'checked');
-  updateAttribute(newNode, oldNode, 'disabled');
-
-  if (newValue !== oldValue) {
-    oldNode.setAttribute('value', newValue);
-    oldNode.value = newValue;
-  }
-
-  if (newValue === 'null') {
-    oldNode.value = '';
-    oldNode.removeAttribute('value');
-  }
-
-  if (!newNode.hasAttributeNS(null, 'value')) {
-    oldNode.removeAttribute('value');
-  } else if (oldNode.type === 'range') {
-    // this is so elements like slider move their UI thingy
-    oldNode.value = newValue;
-  }
-}
-
-function updateTextarea(newNode, oldNode) {
-  const { value: newValue } = newNode;
-
-  if (newValue !== oldNode.value) {
-    oldNode.value = newValue;
-  }
-
-  if (oldNode.firstChild && oldNode.firstChild.nodeValue !== newValue) {
-    // Needed for IE. Apparently IE sets the placeholder as the
-    // node value and vise versa. This ignores an empty update.
-    if (newValue === '' && oldNode.firstChild.nodeValue === oldNode.placeholder) {
-      return;
-    }
-
-    oldNode.firstChild.nodeValue = newValue;
-  }
-}
-
-function updateAttribute(newNode, oldNode, name) {
-  if (newNode[name] !== oldNode[name]) {
-    oldNode[name] = newNode[name];
-
-    if (newNode[name]) {
-      oldNode.setAttribute(name, '');
-    } else {
-      oldNode.removeAttribute(name);
     }
   }
 }

--- a/src/js/abstract/utils/special-el-handlers.js
+++ b/src/js/abstract/utils/special-el-handlers.js
@@ -1,6 +1,6 @@
 export default specialElHandlers;
 
-// diff elements and apply the resulting patch to the old node
+// applies special el handlers depending on the node name.
 // (obj, obj) -> null
 function specialElHandlers(newNode, oldNode) {
   const { nodeName } = newNode;
@@ -23,32 +23,32 @@ function updateOption(newNode, oldNode) {
 }
 
 function updateSelect(newNode, oldNode) {
-  var selectedIndex = -1;
-  var i = 0;
+  let selectedIndex = -1;
+  let i = 0;
   // We have to loop through children of oldNode, not newNode since nodes can be moved
   // from newNode to oldNode directly when morphing.
   // At the time this special handler is invoked, all children have already been morphed
   // and appended to / removed from newNode, so using oldNode here is safe and correct.
-  var curChild = oldNode.firstChild;
-  var optgroup;
-  var nodeName;
+  let curChild = oldNode.firstChild;
+  let optGroup;
+  let nodeName;
   while (curChild) {
     nodeName = curChild.nodeName && curChild.nodeName.toUpperCase();
     if (nodeName === 'OPTGROUP') {
-      optgroup = curChild;
-      curChild = optgroup.firstChild;
+      optGroup = curChild;
+      curChild = optGroup.firstChild;
     } else {
       if (nodeName === 'OPTION') {
         if (curChild.hasAttributeNS(null, 'selected')) {
           selectedIndex = i;
           break;
         }
-        i++;
+        i += 1;
       }
       curChild = curChild.nextSibling;
-      if (!curChild && optgroup) {
-        curChild = optgroup.nextSibling;
-        optgroup = null;
+      if (!curChild && optGroup) {
+        curChild = optGroup.nextSibling;
+        optGroup = null;
       }
     }
   }

--- a/src/js/abstract/utils/special-el-handlers.js
+++ b/src/js/abstract/utils/special-el-handlers.js
@@ -1,0 +1,115 @@
+export default specialElHandlers;
+
+// diff elements and apply the resulting patch to the old node
+// (obj, obj) -> null
+function specialElHandlers(newNode, oldNode) {
+  const { nodeName } = newNode;
+
+  // Some DOM nodes are weird
+  // https://github.com/patrick-steele-idem/morphdom/blob/master/src/specialElHandlers.js
+  if (nodeName === 'INPUT') {
+    updateInput(newNode, oldNode);
+  } else if (nodeName === 'OPTION') {
+    updateOption(newNode, oldNode);
+  } else if (nodeName === 'TEXTAREA') {
+    updateTextarea(newNode, oldNode);
+  } else if (nodeName === 'SELECT') {
+    updateSelect(newNode, oldNode);
+  }
+}
+
+function updateOption(newNode, oldNode) {
+  updateAttribute(newNode, oldNode, 'selected');
+}
+
+function updateSelect(newNode, oldNode) {
+  var selectedIndex = -1;
+  var i = 0;
+  // We have to loop through children of oldNode, not newNode since nodes can be moved
+  // from newNode to oldNode directly when morphing.
+  // At the time this special handler is invoked, all children have already been morphed
+  // and appended to / removed from newNode, so using oldNode here is safe and correct.
+  var curChild = oldNode.firstChild;
+  var optgroup;
+  var nodeName;
+  while (curChild) {
+    nodeName = curChild.nodeName && curChild.nodeName.toUpperCase();
+    if (nodeName === 'OPTGROUP') {
+      optgroup = curChild;
+      curChild = optgroup.firstChild;
+    } else {
+      if (nodeName === 'OPTION') {
+        if (curChild.hasAttributeNS(null, 'selected')) {
+          selectedIndex = i;
+          break;
+        }
+        i++;
+      }
+      curChild = curChild.nextSibling;
+      if (!curChild && optgroup) {
+        curChild = optgroup.nextSibling;
+        optgroup = null;
+      }
+    }
+  }
+  oldNode.selectedIndex = selectedIndex;
+}
+
+// The "value" attribute is special for the <input> element since it sets the
+// initial value. Changing the "value" attribute without changing the "value"
+// property will have no effect since it is only used to the set the initial
+// value. Similar for the "checked" attribute, and "disabled".
+function updateInput(newNode, oldNode) {
+  const { value: newValue } = newNode;
+  const { value: oldValue } = oldNode;
+
+  updateAttribute(newNode, oldNode, 'checked');
+  updateAttribute(newNode, oldNode, 'disabled');
+
+  if (newValue !== oldValue) {
+    oldNode.setAttribute('value', newValue);
+    oldNode.value = newValue;
+  }
+
+  if (newValue === 'null') {
+    oldNode.value = '';
+    oldNode.removeAttribute('value');
+  }
+
+  if (!newNode.hasAttributeNS(null, 'value')) {
+    oldNode.removeAttribute('value');
+  } else if (oldNode.type === 'range') {
+    // this is so elements like slider move their UI thingy
+    oldNode.value = newValue;
+  }
+}
+
+function updateTextarea(newNode, oldNode) {
+  const { value: newValue } = newNode;
+
+  if (newValue !== oldNode.value) {
+    oldNode.value = newValue;
+  }
+
+  if (oldNode.firstChild && oldNode.firstChild.nodeValue !== newValue) {
+    // Needed for IE. Apparently IE sets the placeholder as the
+    // node value and vise versa. This ignores an empty update.
+    if (newValue === '' && oldNode.firstChild.nodeValue === oldNode.placeholder) {
+      return;
+    }
+
+    oldNode.firstChild.nodeValue = newValue;
+  }
+}
+
+function updateAttribute(newNode, oldNode, name) {
+  if (newNode[name] !== oldNode[name]) {
+    oldNode[name] = newNode[name];
+
+    if (newNode[name]) {
+      oldNode.setAttribute(name, '');
+    } else {
+      oldNode.removeAttribute(name);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #758.

Changes proposed in this pull request:

on reset the selected index will be updated if the index changed or set to 0 if there is no selected option

## How to reproduce
Prepare a custom items array (where you change the order) and update it via setAttribute. (Pasting a serialized string into inspector does not work)

Make the element accessible via id first, i.e, add an id='dropdown' and then set the attribute items
```
document.getElementById('dropdown').setAttribute('items', '[{"name": "Item 1 empty value", "url": "#", "value":"a"}, {"name": "Item 2", "url": "#", "value": "b"}, {"name": "Item 3", "url": "#", "value":"c"}]');
```
The native element (when you click) should be updated accordingly to the items array

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
