### PR TITLE
fix rollup build config for Windows platform

### DIFF
--- a/stack/tasks/bundles/lib.js
+++ b/stack/tasks/bundles/lib.js
@@ -14,6 +14,9 @@ components.bundleLibFiles({
       resolved = path.resolve(path.dirname(parent), id);
     }
 
+    //normalize windows dir separators to allow the following regexp
+    resolved = resolved.replace(/\\/g, "/");
+
     return !/\/components\/[amou]-.+\//.test(resolved) && !/\.scss$/i.test(resolved);
   },
   plugins: [

--- a/stack/tasks/bundles/lib.js
+++ b/stack/tasks/bundles/lib.js
@@ -14,8 +14,8 @@ components.bundleLibFiles({
       resolved = path.resolve(path.dirname(parent), id);
     }
 
-    //normalize windows dir separators to allow the following regexp
-    resolved = resolved.replace(/\\/g, "/");
+    //unify dir separators to "/" to allow the following regexp
+    resolved = resolved.split(path.sep).join("/");
 
     return !/\/components\/[amou]-.+\//.test(resolved) && !/\.scss$/i.test(resolved);
   },


### PR DESCRIPTION
Fixes #648

Changes proposed in this pull request:

 - normalize windows dir separators in file location before assuming it is a "/"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
npm run build, then build a react app using PL's react-exports
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
