### PR TITLE
fix font-family name

### DIFF
--- a/src/styles/typo/_typo-webfonts.scss
+++ b/src/styles/typo/_typo-webfonts.scss
@@ -5,7 +5,7 @@
 /// @param {string} $base-path [$font-base-path] - The path where your webfonts are stored.
 @mixin publico-headline($base-path: $font-base-path) {
   @font-face {
-    font-family: 'Publico Headline Web';
+    font-family: 'Publico Headline';
     font-style: normal;
     font-weight: 700;
     src: url('#{$base-path}PublicoHeadline-Bold-Web.eot'); /* IE9 Compat Modes */


### PR DESCRIPTION
Fixes #766.

Changes proposed in this pull request:
- change the font-family name "Publico Headline Web" to "Publico Headline".

the problem is caused by a missmatch of the font-family name and the face-map constant (src/styles/typo/_typo-settings.scss)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
