### PR TITLE
Add prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "endOfLine": "lf",
+  "printWidth": 140,
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
Add prettier config, it is essential for many IDE's, because not all IDE prettier plugins uses editor configs as default.