### PR TITLE
Fix broken icons in button, fixes #836

### DIFF
--- a/src/components/m-button/index.scss
+++ b/src/components/m-button/index.scss
@@ -10,7 +10,11 @@
   @include button--color();
 }
 
-.m-button__icon {
+// a-icon__svg is needed as css ordering is not loaded in the right order
+// I.e sizes in m-button__icon are overridden without this specifier.
+// Relates and fixes gh #836
+.m-button__icon,
+.m-button__icon.a-icon__svg {
   @include button__icon();
 }
 


### PR DESCRIPTION
Button sizes are overridden by the main svg class without this #fix
Fixes #836
