### PR TITLE
fix the build-types run script (source pattern needs quotes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "cross-env NODE_ENV=production concurrently \"node stack/tasks/build.html.js\" \"node stack/tasks/build-examples.js\" \"npm run build-css-prod\" \" npm run build-js-prod\" \"npm run build-lib\" \"npm run build-icons-prod\"",
     "postbuild": "node stack/tasks/copy-dist-to-docs.js",
     "build-lib": "concurrently \"babel src/js --out-dir lib/js --plugins transform-runtime\" \"node stack/tasks/bundles/lib.js\" && babel src/index.js --out-file lib/index.js && npm run build-types",
-    "build-types": "cpx src/**/*.d.ts lib",
+    "build-types": "cpx \"src/**/*.d.ts\" lib",
     "release": "generic-release docs dist"
   },
   "watch": {


### PR DESCRIPTION
Fixes #850 .

Changes proposed in this pull request:

 - quote the source pattern in build-types run script

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
npm run build on Win and OSX.
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
