### PR TITLE
Bugfix/lint prettier fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -107,6 +107,7 @@
     "HTMLImports": true,
     "XMLHttpRequest": true,
     "history": true,
+    "CustomEvent": true,
     "MutationObserver": true,
     "customElements": true,
     "document": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "airbnb",
+  "extends": ["airbnb", "prettier"],
   "rules": {
     "max-len": [
       "error",
@@ -28,7 +28,21 @@
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-underscore-dangle": "off",
     "no-use-before-define": ["error", { "functions": false, "classes": false }],
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": ["scripts/**", "rollup.config.js", "**/_demo*.js", "**/_story*.js", "**/src/**/*.react.js", "**/demo/**"] }],
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": [
+          "scripts/**",
+          "rollup.config.js",
+          "**/_demo*.js",
+          "**/story.js",
+          "**/_story*.js",
+          "**/*.story.js",
+          "**/src/**/*.react.js",
+          "**/demo/**"
+        ]
+      }
+    ],
     "object-curly-newline": ["error", { "multiline": true, "consistent": true }]
   },
   "globals": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dotenv-extended": "^2.3.0",
     "eslint": "^4.10.0",
     "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",

--- a/src/components/00-materials/icons/arrow-right.js
+++ b/src/components/00-materials/icons/arrow-right.js
@@ -1,4 +1,5 @@
 import { html } from 'lit-element';
+
 // only a mock for the moment
 const arrowRight = () => html`
   <svg xmlns="http://www.w3.org/2000/svg" class="m-button__icon" width="12" height="7" viewBox="0 0 12 7">
@@ -6,6 +7,6 @@ const arrowRight = () => html`
       <path d="M.5 3.5H11M9 7l2.798-3.5L9 0" />
     </g>
   </svg>
-  `;
+`;
 
 export default arrowRight;

--- a/src/components/00-materials/package.json
+++ b/src/components/00-materials/package.json
@@ -6,6 +6,9 @@
   "homepage": "https://github.com/axa-ch/patterns-library/tree/master/src/components/materials/#readme",
   "license": "ISC",
   "main": "lib",
+  "dependencies": {
+    "lit-element": "^2.0.1"
+  },
   "directories": {
     "lib": "lib",
     "test": "__tests__"


### PR DESCRIPTION
Fixes conflicts between formatting- and linting rules. This is a known side effect while using prettier and eslint out of the box.

Since prettier is here for formatting only and since this is depending only on the line length, some eslint rules like comma dangles and parens rules are in conflict with each other. Basically, it does not make sense to lint them, since it can change immediately by the line length.

That's why the community brought us the "eslint-prettier-plugin", that disables all rules which are taken over by prettier. (Code formatting).

https://github.com/prettier/eslint-config-prettier