### PR TITLE
Change all story files to story.js

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -24,10 +24,10 @@ addParameters({
   },
 });
 
-const materials = require.context('../src/components/00-materials', true, /\.story\.js$/);
-const atoms = require.context('../src/components/10-atoms', true, /\.story\.js$/);
-const molecules = require.context('../src/components/20-molecules', true, /\.story\.js$/);
-const organisms = require.context('../src/components/30-organisms', true, /\.story\.js$/);
+const materials = require.context('../src/components/00-materials', true, /story\.js$/);
+const atoms = require.context('../src/components/10-atoms', true, /story\.js$/);
+const molecules = require.context('../src/components/20-molecules', true, /story\.js$/);
+const organisms = require.context('../src/components/30-organisms', true, /story\.js$/);
 
 configure(
   () =>


### PR DESCRIPTION
- Story files are not parsed at the moment
- We decided now to use 'story.js' as filename in the team
- Is easier to prevent conflicts between src/lib/dev stuff