### PR TITLE
Remove testcafe from npm tests until ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006 -c .storybook -s src/static",
     "build-storybook": "build-storybook",
-    "test": "npm run test-testcafe && npm run test-testcafe-browserstack",
+    "test": "eslint src/",
     "test-testcafe": "sh build/run-testcafe.sh",
     "test-testcafe-browserstack": "sh build/run-browserstack.sh",
     "test-testcafe-browserstackjs": "node build/run-browserstack.js"


### PR DESCRIPTION
Changes proposed in this pull request:

 - Currently 'npm tests' executes testcafe stuff that does not yet exist. This fixes it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
