### PR TITLE
V2: fix Storybook: use '/' dir seps on win32 to satisfy sass-loader/LibSass

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -7,7 +7,9 @@ require('dotenv-extended').load();
 // Global Import SCSS Materials -> SCSS Materials as they are always a dependency.
 const globals = require(path.resolve(__dirname, '..', 'config', 'globals.js'))
   .map(item => `@import '${base}/${item}';`)
-  .join('\n');
+  .join('\n')
+  .replace(/\\/g, '/'); // use '/' dir seps on win32, to satisfy sass-loader/LibSass; otherwise crash
+;
 
 module.exports = ({ config }) => {
   config.resolve.alias = Object.assign({}, config.resolve.alias, {


### PR DESCRIPTION
Fix Storybook by using '/' dir seps on win32 to satisfy sass-loader/LibSass

Using original dir seps (`\`) causes sass compile crash.

Maybe there is some incompatibility between sass-loader/LibSass when
using options.data, because the `\` chars (windows path) are interpreted
as control chars.

https://github.com/sass/node-sass/blob/master/README.md#data

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?

"npm run storybook" on windows7
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
