### PR TITLE
fix(rollup): use '/' dir seps on win32 to satisfy sass-loader/LibSass

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,8 @@ const glob = require('glob');
 const path = require('path');
 const { uglify } = require('rollup-plugin-uglify');
 
-const base = path.resolve(process.cwd(), 'src');
+// use '/' dir seps on win32, to satisfy sass-loader/LibSass; otherwise crash
+const base = path.resolve(process.cwd(), 'src').replace(/\\/g, '/');
 
 // Global Import SCSS Materials -> SCSS Materials as they are always a dependency.
 const globals = require('./config/globals.js')

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const glob = require('glob');
 const path = require('path');
 const { uglify } = require('rollup-plugin-uglify');
 
-// use '/' dir seps on win32, to satisfy sass-loader/LibSass; otherwise crash
+// map platform native backslash on win32 to platform neutral forward slash (which sass-loader/LibSass needs)
 const base = path.resolve(process.cwd(), 'src').replace(/\\/g, '/');
 
 // Global Import SCSS Materials -> SCSS Materials as they are always a dependency.


### PR DESCRIPTION
Fix build on windows by using `/` dir seps on win32 to satisfy sass-loader/LibSass

Using original dir seps (`\`) causes sass compile crash.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?

"npm run build" on windows7
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
