### PR TITLE
fix: monkey patched node was cloned

### DIFF
--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -18,6 +18,7 @@ const withMonkeyPatches = Base =>
 
       const textNode = document.createTextNode(text);
 
+      textNode.__isPatching = true;
       this._lightDOMRefs = [textNode];
 
       this.render();
@@ -36,6 +37,7 @@ const withMonkeyPatches = Base =>
 
       const textNode = document.createTextNode(text);
 
+      textNode.__isPatching = true;
       this._lightDOMRefs = [textNode];
 
       this.render();
@@ -56,7 +58,10 @@ const withMonkeyPatches = Base =>
 
       div.innerHTML = html;
 
-      this._lightDOMRefs = Array.from(div.children);
+      this._lightDOMRefs = Array.from(div.children).map((node) => {
+        node.__isPatching = true;
+        return node;
+      });
 
       this.render();
     }
@@ -72,6 +77,7 @@ const withMonkeyPatches = Base =>
         return;
       }
 
+      node.__isPatching = true;
       this._lightDOMRefs.push(node);
 
       this.render();

--- a/src/js/abstract/hocs/with-render.js
+++ b/src/js/abstract/hocs/with-render.js
@@ -87,6 +87,13 @@ const withRender = Base =>
             this.childrenFragment = childrenFragment;
           } else { // Reuse the light DOM for subsequent rendering
             this._lightDOMRefs.forEach((ref) => {
+              // IMPORTANT: monkey patched nodes are new and should not be cloned!
+              if (ref.__isPatching === true) {
+                this.childrenFragment.appendChild(ref);
+                delete ref.__isPatching;
+                return;
+              }
+
               // Important: Once the light DOM is live it shouldn't be moved out
               // instead make sure to clone it for incremental updates
               const refClone = ref.cloneNode(true);


### PR DESCRIPTION
Fixes #778 
Should also handle #859 

Changes proposed in this pull request:

 - Fixes monkey patching breaks react refs by cloning new nodes

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
