### PR TITLE
Feature/readme storyook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,1 @@
+import './addons/markdown';

--- a/.storybook/addons/markdown.js
+++ b/.storybook/addons/markdown.js
@@ -18,22 +18,22 @@ const e = React.createElement;
 addons.register(ADDON_ID, (api) => {
   const title = 'Readme';
   const channel = addons.getChannel();
-  let initalText = DEFAULT_MSG;
-  let initalTemplate = '';
+  let initialText = DEFAULT_MSG;
+  let initialTemplate = '';
 
   class Wrapper extends Component {
     constructor(props) {
       super(props);
       this.state = {
-        html: initalText,
-        template: initalTemplate,
+        html: initialText,
+        template: initialTemplate,
       };
       this.onAddonAdded = this.onAddonAdded.bind(this);
     }
 
     onAddonAdded ({ template, html }) {
-      initalText = html;
-      initalTemplate = template;
+      initialText = html;
+      initialTemplate = template;
       this.setState({ html, template });
     }
 

--- a/.storybook/addons/markdown.js
+++ b/.storybook/addons/markdown.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 const ADDON_ID = 'markdown';
 const ADDON_EVENT = `${ADDON_ID}/event`;
 const PANEL_ID = `${ADDON_ID}/panel`;
-const DEFAULT_MSG = 'No Markdown Provided';
+const DEFAULT_MSG = '<h2>No Markdown Provided</h2><br>';
 
 const uuidv4 = () => {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
@@ -34,7 +34,7 @@ addons.register(ADDON_ID, (api) => {
     }
 
     onAddonAdded ({ template, html }) {
-      initialText = html;
+      initialText = html || '';
       initialTemplate = typeof template === 'string' ? template.trim() : '';
       this.setState({ html, template: initialTemplate });
     }
@@ -57,9 +57,6 @@ addons.register(ADDON_ID, (api) => {
 
     render() {
       const { template, html } = this.state;
-      if (html === DEFAULT_MSG) {
-        return html;
-      }
       return [
         e('style', {
           key: uuidv4(),

--- a/.storybook/addons/markdown.js
+++ b/.storybook/addons/markdown.js
@@ -19,19 +19,22 @@ addons.register(ADDON_ID, (api) => {
   const title = 'Readme';
   const channel = addons.getChannel();
   let initalText = DEFAULT_MSG;
+  let initalTemplate = '';
 
   class Wrapper extends Component {
     constructor(props) {
       super(props);
       this.state = {
         html: initalText,
+        template: initalTemplate,
       };
       this.onAddonAdded = this.onAddonAdded.bind(this);
     }
 
-    onAddonAdded ({ html }) {
+    onAddonAdded ({ template, html }) {
       initalText = html;
-      this.setState({ html });
+      initalTemplate = template;
+      this.setState({ html, template });
     }
 
     componentDidMount() {
@@ -43,10 +46,23 @@ addons.register(ADDON_ID, (api) => {
     }
 
     render() {
-      return e('div', {
-        key: uuidv4(),
-        dangerouslySetInnerHTML: { __html: this.state.html },
-      });
+      return [
+        e('style', {
+          key: uuidv4(),
+          dangerouslySetInnerHTML: { __html: 'code { background-color: #F0F0F0; }' },
+        }),
+        e('div', {
+          key: uuidv4(),
+          dangerouslySetInnerHTML: { __html: this.state.html },
+        }),
+        e('div', {
+          key: uuidv4(),
+          dangerouslySetInnerHTML: { __html: '<h3>Code Snipped</h3>' },
+        }),
+        e('pre', {
+          key: uuidv4()
+        }, e('code', { key: uuidv4() }, this.state.template.trim())),
+      ]
     }
   };
 
@@ -64,7 +80,8 @@ export const withMarkdown = makeDecorator({
   parameterName: 'markdown',
   wrapper: (storyFn, context, { options : html }) => {
     const channel = addons.getChannel();
-    channel.emit(ADDON_EVENT, { html: html || DEFAULT_MSG });
-    return storyFn(context);
+    const template = storyFn(context);
+    channel.emit(ADDON_EVENT, { template, html: html || DEFAULT_MSG });
+    return template;
   },
 });

--- a/.storybook/addons/markdown.js
+++ b/.storybook/addons/markdown.js
@@ -1,5 +1,5 @@
 import addons, { types, makeDecorator } from '@storybook/addons';
-import { STORY_RENDERED } from '@storybook/core-events';
+import { STORY_CHANGED } from '@storybook/core-events';
 import React, { Component } from 'react';
 
 const ADDON_ID = 'markdown';
@@ -30,6 +30,7 @@ addons.register(ADDON_ID, (api) => {
         template: initialTemplate,
       };
       this.onAddonAdded = this.onAddonAdded.bind(this);
+      this.onStoryChanged = this.onStoryChanged.bind(this);
     }
 
     onAddonAdded ({ template, html }) {
@@ -38,16 +39,27 @@ addons.register(ADDON_ID, (api) => {
       this.setState({ html, template: initialTemplate });
     }
 
+    onStoryChanged () {
+      initialText = DEFAULT_MSG;
+      initialTemplate = '';
+      this.setState({ html: initialText, template: initialTemplate });
+    }
+
     componentDidMount() {
       channel.on(ADDON_EVENT, this.onAddonAdded);
+      channel.on(STORY_CHANGED, this.onStoryChanged);
     }
 
     componentWillUnmount() {
       channel.removeListener(ADDON_EVENT, this.onAddonAdded);
+      channel.removeListener(STORY_CHANGED, this.onStoryChanged);
     }
 
     render() {
       const { template, html } = this.state;
+      if (html === DEFAULT_MSG) {
+        return html;
+      }
       return [
         e('style', {
           key: uuidv4(),

--- a/.storybook/addons/markdown.js
+++ b/.storybook/addons/markdown.js
@@ -1,0 +1,50 @@
+import addons, { types, makeDecorator } from '@storybook/addons';
+import React from 'react';
+
+const ADDON_ID = 'markdown';
+const ADDON_EVENT = `${ADDON_ID}/event`;
+const PANEL_ID = `${ADDON_ID}/panel`;
+const DEFAULT_MSG = 'No Markdown Provided';
+
+const uuidv4 = () => {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+};
+
+addons.register(ADDON_ID, (api) => {
+  let input = DEFAULT_MSG;
+
+  const render = () => {
+    return  React.createElement(
+      'div',
+      { key: uuidv4(), dangerouslySetInnerHTML: { __html: input } }
+    );
+  };
+  const title = 'Readme';
+  const channel = addons.getChannel();
+
+  channel.on(ADDON_EVENT, ({ id, html }) => {
+    const { render: _render } = addons.getElements(types.PANEL)[PANEL_ID];
+    input = html;
+    _render();
+  });
+
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title,
+    render,
+  });
+});
+
+export const withMarkdown = makeDecorator({
+  name: 'withMarkdown',
+  parameterName: 'markdown',
+  wrapper: (storyFn, context, { options : html, parameters }) => {
+    const channel = addons.getChannel();
+    const { id } = context;
+    channel.emit(ADDON_EVENT, { id, html: html || DEFAULT_MSG });
+    return storyFn(context);
+  },
+});

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,4 @@
-import { addParameters, configure, addDecorator } from '@storybook/html';
+import { addParameters, configure } from '@storybook/html';
 import { create } from '@storybook/theming';
 
 import '@webcomponents/webcomponentsjs';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,4 @@
-import { addParameters, configure } from '@storybook/html';
+import { addParameters, configure, addDecorator } from '@storybook/html';
 import { create } from '@storybook/theming';
 
 import '@webcomponents/webcomponentsjs';

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -43,7 +43,13 @@ module.exports = ({ config }) => {
       loader: 'babel-loader',
       options: {...babelOptions, presets: [...babelOptions.presets, '@babel/preset-react']},
     },
-
+    {
+      test: /\.md$/,
+      loader: "markdown-loader",
+      options: {
+          /* your options here */
+      }
+    }
   );
 
   return config;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "glob": "^7.1.3",
     "jest": "^24.5.0",
     "lerna": "^3.13.1",
+    "markdown-loader": "^5.0.0",
     "mutationobserver-shim": "^0.3.3",
     "node-sass": "^4.11.0",
     "outdent": "^0.7.0",

--- a/src/components/10-atoms/button/README.md
+++ b/src/components/10-atoms/button/README.md
@@ -1,1 +1,6 @@
 # AXA Versicherungen AG
+
+Here will be button description
+
+- marco
+- luca

--- a/src/components/10-atoms/button/README.md
+++ b/src/components/10-atoms/button/README.md
@@ -1,6 +1,3 @@
-# AXA Versicherungen AG
+# Button
 
-Here will be button description
-
-- marco
-- luca
+TODO Description

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -1,8 +1,11 @@
 /* global document */
 import { storiesOf } from '@storybook/html';
 import './index';
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
 
 storiesOf('Atoms/Button', module)
+  .addDecorator(withMarkdown(Readme))
   .add('Button - click event', () => {
     const btn = document.createElement('axa-button');
     let counter = 0;

--- a/src/components/10-atoms/icon/story.js
+++ b/src/components/10-atoms/icon/story.js
@@ -2,7 +2,11 @@
 import { storiesOf } from '@storybook/html';
 import AXAIcon from "./index";
 
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
+
 storiesOf('Atoms/Icon', module)
+  .addDecorator(withMarkdown(Readme))
   .add('Icon - show all icons', () => {
     const list = document.createElement('ul');
 
@@ -21,4 +25,3 @@ storiesOf('Atoms/Icon', module)
   })
   .add('Icon - icon from a resource', () => '<axa-icon icon="/svg/logo-axa.svg"></axa-icon>')
   .add('Icon - icon undefined case', () => 'should be empty: <axa-icon></axa-icon>');
-

--- a/src/components/10-atoms/link/README.md
+++ b/src/components/10-atoms/link/README.md
@@ -1,3 +1,3 @@
-# Icon
+# Link
 
 TODO Description

--- a/src/components/10-atoms/link/story.js
+++ b/src/components/10-atoms/link/story.js
@@ -2,7 +2,11 @@
 import { storiesOf } from '@storybook/html';
 import './index';
 
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
+
 storiesOf('Atoms/Link', module)
+  .addDecorator(withMarkdown(Readme))
   .add('Unstyled link', () => `<axa-link href="https://axa.ch/en/private-customers.html">This simple link just links</axa-link>`)
   .add('Red link', () => `<axa-link href="https://axa.ch/en/private-customers.html" color="red">Red Link</axa-link>`)
   .add(

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -1,3 +1,3 @@
-# Icon
+# Datepicker
 
 TODO Description

--- a/src/components/20-molecules/datepicker/story.js
+++ b/src/components/20-molecules/datepicker/story.js
@@ -1,7 +1,11 @@
 import { storiesOf } from '@storybook/html';
 import './index';
 
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
+
 storiesOf('Molecules/Datepicker', module)
+  .addDecorator(withMarkdown(Readme))
   .add(
     'Datepicker',
     () =>

--- a/src/components/20-molecules/dropdown/README.md
+++ b/src/components/20-molecules/dropdown/README.md
@@ -1,3 +1,3 @@
-# Icon
+# Dropdown
 
 TODO Description

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -1,7 +1,11 @@
 import { storiesOf } from '@storybook/html';
 import './index';
 
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
+
 storiesOf('Molecules/Dropdown', module)
+  .addDecorator(withMarkdown(Readme))
   .add(
     'Dropdown',
     () => `<axa-dropdown title="Please Select"

--- a/src/components/20-molecules/footer-small/README.md
+++ b/src/components/20-molecules/footer-small/README.md
@@ -1,3 +1,3 @@
-# Icon
+# FooterSmall
 
 TODO Description

--- a/src/components/20-molecules/footer-small/story.js
+++ b/src/components/20-molecules/footer-small/story.js
@@ -2,6 +2,9 @@
 import { storiesOf } from '@storybook/html';
 import './index';
 
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
+
 const languages = JSON.stringify([
   { text: 'DE', link: 'https://axa.ch/de/privatkunden.html' },
   { text: 'FR', link: 'https://axa.ch/fr/particuliers.html' },
@@ -14,8 +17,8 @@ const disclaimer = JSON.stringify([
   { text: 'Data protection', link: 'https://axa.ch/en/information/data-protection.html' },
 ]);
 
-storiesOf('Molecules/Footer Small', module).add(
-  'Footer Small',
-  () =>
-    `<axa-footer-small languageitems='${languages}' disclaimeritems='${disclaimer}' copyrighttext="© 2019 AXA Insurance Ltd."></axa-footer-small>`
-);
+storiesOf('Molecules/Footer Small', module)
+  .addDecorator(withMarkdown(Readme))
+  .add(
+    'Footer Small',
+    () => `<axa-footer-small languageitems='${languages}' disclaimeritems='${disclaimer}' copyrighttext="© 2019 AXA Insurance Ltd."></axa-footer-small>`);

--- a/src/demo/react/story.jsx
+++ b/src/demo/react/story.jsx
@@ -8,6 +8,7 @@ import DemoControlledInputsApp from '../demo-controlled-inputs/App';
 import DemoDynamicChildrenApp from '../demo-dynamic-children/App';
 
 storiesOf('Demos', module)
+  // .addDecorator(withMarkdown(Readme))
   .add('Button with React', () => {
     const div = document.createElement('div');
     ReactDOM.render(<DemoButton />, div);

--- a/src/demo/react/story.jsx
+++ b/src/demo/react/story.jsx
@@ -7,8 +7,10 @@ import DemoIcon from './DemoIcon';
 import DemoControlledInputsApp from '../demo-controlled-inputs/App';
 import DemoDynamicChildrenApp from '../demo-dynamic-children/App';
 
+import { withMarkdown } from '../../../.storybook/addons/markdown';
+
 storiesOf('Demos', module)
-  // .addDecorator(withMarkdown(Readme))
+  .addDecorator(withMarkdown())
   .add('Button with React', () => {
     const div = document.createElement('div');
     ReactDOM.render(<DemoButton />, div);


### PR DESCRIPTION
Add Addon for Markdown. 

Unfortunatly existing markdowns addons only work with `storybook/react` or `storybook/vue`: https://github.com/tuchk4/storybook-readme

Or cannt be place in a Panel like: https://www.npmjs.com/package/@storybook/addon-notes

I Added a wrapper for the rendering as `storybook/html` addons cannot render HTML, just text. React wrapper is written in NO JSX syntax to avoid build complexity