### PR TITLE
Add 'npm run build' to 'npm test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006 -c .storybook -s src/static",
     "build-storybook": "build-storybook",
-    "test": "npm run test-lint && node ./scripts/build.test.js && npm run test-chrome",
+    "test": "npm run test-lint && node ./scripts/build.test.js && npm run test-chrome && npm run build",
     "test-lint": "eslint src/",
     "test-chrome": "sh scripts/testcafe-chrome.sh",
     "test-ie": "sh scripts/testcafe-ie.sh",


### PR DESCRIPTION
Changes proposed in this pull request:

We had the issue, that everything was working fine, but ```npm run build``` crashed with a dependency problem. To avoid that, we put it into the ```npm test```, to make sure that the local npm test does the same as the CI pipeline. We put it into test, because npm test should make sure that the build does not break. We should not diverge the things the CI and out local npm test do. To always be sure, that a build will be green with a local ```npm test```, we put it into here, because we have to make sure, that this does not fail.
