### PR TITLE
Feature/monkey patch remove and replace child

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,7 +368,7 @@ Adds the ability to provide and consume contextual data.
 
 Guarantees that updates to the custom element's children do not mess up the [**Flattened DOM**](#flattened-dom) and keeps it's [**Local DOM**](#local-dom) untouched.
 
-**Note:** this is obsolete if `ShadowDOM` is enabled.
+**Note:** this is obsolete if `ShadowDOM` is enabled and `<slot>` is utilised.
 
 #### `withRender()`
 

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -79,14 +79,16 @@ const withMonkeyPatches = Base =>
         return;
       }
 
+      const { _lightDOMRefs } = this;
+
       if (isDocumentFragment(node)) {
         Array.from(node.childNodes).forEach((childNode) => {
           childNode.__isPatching = true;
-          this._lightDOMRefs.push(childNode);
+          _lightDOMRefs.push(childNode);
         });
       } else {
         node.__isPatching = true;
-        this._lightDOMRefs.push(node);
+        _lightDOMRefs.push(node);
       }
 
       this.render();
@@ -139,11 +141,11 @@ const withMonkeyPatches = Base =>
       if (isDocumentFragment(newNode)) {
         Array.from(newNode.childNodes).forEach((childNode, childIndex) => {
           childNode.__isPatching = true;
-          this._lightDOMRefs.splice(index + childIndex, 0, childNode);
+          _lightDOMRefs.splice(index + childIndex, 0, childNode);
         });
       } else {
         newNode.__isPatching = true;
-        this._lightDOMRefs.splice(index, 0, newNode);
+        _lightDOMRefs.splice(index, 0, newNode);
       }
 
       this.render();

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -84,6 +84,31 @@ const withMonkeyPatches = Base =>
     }
 
     /**
+     * Monkey patch `insertBefore` API to re-rendering.
+     *
+     * @param {Element} newNode
+     * @param {Element} referenceNode
+     */
+    insertBefore(newNode, referenceNode) {
+      if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
+        super.insertBefore(newNode, referenceNode);
+        return;
+      }
+
+      newNode.__isPatching = true;
+      const { _lightDOMRefs } = this;
+      const index = _lightDOMRefs.indexOf(referenceNode);
+
+      if (index !== -1) {
+        this._lightDOMRefs.splice(index, 0, newNode);
+      } else {
+        this._lightDOMRefs.push(newNode);
+      }
+
+      this.render();
+    }
+
+    /**
      * Monkey patch `removeChild` API to re-rendering.
      *
      * @param {Element} node

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -1,5 +1,4 @@
 import isDocumentFragment from '../../is-document-fragment';
-import { notEqual } from 'assert';
 
 const withMonkeyPatches = Base =>
   /**

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -72,11 +72,12 @@ const withMonkeyPatches = Base =>
      * Monkey patch `appendChild` API to re-rendering.
      *
      * @param {Element} node
+     *
+     * @returns {DocumentFragment|Element|null} appendedChild
      */
     appendChild(node) {
       if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
-        super.appendChild(node);
-        return;
+        return super.appendChild(node);
       }
 
       const { _lightDOMRefs } = this;
@@ -92,6 +93,8 @@ const withMonkeyPatches = Base =>
       }
 
       this.render();
+
+      return node;
     }
 
     /**
@@ -123,11 +126,12 @@ const withMonkeyPatches = Base =>
      *
      * @param {Element} newNode
      * @param {Element} referenceNode
+     *
+     * @returns {DocumentFragment|Element|null} insertedNode
      */
     insertBefore(newNode, referenceNode) {
       if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
-        super.insertBefore(newNode, referenceNode);
-        return;
+        return super.insertBefore(newNode, referenceNode);
       }
 
       const { _lightDOMRefs } = this;
@@ -149,25 +153,30 @@ const withMonkeyPatches = Base =>
       }
 
       this.render();
+
+      return newNode;
     }
 
     /**
      * Monkey patch `removeChild` API to re-rendering.
      *
      * @param {Element} node
+     *
+     * @returns {Element} removedNode
      */
     removeChild(node) {
       if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
-        super.removeChild(node);
-        return;
+        return super.removeChild(node);
       }
 
-      node.parentNode.removeChild(node);
+      const removedNode = node.parentNode.removeChild(node);
 
       // important: in case childrens are being wrapped
       // the wrapping nodes have to be removed too
       this._lightDOMRefs = this._lightDOMRefs.filter(ref => ref !== node);
       this.render();
+
+      return removedNode;
     }
 
     /**
@@ -175,14 +184,15 @@ const withMonkeyPatches = Base =>
      *
      * @param {Element} newChild
      * @param {Element} oldChild
+     *
+     * @returns {Element} replacedNode
      */
     replaceChild(newChild, oldChild) {
       if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
-        super.replaceChild(newChild, oldChild);
-        return;
+        return super.replaceChild(newChild, oldChild);
       }
 
-      oldChild.parentNode.replaceChild(newChild, oldChild);
+      return oldChild.parentNode.replaceChild(newChild, oldChild);
     }
   };
 

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -93,6 +93,30 @@ const withMonkeyPatches = Base =>
     }
 
     /**
+     * Monkey patch `append` API to re-rendering.
+     *
+     * @param {Element} nodes
+     */
+    append(...nodes) {
+      if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
+        super.append(...nodes);
+        return;
+      }
+
+      nodes.forEach((node) => {
+        if (typeof node === 'string') {
+          // eslint-disable-next-line no-param-reassign
+          node = document.createTextNode(node);
+        }
+
+        node.__isPatching = true;
+        this._lightDOMRefs.push(node);
+      });
+
+      this.render();
+    }
+
+    /**
      * Monkey patch `insertBefore` API to re-rendering.
      *
      * @param {Element} newNode

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -105,26 +105,21 @@ const withMonkeyPatches = Base =>
       }
 
       const { _lightDOMRefs } = this;
-      const index = _lightDOMRefs.indexOf(referenceNode);
+      let index = _lightDOMRefs.indexOf(referenceNode);
 
+      // if not found -> push to the end of the array
       if (index !== -1) {
-        if (isDocumentFragment(newNode)) {
-          Array.from(newNode.childNodes).forEach((childNode, childIndex) => {
-            childNode.__isPatching = true;
-            this._lightDOMRefs.splice(index + childIndex, 0, childNode);
-          });
-        } else {
-          newNode.__isPatching = true;
-          this._lightDOMRefs.splice(index, 0, newNode);
-        }
-      } else if (isDocumentFragment(newNode)) {
-        Array.from(newNode.childNodes).forEach((childNode) => {
+        index = _lightDOMRefs.length;
+      }
+
+      if (isDocumentFragment(newNode)) {
+        Array.from(newNode.childNodes).forEach((childNode, childIndex) => {
           childNode.__isPatching = true;
-          this._lightDOMRefs.push(childNode);
+          this._lightDOMRefs.splice(index + childIndex, 0, childNode);
         });
       } else {
         newNode.__isPatching = true;
-        this._lightDOMRefs.push(newNode);
+        this._lightDOMRefs.splice(index, 0, newNode);
       }
 
       this.render();

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -82,6 +82,25 @@ const withMonkeyPatches = Base =>
 
       this.render();
     }
+
+    /**
+     * Monkey patch `removeChild` API to re-rendering.
+     *
+     * @param {Element} node
+     */
+    removeChild(node) {
+      if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
+        super.removeChild(node);
+        return;
+      }
+
+      node.parentNode.removeChild(node);
+
+      // important: in case childrens are being wrapped
+      // the wrapping nodes have to be removed too
+      this._lightDOMRefs.filter(ref => ref !== node);
+      this.render();
+    }
   };
 
 export default withMonkeyPatches;

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -98,7 +98,7 @@ const withMonkeyPatches = Base =>
 
       // important: in case childrens are being wrapped
       // the wrapping nodes have to be removed too
-      this._lightDOMRefs.filter(ref => ref !== node);
+      this._lightDOMRefs = this._lightDOMRefs.filter(ref => ref !== node);
       this.render();
     }
 

--- a/src/js/abstract/hocs/with-monkey-patches.js
+++ b/src/js/abstract/hocs/with-monkey-patches.js
@@ -101,6 +101,21 @@ const withMonkeyPatches = Base =>
       this._lightDOMRefs.filter(ref => ref !== node);
       this.render();
     }
+
+    /**
+     * Monkey patch `replaceChild` API to re-rendering.
+     *
+     * @param {Element} newChild
+     * @param {Element} oldChild
+     */
+    replaceChild(newChild, oldChild) {
+      if (this._isMorphing || !this._hasTemplate || !this._hasRendered) {
+        super.replaceChild(newChild, oldChild);
+        return;
+      }
+
+      oldChild.parentNode.replaceChild(newChild, oldChild);
+    }
   };
 
 export default withMonkeyPatches;

--- a/src/js/is-document-fragment.js
+++ b/src/js/is-document-fragment.js
@@ -1,0 +1,5 @@
+function isDocumentFragment(value) {
+  return Object.prototype.toString.call(value).indexOf('DocumentFragment') !== -1;
+}
+
+export default isDocumentFragment;


### PR DESCRIPTION
Fixes [`removeChild`](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild), [`replaceChild`](https://developer.mozilla.org/en-US/docs/Web/API/Node/replaceChild), [`insertBefore`](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore) and [`append`](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append) aren't monkey patched.

Also added support for [`DocuemntFragment`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment)'s.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
 <!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
 
 # Checklist:
 
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have commented my code, particularly in hard-to-understand areas
 - [x] I have made corresponding changes to the documentation
 - [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
