### PR TITLE
Use es6 lib export for better integration

### DIFF
--- a/.storybook/.babelrc.js
+++ b/.storybook/.babelrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     [
-      '@babel/env',
+      '@babel/preset-env',
       {
         targets: {
           browsers: ['last 2 versions', 'safari >= 8', 'not ie <= 10']

--- a/.storybook/.babelrc.js
+++ b/.storybook/.babelrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     [
-      '@babel/preset-env',
+      '@babel/env',
       {
         targets: {
           browsers: ['last 2 versions', 'safari >= 8', 'not ie <= 10']
@@ -10,7 +10,6 @@ module.exports = {
     ],
   ],
   plugins: [
-    'transform-custom-element-classes',
     '@babel/plugin-proposal-class-properties',
   ]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,6 +61,13 @@ const generatePlugins = type => {
     return [
       ...commons,
       babel({
+        presets: [
+          [ '@babel/preset-env', {
+            targets: {
+              esmodules: true
+            }
+          }]
+        ],
         plugins: [
           '@babel/plugin-proposal-class-properties',
         ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,10 +61,12 @@ const generatePlugins = type => {
     return [
       ...commons,
       babel({
-        ...babelOptions,
+        plugins: [
+          '@babel/plugin-proposal-class-properties',
+        ],
         babelrc: false,
         exclude: ['node_modules/**'],
-        runtimeHelpers: true,
+        runtimeHelpers: false,
       }),
       resolve({
         mainFields: ['module', 'main'],


### PR DESCRIPTION
This is crucial.

It exports Build Agnostic ES6 Modules instead of ES6 transpiled to ES5 Modules.

It fixes a issue older build system can might encounter by using the plib. 

It requires a Release for all components again

Please Review ASAP