### PR TITLE
Add fix to reset rest css that can be used on consumers website

### DIFF
--- a/src/components/10-atoms/button-link/index.js
+++ b/src/components/10-atoms/button-link/index.js
@@ -43,6 +43,15 @@ class AXAButtonLink extends LitElement {
     this.onClick = () => {};
   }
 
+  firstUpdated() {
+    const { style } = this;
+    style.appearance = 'none';
+    style.mozAppearance = 'none';
+    style.webkitAppearance = 'none';
+    style.msAppearance = 'none';
+    style.oAppearance = 'none';
+  }
+
   render() {
     const {
       href,
@@ -72,12 +81,10 @@ class AXAButtonLink extends LitElement {
         @click="${this.onClick}"
       >
         <div class="a-button-link__flex-wrapper">
-          <slot></slot> ${
-            icon &&
-              html`
-                <axa-icon class="a-button-link__icon" icon="${icon}"></axa-icon>
-              `
-          }
+          <slot></slot> ${icon &&
+            html`
+              <axa-icon class="a-button-link__icon" icon="${icon}"></axa-icon>
+            `}
         </div>
       </a>
     `;

--- a/src/components/10-atoms/button/index.js
+++ b/src/components/10-atoms/button/index.js
@@ -44,6 +44,7 @@ class AXAButton extends LitElement {
   isTypeSubmitOrReset = () => this.type === 'submit' || this.type === 'reset';
 
   firstUpdated() {
+    const { style } = this;
     // shadow dom submit btn workaround
     if (this.isTypeSubmitOrReset()) {
       const fakeButton = document.createElement('button');
@@ -52,6 +53,12 @@ class AXAButton extends LitElement {
       this.appendChild(fakeButton);
       this.onclick = () => fakeButton.click();
     }
+
+    style.appearance = 'none';
+    style.mozAppearance = 'none';
+    style.webkitAppearance = 'none';
+    style.msAppearance = 'none';
+    style.oAppearance = 'none';
   }
 
   render() {


### PR DESCRIPTION
Reset common reset.css/normalise.css out there.

they add styling like so: `[type="button"]` and add appearance to 'button'

fixes #1021 