### PR TITLE
Remove markup that does not get styled

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-**Please only report technical bugs. Clarify design issues with one of our designers: Ken Brossi, Jonas Güther and Thomas Veit**
+Please only report technical bugs. Clarify design issues with one of our designers: Ken Brossi, Jonas Güther and Thomas Veit

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,11 +7,10 @@ assignees: ''
 
 ---
 
-**
 Feature requests posted here should be of a smaller scope. Kind of like a "wishlist".
 
 Use the following channels for other requests:
 - Bigger feature requests (Components, etc): Slack @martin.stuedle
 - Questions, ask for help, request product presentations, etc: Slack #patterns-lib-devs
 
-We will close requests that do not belong in here.**
+We will close requests that do not belong in here.


### PR DESCRIPTION
The markup was not rendered for the github issue reports, so I removed it.