### PR TITLE
Feature/atom title section

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,7 @@
     "src/components/10-atoms/checkbox",
     "src/components/10-atoms/fieldset",
     "src/components/10-atoms/link",
+    "src/components/10-atoms/title-section",
     "src/components/20-molecules/footer-small",
     "src/components/30-organisms/table",
     "src/components/30-organisms/container",

--- a/src/components/10-atoms/title-section/README.md
+++ b/src/components/10-atoms/title-section/README.md
@@ -1,0 +1,68 @@
+# Title section
+
+This component comes with all needed styles for an AXA headline
+
+## Usage
+
+```bash
+npm install @axa-ch/title-section
+```
+
+```js
+import '@axa-ch/title-section';
+...
+<axa-title-section></axa-title-section>
+```
+
+### React
+
+Create a React-ified title-section with the createElement function from your React version and then use it like this:
+
+```js
+import { createElement } from 'react';
+import createAXATitleSectionReact from '@axa-ch/title-section/lib/index.react';
+
+const AXATitleSectionReact = createAXATitleSectionReact(createElement);
+
+export default AXATitleSectionReact;
+```
+
+```js
+<AXATitleSectionReact onClick={handler} />
+```
+
+### Pure HTML pages
+
+Import the title-section-defining script and use a title-section like this:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Your awesome title</title>
+  </head>
+  <body>
+    <axa-title-section></axa-title-section>
+    <script src="node_modules/@axa-ch/title-section/dist/index.js"></script>
+  </body>
+</html>
+```
+
+## Properties
+
+### Variant
+
+| Attribute       | Details         |
+| --------------- | --------------- |
+| `variant="foo"` | Desc of Variant |
+
+### Bar
+
+The attribute `bar` specifies...
+
+### onClick
+
+The function-valued attribute `onClick` can be used as a callback prop for React and other frameworks.

--- a/src/components/10-atoms/title-section/README.md
+++ b/src/components/10-atoms/title-section/README.md
@@ -4,7 +4,7 @@ This gives you a fully styled section title according to AXA guidelines.
 
 **Attention:**
 
-This title is rendered within an H1 Element, meaning you must wrap this component within a custom `<section>` or `<axa-container>` to be semantically correct.
+This title is rendered within an H1 Element, meaning you must wrap this component within a custom `<section>`, `<article>` or `<axa-container>` to be semantically correct.
 
 ## Usage
 

--- a/src/components/10-atoms/title-section/README.md
+++ b/src/components/10-atoms/title-section/README.md
@@ -49,7 +49,7 @@ Import the title-section-defining script and use a title-section like this:
     <title>Your awesome title</title>
   </head>
   <body>
-    <axa-title-section></axa-title-section>
+    <axa-title-section>This is a title for a section</axa-title-section>
     <script src="node_modules/@axa-ch/title-section/dist/index.js"></script>
   </body>
 </html>

--- a/src/components/10-atoms/title-section/README.md
+++ b/src/components/10-atoms/title-section/README.md
@@ -1,6 +1,6 @@
 # Title section
 
-This component comes with all needed styles for an AXA headline
+This gives you a fully styled section title according AXA guidelines
 
 ## Usage
 
@@ -11,7 +11,7 @@ npm install @axa-ch/title-section
 ```js
 import '@axa-ch/title-section';
 ...
-<axa-title-section></axa-title-section>
+<axa-title-section>This is a title for a section</axa-title-section>
 ```
 
 ### React
@@ -28,7 +28,7 @@ export default AXATitleSectionReact;
 ```
 
 ```js
-<AXATitleSectionReact onClick={handler} />
+<AXATitleSectionReact>A section title</AXATitleSectionReact>
 ```
 
 ### Pure HTML pages
@@ -55,14 +55,6 @@ Import the title-section-defining script and use a title-section like this:
 
 ### Variant
 
-| Attribute       | Details         |
-| --------------- | --------------- |
-| `variant="foo"` | Desc of Variant |
-
-### Bar
-
-The attribute `bar` specifies...
-
-### onClick
-
-The function-valued attribute `onClick` can be used as a callback prop for React and other frameworks.
+| Attribute         | Details                                                 |
+| ----------------- | ------------------------------------------------------- |
+| `variant="white"` | The title in white, to be used on different backgrounds |

--- a/src/components/10-atoms/title-section/README.md
+++ b/src/components/10-atoms/title-section/README.md
@@ -1,6 +1,10 @@
 # Title section
 
-This gives you a fully styled section title according AXA guidelines
+This gives you a fully styled section title according to AXA guidelines.
+
+**Attention:**
+
+This title is rendered within an H1 Element, meaning you must wrap this component within a custom `<section>` or `<axa-container>` to be semantically correct.
 
 ## Usage
 

--- a/src/components/10-atoms/title-section/index.js
+++ b/src/components/10-atoms/title-section/index.js
@@ -32,9 +32,9 @@ class AXATitleSection extends LitElement {
     });
 
     return html`
-      <h1 class="a-title-section ${classes}">
+      <h2 class="a-title-section ${classes}">
         <slot></slot>
-      </h1>
+      </h2>
     `;
   }
 }

--- a/src/components/10-atoms/title-section/index.js
+++ b/src/components/10-atoms/title-section/index.js
@@ -1,0 +1,44 @@
+import { LitElement, html, css, unsafeCSS } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
+/* eslint-disable import/no-extraneous-dependencies */
+import defineOnce from '../../../utils/define-once';
+import styles from './index.scss';
+
+class AXATitleSection extends LitElement {
+  static get tagName() {
+    return 'axa-title-section';
+  }
+
+  static get styles() {
+    return css`
+      ${unsafeCSS(styles)}
+    `;
+  }
+
+  static get properties() {
+    return {
+      variant: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this.variant = '';
+  }
+
+  render() {
+    const classes = {
+      'a-title-section--white': this.variant === 'white',
+    };
+
+    return html`
+      <h2 class="a-title-section ${classMap(classes)}">
+        <slot></slot>
+      </h2>
+    `;
+  }
+}
+
+defineOnce(AXATitleSection.tagName, AXATitleSection);
+
+export default AXATitleSection;

--- a/src/components/10-atoms/title-section/index.js
+++ b/src/components/10-atoms/title-section/index.js
@@ -27,14 +27,14 @@ class AXATitleSection extends LitElement {
   }
 
   render() {
-    const classes = {
+    const classes = classMap({
       'a-title-section--white': this.variant === 'white',
-    };
+    });
 
     return html`
-      <h2 class="a-title-section ${classMap(classes)}">
+      <h1 class="a-title-section ${classes}">
         <slot></slot>
-      </h2>
+      </h1>
     `;
   }
 }

--- a/src/components/10-atoms/title-section/index.react.d.ts
+++ b/src/components/10-atoms/title-section/index.react.d.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type Variant = 'white';
+
+interface AXATitleSectionProps {
+  variant?: Variant;
+}
+
+declare function createAXATitleSection(
+  createElement: typeof React.createElement
+): React.ComponentType<AXATitleSectionProps>;
+
+export = createAXATitleSection;

--- a/src/components/10-atoms/title-section/index.react.js
+++ b/src/components/10-atoms/title-section/index.react.js
@@ -1,0 +1,14 @@
+import withReact from '../../../utils/with-react';
+import AXATitleSection from './index';
+
+export default createElement => ({
+  /* props here, same as in the constructor of index.js */
+  children,
+}) =>
+  withReact(createElement)(
+    AXATitleSection.tagName,
+    {
+      /* props here, same as in the constructor of index.js */
+    },
+    children
+  );

--- a/src/components/10-atoms/title-section/index.react.js
+++ b/src/components/10-atoms/title-section/index.react.js
@@ -1,14 +1,11 @@
 import withReact from '../../../utils/with-react';
 import AXATitleSection from './index';
 
-export default createElement => ({
-  /* props here, same as in the constructor of index.js */
-  children,
-}) =>
+export default createElement => ({ variant = '', children }) =>
   withReact(createElement)(
     AXATitleSection.tagName,
     {
-      /* props here, same as in the constructor of index.js */
+      variant,
     },
     children
   );

--- a/src/components/10-atoms/title-section/index.scss
+++ b/src/components/10-atoms/title-section/index.scss
@@ -1,0 +1,11 @@
+.a-title-section {
+  @include typo(secondary, larger);
+
+  @include breakpoint($mediaquery-md-up) {
+    @include typo(secondary, largest);
+  }
+}
+
+.a-title-section--white {
+  color: $color-prim-white;
+}

--- a/src/components/10-atoms/title-section/package.json
+++ b/src/components/10-atoms/title-section/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@axa-ch/title-section",
+  "version": "0.0.0-beta.0",
+  "description": "This title section comes with all needed styles",
+  "author": "Pattern Warriors",
+  "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/title-section#readme",
+  "license": "Copyright 2019 AXA Versicherungen AG",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "rollup --silent --config ../../../../rollup.config.js",
+    "watch": "rollup --watch --silent --config ../../../../rollup.config.js"
+  },
+  "files": [
+    "lib",
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/axa-ch/patterns-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/axa-ch/patterns-library/issues"
+  },
+  "dependencies": {
+    "@skatejs/val": "^0.4.0",
+    "lit-element": "^2.1.0",
+    "lit-html": "^1.0.0"
+  }
+}

--- a/src/components/10-atoms/title-section/story.js
+++ b/src/components/10-atoms/title-section/story.js
@@ -1,0 +1,17 @@
+/* global document */
+import { storiesOf } from '@storybook/html';
+import './index';
+import { withMarkdown } from '../../../../.storybook/addons/markdown';
+import Readme from './README.md';
+
+storiesOf('Atoms/Title section', module)
+  .addDecorator(withMarkdown(Readme))
+  .add(
+    'Title section',
+    () => '<axa-title-section>This is a section title</axa-title-section>'
+  )
+  .add(
+    'Title section White',
+    () =>
+      `<div style="background: #00008f; padding: 50px; 100px;"><axa-title-section variant="white">This is the section title in white to be used on backgrounds</axa-title-section></div>`
+  );

--- a/src/components/10-atoms/title-section/story.js
+++ b/src/components/10-atoms/title-section/story.js
@@ -13,5 +13,7 @@ storiesOf('Atoms/Title section', module)
   .add(
     'Title section White',
     () =>
-      `<div style="background: #00008f; padding: 50px; 100px;"><axa-title-section variant="white">This is the section title in white to be used on backgrounds</axa-title-section></div>`
+      `<article style="background: #00008f; padding: 50px; 100px;">
+        <axa-title-section variant="white">This is the section title in white to be used on backgrounds</axa-title-section>
+      </article>`
   );

--- a/src/components/10-atoms/title-section/story.js
+++ b/src/components/10-atoms/title-section/story.js
@@ -13,7 +13,7 @@ storiesOf('Atoms/Title section', module)
   .add(
     'Title section White',
     () =>
-      `<article style="background: #00008f; padding: 50px; 100px;">
+      `<section style="background: #00008f; padding: 50px; 100px;">
         <axa-title-section variant="white">This is the section title in white to be used on backgrounds</axa-title-section>
-      </article>`
+       </section>`
   );

--- a/src/components/10-atoms/title-section/ui.test.js
+++ b/src/components/10-atoms/title-section/ui.test.js
@@ -1,8 +1,10 @@
-import { Selector } from 'testcafe';
+import { Selector, ClientFunction } from 'testcafe';
 
 const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
 
-fixture('Title section - basic functionality').page(`${host}/iframe.html?id=atoms-title-section--title-section-default`);
+fixture('Title section - basic functionality').page(
+  `${host}/iframe.html?id=atoms-title-section--title-section`
+);
 
 const TAG = 'axa-title-section';
 const CLASS = '.a-title-section';
@@ -10,7 +12,24 @@ const CLASS = '.a-title-section';
 test('should render title-section', async t => {
   const $axaElem = await Selector(TAG);
   await t.expect($axaElem.exists).ok();
-  const $axaElemShadow = await Selector(() => document.querySelector('axa-title-section').shadowRoot);
+  const $axaElemShadow = await Selector(
+    () => document.querySelector('axa-title-section').shadowRoot
+  );
   const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
   await t.expect($axaElemShadowEl.exists).ok();
+});
+
+fixture('Title section - basic functionality').page(
+  `${host}/iframe.html?id=atoms-title-section--title-section-white`
+);
+
+test('should render a title with white color', async t => {
+  const getTextColor = ClientFunction(() => {
+    const titleSection = document.querySelector('axa-title-section').shadowRoot;
+    return window
+      .getComputedStyle(titleSection.querySelector('.a-title-section--white'))
+      .getPropertyValue('color');
+  });
+  const measuredColor = await getTextColor();
+  await t.expect(measuredColor).eql('rgb(255, 255, 255)');
 });

--- a/src/components/10-atoms/title-section/ui.test.js
+++ b/src/components/10-atoms/title-section/ui.test.js
@@ -19,7 +19,7 @@ test('should render title-section', async t => {
   await t.expect($axaElemShadowEl.exists).ok();
 });
 
-fixture('Title section - basic functionality').page(
+fixture('Title section - Variant white').page(
   `${host}/iframe.html?id=atoms-title-section--title-section-white`
 );
 

--- a/src/components/10-atoms/title-section/ui.test.js
+++ b/src/components/10-atoms/title-section/ui.test.js
@@ -1,0 +1,16 @@
+import { Selector } from 'testcafe';
+
+const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+
+fixture('Title section - basic functionality').page(`${host}/iframe.html?id=atoms-title-section--title-section-default`);
+
+const TAG = 'axa-title-section';
+const CLASS = '.a-title-section';
+
+test('should render title-section', async t => {
+  const $axaElem = await Selector(TAG);
+  await t.expect($axaElem.exists).ok();
+  const $axaElemShadow = await Selector(() => document.querySelector('axa-title-section').shadowRoot);
+  const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
+  await t.expect($axaElemShadowEl.exists).ok();
+});


### PR DESCRIPTION
Allows consumers to include a section title as a component.
i.e `<axa-title-section>Kundenbewertungen</axa-title-section>`

In many times as an app builder, the title of a section is staying outside of the next component.
That's why we deliver a title as a component that comes with all the needed stylings - out of the box.

An example of a independent section title and the following component (rating) from axa.ch
<img width="1506" alt="Screenshot 2019-05-29 at 22 31 53" src="https://user-images.githubusercontent.com/2416200/58593830-51aecd80-826c-11e9-816d-57b64e52c135.png">
