### PR TITLE
Fix bug on IE (probably shadyCSS) that hid the icon in links

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,22 +1,6 @@
 {
   "packages": [
-    "src/components/00-materials",
-    "src/components/05-utils/polyfill",
-    "src/components/10-atoms/icon",
-    "src/components/10-atoms/button",
-    "src/components/10-atoms/button-link",
-    "src/components/10-atoms/checkbox",
-    "src/components/10-atoms/input-text",
-    "src/components/10-atoms/fieldset",
-    "src/components/10-atoms/input-file",
-    "src/components/10-atoms/link",
-    "src/components/20-molecules/footer-small",
-    "src/components/30-organisms/table",
-    "src/components/30-organisms/container",
-    "src/components/30-organisms/table-sortable",
-    "src/components/20-molecules/dropdown",
-    "src/components/20-molecules/top-content-bar",
-    "src/components/20-molecules/datepicker"
+    "src/components/10-atoms/link"
   ],
   "version": "independent",
   "npmClient": "npm"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,22 @@
 {
   "packages": [
-    "src/components/10-atoms/link"
+    "src/components/00-materials",
+    "src/components/05-utils/polyfill",
+    "src/components/10-atoms/icon",
+    "src/components/10-atoms/button",
+    "src/components/10-atoms/button-link",
+    "src/components/10-atoms/checkbox",
+    "src/components/10-atoms/input-text",
+    "src/components/10-atoms/fieldset",
+    "src/components/10-atoms/input-file",
+    "src/components/10-atoms/link",
+    "src/components/20-molecules/footer-small",
+    "src/components/30-organisms/table",
+    "src/components/30-organisms/container",
+    "src/components/30-organisms/table-sortable",
+    "src/components/20-molecules/dropdown",
+    "src/components/20-molecules/top-content-bar",
+    "src/components/20-molecules/datepicker"
   ],
   "version": "independent",
   "npmClient": "npm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5344,11 +5344,6 @@
         }
       }
     },
-    "breakpoint-sass": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/breakpoint-sass/-/breakpoint-sass-2.7.1.tgz",
-      "integrity": "sha1-jvbEdE3MJbqD2Wm2yaF+XaopmAo="
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",

--- a/src/components/10-atoms/link/index.js
+++ b/src/components/10-atoms/link/index.js
@@ -69,6 +69,8 @@ class AXALink extends LitElement {
     };
 
     // Prettier sets the closing template string literal on a new line, which causes a whitespace after the link.
+    // This whole HTML structure should not be changed easily! Depending on how you format it, icons will no longer
+    // be displayed and other weird stuff.
     // prettier-ignore
     return html`
       <a
@@ -100,7 +102,8 @@ class AXALink extends LitElement {
                 class="a-link__icon a-link__icon--left"
               ></axa-icon>
             `
-          : ''}<slot></slot>${this.variant.includes('arrowright')
+          : ''}
+          <slot></slot>${this.variant.includes('arrowright')
           ? html`
               <axa-icon icon="arrow-right" class="a-link__icon"></axa-icon>
             `

--- a/src/components/10-atoms/link/package.json
+++ b/src/components/10-atoms/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/link",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "The axa link for internal and external page navigation.",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/link/README.md",

--- a/src/components/10-atoms/link/package.json
+++ b/src/components/10-atoms/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/link",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "The axa link for internal and external page navigation.",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/link/README.md",

--- a/src/components/10-atoms/link/story.js
+++ b/src/components/10-atoms/link/story.js
@@ -65,7 +65,7 @@ storiesOf('Atoms/Link', module)
       `
   )
   .add(
-    'Simple Link - White Color hyperlink and underline',
+    'Simple Link - White Hyperlink & Underline',
     () => `<style>body {background-color: #3032c1;}</style>
     <axa-link href="https://axa.ch/en/private-customers.html" variant="hyperlink-white">Hyperlink white</axa-link><br><br>
     <axa-link href="https://axa.ch/en/private-customers.html" variant="hyperlink-white-underline">Hyperlink white underlined</axa-link><br><br>


### PR DESCRIPTION
The HTML structure is VITAL when it comes to displaying icons in IE it seems. That problem is probanly related to shadyCSS, which manipulated slot elements, that were directly next to the icon