### PR TITLE
Feature/upgrade readme with ie11 polyfill note

### DIFF
--- a/scripts/create-a-m-o/functions.js
+++ b/scripts/create-a-m-o/functions.js
@@ -80,6 +80,8 @@ const createFiles = (store, a, m, o, done) => () => {
 
     ## Usage
 
+    **Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
     \`\`\`bash
     npm install @axa-ch/${fileName}
     \`\`\`

--- a/src/components/10-atoms/button-link/README.md
+++ b/src/components/10-atoms/button-link/README.md
@@ -5,6 +5,8 @@ If you need a semantically correct button, use [axa-button](https://github.com/a
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/button-link
 ```

--- a/src/components/10-atoms/button/README.md
+++ b/src/components/10-atoms/button/README.md
@@ -5,6 +5,8 @@ If you need a link with button styling, use [axa-button-link](https://github.com
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/button
 ```

--- a/src/components/10-atoms/checkbox/README.md
+++ b/src/components/10-atoms/checkbox/README.md
@@ -8,6 +8,8 @@ For grouping multiple related checkboxes in a style-guide-conformant fashion see
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/checkbox
 ```

--- a/src/components/10-atoms/fieldset/README.md
+++ b/src/components/10-atoms/fieldset/README.md
@@ -11,3 +11,5 @@ Starred property names are reflected to attributes.
 ### horizontal\*
 
 Boolean `horizontal` changes the layout direction of the element's children to horizontal (default: false).
+
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).

--- a/src/components/10-atoms/icon/README.md
+++ b/src/components/10-atoms/icon/README.md
@@ -4,6 +4,8 @@
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 `npm install @axa-ch/icon`
 
 ```js

--- a/src/components/10-atoms/input-file/README.md
+++ b/src/components/10-atoms/input-file/README.md
@@ -4,6 +4,8 @@ Input-File provides a clickable element, which can be used in forms to upload fi
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/input-file
 ```

--- a/src/components/10-atoms/input-text/README.md
+++ b/src/components/10-atoms/input-text/README.md
@@ -5,6 +5,8 @@ It accepts most of the same properties as HTML &lt;input&gt;, but with `type`res
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/input-text
 ```

--- a/src/components/10-atoms/link/README.md
+++ b/src/components/10-atoms/link/README.md
@@ -6,6 +6,8 @@ All links support the colors "red" and "white" if declared within the `variant` 
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/link
 ```
@@ -131,4 +133,4 @@ If the variant is `icon`, using the attribute `icon`'s string value as icon name
 
 ### onClick
 
-On a react-ified component this can be used as a callback function. It will prevent default 
+On a react-ified component this can be used as a callback function. It will prevent default

--- a/src/components/10-atoms/link/README.md
+++ b/src/components/10-atoms/link/README.md
@@ -133,4 +133,4 @@ If the variant is `icon`, using the attribute `icon`'s string value as icon name
 
 ### onClick
 
-On a react-ified component this can be used as a callback function. It will prevent default
+On a React-ified component this can be used as a callback function. It will prevent default

--- a/src/components/10-atoms/text/README.md
+++ b/src/components/10-atoms/text/README.md
@@ -4,6 +4,8 @@ Allows you to control all the possible axa text styles by a component
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/text
 ```

--- a/src/components/10-atoms/title-primary/README.md
+++ b/src/components/10-atoms/title-primary/README.md
@@ -6,6 +6,8 @@ Shows you an AXA conform title. A predefined size can be changed by setting a va
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/title-primary
 ```

--- a/src/components/10-atoms/title-secondary/README.md
+++ b/src/components/10-atoms/title-secondary/README.md
@@ -6,6 +6,8 @@ Shows you an AXA conform title. A predefined size can be changed by setting a va
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/title-secondary
 ```

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -9,6 +9,8 @@ Note:
 
 ## Install
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/datepicker
 ```

--- a/src/components/20-molecules/dropdown/README.md
+++ b/src/components/20-molecules/dropdown/README.md
@@ -9,6 +9,8 @@ Note:
 
 ## Install
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 `npm install @axa-ch/dropdown`
 
 ## Example Usage

--- a/src/components/20-molecules/footer-small/README.md
+++ b/src/components/20-molecules/footer-small/README.md
@@ -4,6 +4,8 @@ This is the small version of the footer. If you use multiple footers, this one s
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/footer-small
 ```

--- a/src/components/20-molecules/top-content-bar/README.md
+++ b/src/components/20-molecules/top-content-bar/README.md
@@ -4,6 +4,8 @@ Used as top of the page Warning or info box that can show text and have a call t
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/top-content-bar
 ```

--- a/src/components/30-organisms/container/README.md
+++ b/src/components/30-organisms/container/README.md
@@ -4,6 +4,8 @@ Adds a max-with and margin auto according to Style Guide
 
 ## Usage
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 ```bash
 npm install @axa-ch/container
 ```

--- a/src/components/30-organisms/table-sortable/README.md
+++ b/src/components/30-organisms/table-sortable/README.md
@@ -2,8 +2,9 @@
 
 _WARNING: For mobile use, currently the innerscroll property must be set. This restriction will be lifted in the future._
 
-
 ## Usage
+
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
 
 Install it with your CLI:
 `npm install @axa-ch/table-sortable`
@@ -111,10 +112,10 @@ export default App;
 
 ## Properties
 
-| Attribute           | Details                                                                                   |
-| ------------------- | ----------------------------------------------------------------------------------------- |
+| Attribute           | Details                                                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `innerscroll="500"` | set a min width and if the viewport width is less than _innerscroll_ pixels, add a horizontal scrollbar. This property obligatorily requires thead and tbody. |
-| `model="{}"`        | sets the model from which the component should render. See example below.                      |
+| `model="{}"`        | sets the model from which the component should render. See example below.                                                                                     |
 
 Model example:
 

--- a/src/components/30-organisms/table/README.md
+++ b/src/components/30-organisms/table/README.md
@@ -3,6 +3,8 @@
 Install it with your CLI:
 `npm install @axa-ch/table-sortable`
 
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
 Example on how to use it in a HTML standalone page:
 
 ```html
@@ -108,11 +110,10 @@ export default App;
 
 **Note: axa-table does _not_ use ShadowDOM, unlike its sister component axa-table-sortable.**
 
-
 ## Properties
 
-| Attribute           | Details                                                                                   |
-| ------------------- | ----------------------------------------------------------------------------------------- |
+| Attribute           | Details                                                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `innerscroll="500"` | set a min width and if the viewport width is less than _innerscroll_ pixels, add a horizontal scrollbar. This property obligatorily requires thead and tbody. |
 
 ## Variants


### PR DESCRIPTION
Polyfill node should be contained in all readmes.

Also, the scaffolding delivers that information now from scratch.

The scaffolding is already tested.