### PR TITLE
Fix correct html semantics and open shadow for style overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10114,8 +10114,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10136,14 +10135,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10158,20 +10155,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10288,8 +10282,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10301,7 +10294,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10316,7 +10308,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10324,14 +10315,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10350,7 +10339,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10431,8 +10419,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10444,7 +10431,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10530,8 +10516,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10567,7 +10552,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10587,7 +10571,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10631,14 +10614,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/components/10-atoms/text/README.md
+++ b/src/components/10-atoms/text/README.md
@@ -1,6 +1,8 @@
 # Text
 
-Allows you to control all the possible axa text styles by a component
+Allows you to control all the possible axa text styles by a component.
+
+It accepts a simple text as children or a HTML tag like `<p>` or `<span>`. Please make sure that only one direct HTML child is provided.
 
 ## Usage
 

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -1,11 +1,11 @@
-import { LitElement, html, css, unsafeCSS } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
+import { css, unsafeCSS } from 'lit-element';
+import NoShadowDOM from '../../../utils/no-shadow';
 
 /* eslint-disable import/no-extraneous-dependencies */
 import defineOnce from '../../../utils/define-once';
 import styles from './index.scss';
 
-class AXAText extends LitElement {
+class AXAText extends NoShadowDOM {
   static get tagName() {
     return 'axa-text';
   }
@@ -34,17 +34,28 @@ class AXAText extends LitElement {
     const isSize3 = variant.includes('size-3');
     const isBold = variant.includes('bold');
 
-    const classes = classMap({
-      'a-text--size-2': isSize2,
-      'a-text--size-3': isSize3,
-      'a-text--bold': isBold,
-    });
+    const classes = ['a-text'];
+    if (isSize2) {
+      classes.push('a-text--size-2');
+    }
+    if (isSize3) {
+      classes.push('a-text--size-3');
+    }
+    if (isBold) {
+      classes.push('a-text--bold');
+    }
 
-    return html`
-      <span class="a-text ${classes}">
-        <slot></slot>
-      </span>
-    `;
+    const { firstChild, firstElementChild } = this;
+
+    if (firstChild.nodeType === 3 && firstElementChild === null) {
+      const p = document.createElement('p');
+      p.innerHTML = firstChild.textContent;
+      p.className = classes.join(' ');
+      this.innerHTML = '';
+      this.appendChild(p);
+    } else {
+      classes.forEach(_class => firstElementChild.classList.add(_class));
+    }
   }
 }
 

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -47,13 +47,15 @@ class AXAText extends NoShadowDOM {
 
     const { firstChild, firstElementChild } = this;
 
+    // nodeType === 3 is Text
     if (firstChild.nodeType === 3 && firstElementChild === null) {
       const p = document.createElement('p');
       p.innerHTML = firstChild.textContent;
       p.className = classes.join(' ');
       this.innerHTML = '';
       this.appendChild(p);
-    } else {
+    // if firstElementChild is there, apply classes on the first element
+    } else if (firstElementChild) {
       classes.forEach(_class => firstElementChild.classList.add(_class));
     }
   }

--- a/src/components/10-atoms/text/index.scss
+++ b/src/components/10-atoms/text/index.scss
@@ -6,6 +6,10 @@
   }
 }
 
+p.a-text {
+  margin: 0;
+}
+
 .a-text--size-2 {
   @include typo(primary, medium);
 

--- a/src/components/10-atoms/text/package.json
+++ b/src/components/10-atoms/text/package.json
@@ -25,6 +25,7 @@
     "url": "https://github.com/axa-ch/patterns-library/issues"
   },
   "dependencies": {
+    "@axa-ch/materials": "^1.3.5",
     "@skatejs/val": "^0.4.0",
     "lit-element": "^2.2.0",
     "lit-html": "^1.1.0"

--- a/src/components/10-atoms/text/story.js
+++ b/src/components/10-atoms/text/story.js
@@ -40,6 +40,36 @@ storiesOf('Atoms/Text', module)
           </axa-text>`
   )
   .add(
+    'Text - Size 2 with custom span tag',
+    () => `<axa-text variant="size-2">
+            <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse laoreet laoreet mauris sit amet congue.
+            Pellentesque lacinia imperdiet turpis, sit amet finibus est porta sit amet.
+            Vestibulum maximus enim suscipit, bibendum nisi et, sodales turpis.
+            Morbi eget eros sed tortor finibus pretium nec at lacus. Fusce egestas cursus nisl et sollicitudin.
+            Pellentesque id metus neque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+            Donec ornare risus non egestas vulputate. Aliquam ultrices condimentum libero ut ultrices.
+            Vivamus mauris tellus, semper at consequat sit amet, semper nec metus. Mauris sed commodo dolor.
+            Pellentesque lorem neque, varius sit amet euismod eget, hendrerit quis justo.
+            Nam quis nunc sit amet tellus volutpat convallis quis nec tellus.
+            Mauris sed mi risus. Praesent ultrices neque ac leo vehicula facilisis. Morbi eu ullamcorper mauris.</span>
+          </axa-text>`
+  )
+  .add(
+    'Text - Size 2 with custom p tag',
+    () => `<axa-text variant="size-2">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse laoreet laoreet mauris sit amet congue.
+            Pellentesque lacinia imperdiet turpis, sit amet finibus est porta sit amet.
+            Vestibulum maximus enim suscipit, bibendum nisi et, sodales turpis.
+            Morbi eget eros sed tortor finibus pretium nec at lacus. Fusce egestas cursus nisl et sollicitudin.
+            Pellentesque id metus neque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+            Donec ornare risus non egestas vulputate. Aliquam ultrices condimentum libero ut ultrices.
+            Vivamus mauris tellus, semper at consequat sit amet, semper nec metus. Mauris sed commodo dolor.
+            Pellentesque lorem neque, varius sit amet euismod eget, hendrerit quis justo.
+            Nam quis nunc sit amet tellus volutpat convallis quis nec tellus.
+            Mauris sed mi risus. Praesent ultrices neque ac leo vehicula facilisis. Morbi eu ullamcorper mauris.</p>
+          </axa-text>`
+  )
+  .add(
     'Text - Size 3',
     () => `<axa-text variant="size-3">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse laoreet laoreet mauris sit amet congue.

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -15,7 +15,7 @@ test('should render text', async t => {
   const $axaElem = await Selector(TAG);
   await t.expect($axaElem.exists).ok();
   const $axaElemShadow = await Selector(
-    () => document.querySelector('axa-text').shadowRoot
+    () => document.querySelector('axa-text')
   );
   const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
   await t.expect($axaElemShadowEl.exists).ok();
@@ -23,7 +23,7 @@ test('should render text', async t => {
 
 test('should have correct font definitions for text size 1', async t => {
   const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text').shadowRoot.querySelector('.a-text')
+    document.querySelector('axa-text').querySelector('.a-text')
   );
 
   await t
@@ -55,7 +55,7 @@ test('should have correct font definitions for text size 2', async t => {
   const $axaElemShadow = await Selector(() =>
     document
       .querySelector('axa-text[variant="size-2"]')
-      .shadowRoot.querySelector('.a-text')
+      .querySelector('.a-text')
   );
 
   await t
@@ -87,7 +87,7 @@ test('should have correct font definitions for text size 3', async t => {
   const $axaElemShadow = await Selector(() =>
     document
       .querySelector('axa-text[variant="size-3"]')
-      .shadowRoot.querySelector('.a-text')
+      .querySelector('.a-text')
   );
 
   await t
@@ -109,6 +109,39 @@ test('should have correct font definitions for text size 3', async t => {
     .eql('24px');
 });
 
+fixture('Text - Size 2 with custom tag')
+  .page(`${host}/iframe.html?id=atoms-text--text-size-2-with-custom-span-tag`)
+  .beforeEach(async t => {
+    await t.resizeWindow(380, 680);
+  });
+
+test('should have correct font definitions for text size 2 with custom span tag', async t => {
+  const $axaElemShadow = await Selector(() =>
+    document
+      .querySelector('axa-text[variant="size-2"]')
+      .querySelector('.a-text')
+  );
+
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .eql('16px');
+
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .eql('24px');
+
+  await t.resizeWindow(800, 600);
+
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .eql('18px');
+
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .eql('27px');
+});
+
+
 fixture('Text - Bold')
   .page(`${host}/iframe.html?id=atoms-text--text-bold`)
   .beforeEach(async t => {
@@ -119,7 +152,7 @@ test('should have correct font weight for text bold', async t => {
   const $axaElemShadow = await Selector(() =>
     document
       .querySelector('axa-text[variant="bold"]')
-      .shadowRoot.querySelector('.a-text')
+      .querySelector('.a-text')
   );
 
   await t


### PR DESCRIPTION
FIXES:

axa-text should not wrap with <span> and should be NoShadow -> Reason: span is not correct as users could pass <p> or other tags that are not allowd inside span. We decided therefore no wrapper. No shadow was the idea that outside application most likely have to style inner text with colors, etc. Therefore noShadow