### PR TITLE
remove embedded from datepicker and dropdown

### DIFF
--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -400,6 +400,7 @@ class AXADatepicker extends NoShadowDOM {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     window.removeEventListener('keydown', this.handleWindowKeyDown);
     window.removeEventListener('click', this.handleBodyClick);
     window.removeEventListener('resize', this.debouncedHandleViewportCheck);

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -294,7 +294,7 @@ class AXADatepicker extends NoShadowDOM {
                       max-height
                       items="${JSON.stringify(this.monthitems)}"
                       title="${this.monthtitle}"
-                      embedded
+                      data-usecase="datepicker"
                     >
                     </axa-dropdown>
 
@@ -304,7 +304,7 @@ class AXADatepicker extends NoShadowDOM {
                       max-height
                       items="${JSON.stringify(this.yearitems)}"
                       title="${this.yeartitle}"
-                      embedded
+                      data-usecase="datepicker"
                     >
                     </axa-dropdown>
                   </div>

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -122,7 +122,6 @@ class AXADatepicker extends NoShadowDOM {
       invalid: { type: Boolean, reflect: true },
       invaliddatetext: { type: String },
       error: { type: String, reflect: true },
-      embedded: { type: Boolean, reflect: true },
       height: { type: String, reflect: true },
       width: { type: String, reflect: true },
     };
@@ -246,13 +245,15 @@ class AXADatepicker extends NoShadowDOM {
 
     this.setMonthAndYearItems(month, year);
 
-    const { width = 'auto', height = 'auto' } = this;
+    const { width = 'auto', height = 'auto', error, invalid } = this;
 
     const formattedStyle = parameter =>
       `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;
 
     const formattedWidth = `width:${formattedStyle(width)}`;
     const formattedHeight = `height:${formattedStyle(height)}`;
+
+    const needToShowError = error || invalid;
 
     return html`
       <article
@@ -357,11 +358,9 @@ class AXADatepicker extends NoShadowDOM {
               </div>
             `
           : ''}
-        ${!this.embedded
+        ${needToShowError
           ? html`
-              <span class="m-datepicker__error"
-                >${this.error || this.invalid ? this.invaliddatetext : ''}</span
-              >
+              <span class="m-datepicker__error">${this.invaliddatetext}</span>
             `
           : html``}
       </article>

--- a/src/components/20-molecules/datepicker/index.scss
+++ b/src/components/20-molecules/datepicker/index.scss
@@ -30,14 +30,6 @@ axa-datepicker {
     }
   }
 
-  &[embedded] {
-    max-height: 35px;
-
-    &:not([open]) {
-      overflow: hidden;
-    }
-  }
-
   &[width] {
     display: flex;
   }

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -357,6 +357,7 @@ class AXADropdown extends NoShadowDOM {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     window.removeEventListener('resize', this.handleResize);
     window.removeEventListener('keydown', this.handleWindowKeyDown);
     window.removeEventListener('click', this.handleWindowClick);

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -96,7 +96,6 @@ class AXADropdown extends NoShadowDOM {
       native: { type: Boolean },
       valid: { type: Boolean, reflect: true },
       error: { type: String, reflect: true },
-      embedded: { type: Boolean, reflect: true },
       isReact: { type: Boolean },
     };
   }
@@ -333,9 +332,13 @@ class AXADropdown extends NoShadowDOM {
             ${items.map(contentItemsMapper(handleDropdownItemClick))}
           </ul>
         </div>
-        <div class="m-dropdown__valid-icon">
-          <span class="${classMap(validClasses)}"></span>
-        </div>
+        ${valid
+          ? html`
+              <div class="m-dropdown__valid-icon">
+                <span class="${classMap(validClasses)}"></span>
+              </div>
+            `
+          : html``}
       </div>
       <div class="m-dropdown__error">${error}</div>
     `;

--- a/src/components/20-molecules/dropdown/index.scss
+++ b/src/components/20-molecules/dropdown/index.scss
@@ -9,7 +9,6 @@ $dropdown-bottom-border-width: 2px;
 $dropdown-height: 40px;
 $dropdown-icon-width: 10px;
 $dropdown-icon-height: $dropdown-icon-width;
-$dropdown-error-minheight: 19px;
 
 @mixin normalize-native-select-styles() {
   appearance: none;
@@ -63,7 +62,7 @@ axa-dropdown {
       padding-right: 10px;
     }
 
-    &[max-height][embedded] {
+    &[max-height][data-usecase="datepicker"] {
       .m-dropdown__content {
         border: $dropdown-border-style;
         border-top: none;
@@ -71,7 +70,7 @@ axa-dropdown {
     }
   }
 
-  &[max-height][embedded] {
+  &[max-height][data-usecase="datepicker"] {
 
     .m-dropdown__toggle span {
       display: inline-block;
@@ -121,13 +120,6 @@ axa-dropdown {
 
     &__error {
       visibility: visible;
-    }
-  }
-
-  &[embedded] {
-    .m-dropdown__valid-icon,
-    .m-dropdown__error {
-      display: none;
     }
   }
 }
@@ -181,7 +173,6 @@ axa-dropdown {
     margin-top: 10px;
     line-height: 1.2;
     color: $color-validation-error;
-    min-height: $dropdown-error-minheight;
   }
 
   &__select {

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -52,17 +52,6 @@ storiesOf('Molecules/Dropdown', module)
     `
   )
   .add(
-    'Dropdown embedded, w/o space for valid checkmark or error message',
-    () => `<axa-dropdown embedded
-    items='[
-    {"name": "Please Select", "value": "Please Select", "selected": true, "disabled": true },
-    {"name": "Item 1", "value": "Item 1" },
-    {"name": "Item 2", "value": "Item 2" },
-    {"name": "Item 3", "value": "Item 3" }
-    ]'></axa-dropdown>
-    `
-  )
-  .add(
     'Dropdown inside form',
     () => `<form id="dropdown-form" onsubmit="event.preventDefault();document.getElementById('form-data').open=true;document.getElementById('form-data-lang').textContent=(new FormData(this)).get('lang')">
     <fieldset>


### PR DESCRIPTION
No space is reserved anymore. As a result, component geometry changes when checkmark or errors appear.

This PR _en passant_ also fixes missing super.disconnectedCallback() as discovered by Marco.

All tests pass.

Fixes #1146.