### PR TITLE
Defensive coding axa text

### DIFF
--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -48,7 +48,7 @@ class AXAText extends NoShadowDOM {
     const { firstChild, firstElementChild } = this;
 
     // nodeType === 3 is Text
-    if (firstChild.nodeType === 3 && firstElementChild === null) {
+    if (firstChild && firstChild.nodeType === 3 && firstElementChild === null) {
       const p = document.createElement('p');
       p.innerHTML = firstChild.textContent;
       p.className = classes.join(' ');


### PR DESCRIPTION
If node is only in VDOM in react, firstChild is undefined and an error is triggered. This PR fixes the issue