### PR TITLE
TS types: add compatibility with TS "declaration" flag

### DIFF
--- a/scripts/create-a-m-o/functions.js
+++ b/scripts/create-a-m-o/functions.js
@@ -230,9 +230,9 @@ const createFiles = (store, a, m, o, done) => () => {
     outdent`
     import React from 'react';
 
-    type Variant = 'foo' | 'bar';
+    export type Variant = 'foo' | 'bar';
 
-    interface ${className}Props {
+    export interface ${className}Props {
       className?: string;
       variant?: Variant;
       onClick?: () => void;
@@ -242,7 +242,7 @@ const createFiles = (store, a, m, o, done) => () => {
       createElement: typeof React.createElement
     ): React.ComponentType<${className}Props>;
 
-    export = create${className};
+    export default create${className};
     `,
     'utf8',
   );

--- a/src/components/10-atoms/button-link/index.react.d.ts
+++ b/src/components/10-atoms/button-link/index.react.d.ts
@@ -12,7 +12,7 @@ type Variant =
   | 'inverted-green-viridian'
   | 'inverted-blue-teal';
 
-interface AXAButtonLinkProps {
+export interface AXAButtonLinkProps {
   href?: string;
   external?: boolean;
   size?: Size;
@@ -30,4 +30,4 @@ declare function createAXAButtonLink(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAButtonLinkProps>;
 
-export = createAXAButtonLink;
+export default createAXAButtonLink;

--- a/src/components/10-atoms/button/index.react.d.ts
+++ b/src/components/10-atoms/button/index.react.d.ts
@@ -13,7 +13,7 @@ type Variant =
   | 'inverted-green-viridian'
   | 'inverted-blue-teal';
 
-interface AXAButtonProps {
+export interface AXAButtonProps {
   type?: ButtonType;
   variant?: Variant;
   icon?: Icon;
@@ -29,4 +29,4 @@ declare function createAXAButton(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAButtonProps>;
 
-export = createAXAButton;
+export default createAXAButton;

--- a/src/components/10-atoms/checkbox/index.react.d.ts
+++ b/src/components/10-atoms/checkbox/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXACheckboxProps {
+export interface AXACheckboxProps {
   value?: string;
   name?: string;
   label?: string;
@@ -19,4 +19,4 @@ declare function createAXACheckbox(
   createElement: typeof React.createElement
 ): React.ComponentType<AXACheckboxProps>;
 
-export = createAXACheckbox;
+export default createAXACheckbox;

--- a/src/components/10-atoms/fieldset/index.react.d.ts
+++ b/src/components/10-atoms/fieldset/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXAFieldsetProps {
+export interface AXAFieldsetProps {
   horizontal?: boolean;
   error?: string;
   slot?: string;
@@ -10,4 +10,4 @@ declare function createAXAFieldset(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAFieldsetProps>;
 
-export = createAXAFieldset;
+export default createAXAFieldset;

--- a/src/components/10-atoms/icon/index.react.d.ts
+++ b/src/components/10-atoms/icon/index.react.d.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Icon } from './index.d';
 
-interface AXAIconProps {
+export interface AXAIconProps {
   icon?: Icon
 }
 
@@ -9,4 +9,4 @@ declare function createAXAIcon(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAIconProps>;
 
-export = createAXAIcon;
+export default createAXAIcon;

--- a/src/components/10-atoms/input-file/index.react.d.ts
+++ b/src/components/10-atoms/input-file/index.react.d.ts
@@ -3,7 +3,7 @@ import { Icon } from '@axa-ch/icon/lib/index.d';
 
 type Variant = 'secondary' | 'red' | 'inverted';
 
-interface AXAInputFileProps {
+export interface AXAInputFileProps {
   variant?: Variant;
   icon?: Icon;
   id?: String;
@@ -23,4 +23,4 @@ declare function createAXAInputFile(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAInputFileProps>;
 
-export = createAXAInputFile;
+export default createAXAInputFile;

--- a/src/components/10-atoms/input-text/index.react.d.ts
+++ b/src/components/10-atoms/input-text/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXAInputTextProps {
+export interface AXAInputTextProps {
   refId?: string;
   name: string;
   label?: string;
@@ -25,4 +25,4 @@ declare function createAXAInputText(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAInputTextProps>;
 
-export = createAXAInputText;
+export default createAXAInputText;

--- a/src/components/10-atoms/link/index.react.d.ts
+++ b/src/components/10-atoms/link/index.react.d.ts
@@ -35,4 +35,4 @@ declare function createAXALink(
   createElement: typeof React.createElement
 ): React.ComponentType<AXALinkProps>;
 
-export = createAXALink;
+export default createAXALink;

--- a/src/components/10-atoms/radio/index.react.d.ts
+++ b/src/components/10-atoms/radio/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXARadioProps {
+export interface AXARadioProps {
   id?: string;
   refId?: string;
   className?: string;
@@ -23,4 +23,4 @@ declare function createAXARadio(
   createElement: typeof React.createElement
 ): React.ComponentType<AXARadioProps>;
 
-export = createAXARadio;
+export default createAXARadio;

--- a/src/components/10-atoms/text/index.react.d.ts
+++ b/src/components/10-atoms/text/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'size-2' | 'size-3' | 'size-4' | 'bold';
 
-interface AXATextProps {
+export interface AXATextProps {
   className?: string;
   slot?: string;
   variant?: Variant;
@@ -12,4 +12,4 @@ declare function createAXAText(
   createElement: typeof React.createElement
 ): React.ComponentType<AXATextProps>;
 
-export = createAXAText;
+export default createAXAText;

--- a/src/components/10-atoms/textarea/index.react.d.ts
+++ b/src/components/10-atoms/textarea/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXATextareaProps {
+export interface AXATextareaProps {
   refId?: string;
   name: string;
   label?: string;
@@ -26,4 +26,4 @@ declare function createAXATextarea(
   createElement: typeof React.createElement
 ): React.ComponentType<AXATextareaProps>;
 
-export = createAXATextarea;
+export default createAXATextarea;

--- a/src/components/10-atoms/title-primary/index.react.d.ts
+++ b/src/components/10-atoms/title-primary/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'size-2' | 'size-3' | 'size-4' | 'size-5' | 'size-6';
 
-interface AXATitlePrimaryProps {
+export interface AXATitlePrimaryProps {
   variant?: Variant;
   className?: string;
   slot?: string;
@@ -12,4 +12,4 @@ declare function createAXATitlePrimary(
   createElement: typeof React.createElement
 ): React.ComponentType<AXATitlePrimaryProps>;
 
-export = createAXATitlePrimary;
+export default createAXATitlePrimary;

--- a/src/components/10-atoms/title-secondary/index.react.d.ts
+++ b/src/components/10-atoms/title-secondary/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'size-2' | 'size-3' | 'size-4' | 'size-5' | 'size-6';
 
-interface AXATitleSecondaryProps {
+export interface AXATitleSecondaryProps {
   variant?: Variant;
   className?: string;
   slot?: string;
@@ -12,4 +12,4 @@ declare function createAXATitleSecondary(
   createElement: typeof React.createElement
 ): React.ComponentType<AXATitleSecondaryProps>;
 
-export = createAXATitleSecondary;
+export default createAXATitleSecondary;

--- a/src/components/20-molecules/cookie-disclaimer/index.react.d.ts
+++ b/src/components/20-molecules/cookie-disclaimer/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'fixed';
 
-interface AXACookieDisclaimerProps {
+export interface AXACookieDisclaimerProps {
   variant?: Variant;
   title?: string;
   buttonname?: string;
@@ -14,4 +14,4 @@ declare function createAXACookieDisclaimer(
   createElement: typeof React.createElement
 ): React.ComponentType<AXACookieDisclaimerProps>;
 
-export = createAXACookieDisclaimer;
+export default createAXACookieDisclaimer;

--- a/src/components/20-molecules/datepicker/index.react.d.ts
+++ b/src/components/20-molecules/datepicker/index.react.d.ts
@@ -6,7 +6,7 @@ type AXADatepickerChangeEvent = {
   }
 }
 
-interface AXADatepickerProps {
+export interface AXADatepickerProps {
   dataTestId?: string;
   inputfield?: boolean;
   value?: string;
@@ -44,4 +44,4 @@ declare function createAXADatepicker(
   createElement: typeof React.createElement
 ): React.ComponentType<AXADatepickerProps>;
 
-export = createAXADatepicker;
+export default createAXADatepicker;

--- a/src/components/20-molecules/dropdown/index.react.d.ts
+++ b/src/components/20-molecules/dropdown/index.react.d.ts
@@ -11,7 +11,7 @@ type AXADropdownChangeEvent<T> = {
   target: Item<T>;
 };
 
-interface AXADropdownProps<T = number | string> {
+export interface AXADropdownProps<T = number | string> {
   items: Array<Item<T>>;
   embedded?: boolean;
   refId?: string;
@@ -35,4 +35,4 @@ declare function createAXADropdown(
   createElement: typeof React.createElement
 ): React.ComponentType<AXADropdownProps>;
 
-export = createAXADropdown;
+export default createAXADropdown;

--- a/src/components/20-molecules/footer-small/index.react.d.ts
+++ b/src/components/20-molecules/footer-small/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface Item {
+export interface Item {
   text: string;
   link?: string;
 }

--- a/src/components/20-molecules/footer-small/index.react.d.ts
+++ b/src/components/20-molecules/footer-small/index.react.d.ts
@@ -5,7 +5,7 @@ interface Item {
   link?: string;
 }
 
-interface AXAFooterSmallProps {
+export interface AXAFooterSmallProps {
   languageItems: Item[];
   disclaimerItems: Item[];
   copyrightText: string;
@@ -22,4 +22,4 @@ declare function createAXAFooterSmall(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAFooterSmallProps>;
 
-export = createAXAFooterSmall;
+export default createAXAFooterSmall;

--- a/src/components/20-molecules/policy-features/index.react.d.ts
+++ b/src/components/20-molecules/policy-features/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'axa-blue' | 'wild-sand' | 'white';
 
-interface AXAPolicyFeaturesProps {
+export interface AXAPolicyFeaturesProps {
   title: string;
   variant?: Variant;
   className?: string;
@@ -12,4 +12,4 @@ declare function createAXAPolicyFeatures(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAPolicyFeaturesProps>;
 
-export = createAXAPolicyFeatures;
+export default createAXAPolicyFeatures;

--- a/src/components/20-molecules/policy-features/policy-features-item/index.react.d.ts
+++ b/src/components/20-molecules/policy-features/policy-features-item/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXAPolicyFeaturesItemProps {
+export interface AXAPolicyFeaturesItemProps {
   title: string;
   description: string;
   icon?: string;
@@ -11,4 +11,4 @@ declare function createAXAPolicyFeaturesItem(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAPolicyFeaturesItemProps>;
 
-export = createAXAPolicyFeaturesItem;
+export default createAXAPolicyFeaturesItem;

--- a/src/components/20-molecules/popup/index.react.d.ts
+++ b/src/components/20-molecules/popup/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'foo' | 'bar';
 
-interface AXAPopupProps {
+export interface AXAPopupProps {
   variant?: Variant;
   slot?: string;
   onClick?: () => void;
@@ -12,4 +12,4 @@ declare function createAXAPopup(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAPopupProps>;
 
-export = createAXAPopup;
+export default createAXAPopup;

--- a/src/components/20-molecules/top-content-bar/index.react.d.ts
+++ b/src/components/20-molecules/top-content-bar/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'warning';
 
-interface AXATopContentBarProps {
+export interface AXATopContentBarProps {
   variant?: Variant;
   ctatext: string;
   href?: string;
@@ -14,4 +14,4 @@ declare function createAXATopContentBar(
   createElement: typeof React.createElement
 ): React.ComponentType<AXATopContentBarProps>;
 
-export = createAXATopContentBar;
+export default createAXATopContentBar;

--- a/src/components/30-organisms/commercial-hero-banner/index.react.d.ts
+++ b/src/components/30-organisms/commercial-hero-banner/index.react.d.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 type Variant = 'light' | 'dark';
 
-interface AXACommercialHeroBannerProps {
+export interface AXACommercialHeroBannerProps {
   imageSource: string;
   variant?: Variant;
   className?: string;
@@ -12,4 +12,4 @@ declare function createAXACommercialHeroBanner(
   createElement: typeof React.createElement
 ): React.ComponentType<AXACommercialHeroBannerProps>;
 
-export = createAXACommercialHeroBanner;
+export default createAXACommercialHeroBanner;

--- a/src/components/30-organisms/container/index.react.d.ts
+++ b/src/components/30-organisms/container/index.react.d.ts
@@ -2,10 +2,10 @@ import React from 'react';
 
 type Variant = 'foo' | 'bar';
 
-interface AXAContainerProps {}
+export interface AXAContainerProps {}
 
 declare function createAXAContainer(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAContainerProps>;
 
-export = createAXAContainer;
+export default createAXAContainer;

--- a/src/components/30-organisms/footer/index.react.d.ts
+++ b/src/components/30-organisms/footer/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXAFooterProps {
+export interface AXAFooterProps {
   onItemClick?: Function;
   clickevents?: Boolean;
   className?: string;
@@ -10,4 +10,4 @@ declare function createAXAFooter(
   createElement: typeof React.createElement
 ): React.ComponentType<AXAFooterProps>;
 
-export = createAXAFooter;
+export default createAXAFooter;

--- a/src/components/30-organisms/table/index.react.d.ts
+++ b/src/components/30-organisms/table/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface AXATableProps {
+export interface AXATableProps {
   className?: string;
 }
 
@@ -8,4 +8,4 @@ declare function createAXATable(
   createElement: typeof React.createElement
 ): React.ComponentType<AXATableProps>;
 
-export = createAXATable;
+export default createAXATable;


### PR DESCRIPTION
Avoid below mentioned error when having TS "declaration" flag turned on.

`TS4023: Exported variable 'X' has or is using name 'Y' from external module ... but cannot be named.`

https://github.com/Microsoft/TypeScript/issues/5711
