### PR TITLE
Feature/remove redundant code ui test

### DIFF
--- a/scripts/create-a-m-o/functions.js
+++ b/scripts/create-a-m-o/functions.js
@@ -252,7 +252,7 @@ const createFiles = (store, a, m, o, done) => () => {
     outdent`
     import { Selector } from 'testcafe';
 
-    const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+    const host = process.env.TEST_HOST_STORYBOOK_URL;
 
     fixture('${compTitle} - basic functionality').page(\`\${host}/iframe.html?id=${titleMap[type].toLowerCase()}-${fileName}--${fileName}\`);
 

--- a/src/components/10-atoms/button-link/ui.test.js
+++ b/src/components/10-atoms/button-link/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Button Link - basic functionality').page(
   `${host}/iframe.html?id=atoms-button-link--button-link`

--- a/src/components/10-atoms/button/ui.test.js
+++ b/src/components/10-atoms/button/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 const BUTTON_TAG = 'axa-button';
 const ICON_TAG = 'axa-icon';

--- a/src/components/10-atoms/checkbox/ui.test.js
+++ b/src/components/10-atoms/checkbox/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Checkbox - basic functionality').page(
   `${host}/iframe.html?id=atoms-checkbox--checkbox`

--- a/src/components/10-atoms/fieldset/ui.test.js
+++ b/src/components/10-atoms/fieldset/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Fieldset - basic functionality').page(
   `${host}/iframe.html?id=atoms-fieldset--fieldset-default`

--- a/src/components/10-atoms/icon/ui.test.js
+++ b/src/components/10-atoms/icon/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Icon - show all icons').page(
   `${host}/iframe.html?id=atoms-icon--icon-show-all-icons`

--- a/src/components/10-atoms/input-file/ui.test.js
+++ b/src/components/10-atoms/input-file/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Input File - basic functionality').page(
   `${host}/iframe.html?id=atoms-input-file--input-file-default`

--- a/src/components/10-atoms/input-text/ui.test.js
+++ b/src/components/10-atoms/input-text/ui.test.js
@@ -1,6 +1,6 @@
 import { ClientFunction, Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Input text - basic functionality').page(
   `${host}/iframe.html?id=atoms-input-text--input-text`

--- a/src/components/10-atoms/link/ui.test.js
+++ b/src/components/10-atoms/link/ui.test.js
@@ -2,7 +2,7 @@
 
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 const axaBlue = 'rgb(0, 0, 143)';
 const primRedFlamingo = 'rgb(240, 118, 98)';

--- a/src/components/10-atoms/radio/ui.test.js
+++ b/src/components/10-atoms/radio/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Radio - basic functionality').page(
   `${host}/iframe.html?id=atoms-radio--radio-default`

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Text - basic functionality')
   .page(`${host}/iframe.html?id=atoms-text--text-default`)

--- a/src/components/10-atoms/textarea/ui.test.js
+++ b/src/components/10-atoms/textarea/ui.test.js
@@ -1,6 +1,6 @@
 import { ClientFunction, Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Textarea - basic functionality').page(
   `${host}/iframe.html?id=atoms-textarea--textarea`

--- a/src/components/10-atoms/title-primary/ui.test.js
+++ b/src/components/10-atoms/title-primary/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Title primary - basic functionality')
   .page(`${host}/iframe.html?id=atoms-title-primary--title-primary`)

--- a/src/components/10-atoms/title-secondary/ui.test.js
+++ b/src/components/10-atoms/title-secondary/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Title secondary - basic functionality')
   .page(`${host}/iframe.html?id=atoms-title-secondary--title-secondary`)

--- a/src/components/20-molecules/cookie-disclaimer/ui.test.js
+++ b/src/components/20-molecules/cookie-disclaimer/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Cookie disclaimer - basic functionality').page(
   `${host}/iframe.html?id=molecules-cookie-disclaimer--cookie-disclaimer-default`

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -1,7 +1,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 import { DatePickerAccessor } from './test.accessor';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Datepicker').page(
   `${host}/iframe.html?id=molecules-datepicker--datepicker`

--- a/src/components/20-molecules/dropdown/ui.test.js
+++ b/src/components/20-molecules/dropdown/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Dropdown').page(`${host}/iframe.html?id=molecules-dropdown--dropdown`);
 

--- a/src/components/20-molecules/footer-small/ui.test.js
+++ b/src/components/20-molecules/footer-small/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Footer Small - Static links').page(
   `${host}/iframe.html?id=molecules-footer-small--footer-small`

--- a/src/components/20-molecules/policy-features/policy-features-item/ui.test.js
+++ b/src/components/20-molecules/policy-features/policy-features-item/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 const TAG = 'axa-policy-features-item';
 const CLASS = '.m-policy-features-item';
 const defaultWindowHeight = 1000;

--- a/src/components/20-molecules/policy-features/ui.test.js
+++ b/src/components/20-molecules/policy-features/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 const TAG = 'axa-policy-features';
 const CLASS = '.m-policy-features';
 const defaultWindowHeight = 1000;

--- a/src/components/20-molecules/popup/popup-button/ui.test.js
+++ b/src/components/20-molecules/popup/popup-button/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Popup button - basic functionality').page(`${host}/iframe.html?id=molecules-popup--popup-button`);
 

--- a/src/components/20-molecules/popup/popup-content/ui.test.js
+++ b/src/components/20-molecules/popup/popup-content/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Popup content - basic functionality').page(`${host}/iframe.html?id=molecules-popup--popup-content`);
 

--- a/src/components/20-molecules/top-content-bar/ui.test.js
+++ b/src/components/20-molecules/top-content-bar/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector, ClientFunction } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Top content bar - basic functionality').page(
   `${host}/iframe.html?id=molecules-top-content-bar--top-content-bar-default-with-button`

--- a/src/components/30-organisms/commercial-hero-banner/ui.test.js
+++ b/src/components/30-organisms/commercial-hero-banner/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Commercial Hero Banner - basic functionality').page(
   `${host}/iframe.html?id=organisms-commercial-hero-banner--commercial-hero-banner`

--- a/src/components/30-organisms/container/ui.test.js
+++ b/src/components/30-organisms/container/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Container - basic functionality').page(`${host}/iframe.html?id=organisms-container--container-default`);
 

--- a/src/components/30-organisms/footer/ui.test.js
+++ b/src/components/30-organisms/footer/ui.test.js
@@ -1,7 +1,7 @@
 import { Selector } from 'testcafe';
 import FooterAccessor from './ui.accessor';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Footer - Basic Functionality')
   .page(`${host}/iframe.html?id=organisms-footer--footer`)

--- a/src/components/30-organisms/table-sortable/ui.test.js
+++ b/src/components/30-organisms/table-sortable/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Table Sortable - basic functionality')
   .page(

--- a/src/components/30-organisms/table/ui.test.js
+++ b/src/components/30-organisms/table/ui.test.js
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-const host = process.env.TEST_HOST_STORYBOOK_URL || 'http://localhost:9999';
+const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Table - basic functionality')
   .page(`${host}/iframe.html?id=organisms-table--table-default`)


### PR DESCRIPTION
fixes #1230

short-circuit boolean evaluation can be removed because it is already declared in `.env.default`