### PR TITLE
Bugfix/axa radio fixes

### DIFF
--- a/src/components/10-atoms/fieldset/README.md
+++ b/src/components/10-atoms/fieldset/README.md
@@ -8,6 +8,8 @@ By default, the element children's layout direction is vertical.
 Vertical direction is typically used to used to ensure correct layout for a group of &lt;axa-checkbox&gt; or non-button
 &lt;axa-radio&gt; elements.
 
+_Note: This component only styles its immediate children! For best results, avoid extra &lt;div&gt; wrappers or similar around children components._
+
 ## Usage
 
 **Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).

--- a/src/components/10-atoms/fieldset/index.scss
+++ b/src/components/10-atoms/fieldset/index.scss
@@ -15,7 +15,7 @@ axa-fieldset {
     flex-wrap: wrap;
     margin-top: -$fieldset-vertical-margin;
 
-    > *:not(:last-child):not([nogap]) {
+    > *:not([nogap]) {
       margin-right: $fieldset-horizontal-margin;
     }
 

--- a/src/components/10-atoms/fieldset/index.scss
+++ b/src/components/10-atoms/fieldset/index.scss
@@ -19,6 +19,10 @@ axa-fieldset {
       margin-right: $fieldset-horizontal-margin;
     }
 
+    > *[nogap]:not(:first-child) {
+      margin-left: -2px;
+    }
+
     > * {
       margin-top: $fieldset-vertical-margin;
     }

--- a/src/components/10-atoms/radio/index.js
+++ b/src/components/10-atoms/radio/index.js
@@ -98,6 +98,8 @@ class AXARadio extends NoShadowDOM {
       // ... and select ourselves
       this.checked = true; // causes re-render
 
+      // prevent bubbling
+      event.stopPropagation();
       // fire a custom 'change' event on the component itself
       fireCustomEvent('change', { checked: isChecked, value, name }, this);
       return;

--- a/src/components/10-atoms/radio/index.js
+++ b/src/components/10-atoms/radio/index.js
@@ -162,7 +162,7 @@ class AXARadio extends NoShadowDOM {
     this.state.isControlled = isControlled && isReact;
 
     return html`
-      <label class="a-radio__wrapper">
+      <label class="a-radio__wrapper js-radio__wrapper">
         <input
           id="${refId}"
           class="a-radio__input"
@@ -172,8 +172,8 @@ class AXARadio extends NoShadowDOM {
           value="${value}"
           ?disabled="${disabled}"
           @change="${this.handleChange}"
-          @focus="${this.onFocus}"
-          @blur="${this.onBlur}"
+          @focus="${this.handleFocus}"
+          @blur="${this.handleBlur}"
         />
         ${button
           ? html``
@@ -188,6 +188,7 @@ class AXARadio extends NoShadowDOM {
 
   firstUpdated() {
     this.input = this.querySelector('input');
+    this.wrapper = this.querySelector('.js-radio__wrapper');
     const { name, button, noAutoWidth } = this;
     const ourButton = this.querySelector('.a-radio__content');
     radioButtonGroup[name] = radioButtonGroup[name] || new Set();
@@ -240,6 +241,16 @@ class AXARadio extends NoShadowDOM {
     if (radioButtonGroup[name].size === 0) {
       delete radioButtonGroup[name]; // help GC
     }
+  }
+
+  handleFocus(e) {
+    this.wrapper.classList.add('focus');
+    this.onFocus(e);
+  }
+
+  handleBlur(e) {
+    this.wrapper.classList.remove('focus');
+    this.onBlur(e);
   }
 }
 

--- a/src/components/10-atoms/radio/index.js
+++ b/src/components/10-atoms/radio/index.js
@@ -46,6 +46,10 @@ class AXARadio extends NoShadowDOM {
           },
         },
       },
+      focus: {
+        type: Boolean,
+        reflect: true,
+      },
       isReact: { type: Boolean },
     };
   }
@@ -135,6 +139,7 @@ class AXARadio extends NoShadowDOM {
     this.disabled = false;
     this.button = false;
     this.noGap = false;
+    this.focus = false;
     this.isReact = false;
     this.onFocus = () => {};
     this.onBlur = () => {};
@@ -197,7 +202,8 @@ class AXARadio extends NoShadowDOM {
     radioButtonGroup[name].add(ourButton);
 
     if (button) {
-      setTimeout(() => {
+      // give DOM some time to paint before measuring width
+      window.requestAnimationFrame(() => {
         const { width: labelTextWidth } = this.querySelector(
           '.a-radio__content'
         ).getBoundingClientRect();
@@ -206,12 +212,12 @@ class AXARadio extends NoShadowDOM {
         const width = noAutoWidth ? labelTextWidth : maxWidth[name];
         radioButtonGroup[name].forEach(radioButton => {
           // special case 'noAutoWidth' only impose minWidth on ourselves
-          // (suppresses length changes .a.k.a 'punping effect' between
+          // (suppresses length changes .a.k.a 'pumping effect' between
           // selected/unselected state due to font-weight changes)
           if (noAutoWidth && radioButton !== ourButton) return;
           radioButton.style.minWidth = `${width + WIDTH_SLACK}px`;
         });
-      }, /* give DOM some time to paint before measuring width */ 1);
+      });
     }
   }
 
@@ -246,12 +252,12 @@ class AXARadio extends NoShadowDOM {
   }
 
   handleFocus(e) {
-    this.wrapper.classList.add('focus');
+    this.focus = true;
     this.onFocus(e);
   }
 
   handleBlur(e) {
-    this.wrapper.classList.remove('focus');
+    this.focus = false;
     this.onBlur(e);
   }
 }

--- a/src/components/10-atoms/radio/index.scss
+++ b/src/components/10-atoms/radio/index.scss
@@ -2,6 +2,12 @@ axa-radio {
   @include typo(primary, default);
   display: table;
   flex: none;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+
+  &[focus] {
+    border-color: $color-axa-blue;
+  }
 
   *, *::after, *::before {
     box-sizing: border-box;
@@ -101,10 +107,6 @@ axa-radio {
       padding: 0 20px;
       cursor: pointer;
       width: inherit;
-
-      &.focus {
-        border: 2px solid $color-axa-blue;
-      }
 
       &:hover {
         border-color: $color-axa-blue;

--- a/src/components/10-atoms/radio/index.scss
+++ b/src/components/10-atoms/radio/index.scss
@@ -102,6 +102,10 @@ axa-radio {
       cursor: pointer;
       width: inherit;
 
+      &.focus {
+        border: 2px solid $color-axa-blue;
+      }
+
       &:hover {
         border-color: $color-axa-blue;
         color: $color-axa-blue;

--- a/src/components/10-atoms/radio/react/DemoRadioButtonReact.jsx
+++ b/src/components/10-atoms/radio/react/DemoRadioButtonReact.jsx
@@ -84,6 +84,7 @@ const DemoRadiobuttonsControlled = () => {
           onBlur={handleRadioButtonBlur(1)}
           onChange={handleRadioButtonChange}
           button={button}
+          noGap
         />
       </AXAFieldset>
       <div

--- a/src/components/10-atoms/radio/story.js
+++ b/src/components/10-atoms/radio/story.js
@@ -54,7 +54,7 @@ storiesOf('Atoms/Radio', module)
     () => `
   <axa-fieldset horizontal>
     <axa-radio button nogap name="insurance" label="No, I'm already insured"></axa-radio>
-    <axa-radio button name="insurance" label="Yes, take out insurance" checked></axa-radio>
+    <axa-radio button nogap name="insurance" label="Yes, take out insurance" checked></axa-radio>
   </axa-fieldset>`
   )
   .add(


### PR DESCRIPTION
Fixes #1274.
Fixes #1276.

Prevents undesired width changes upon receiving or losing focus.

Prevents double onchange events.

Removes magic timing constant by moving autowidth measurement to happen under requestAnimationFrame.