### PR TITLE
Feature/Update release manual CONTRIBUTION.md

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -120,6 +120,6 @@ storiesOf('Molecules/Top content bar', module)
   - `npx lerna clean`
   - `rm -rf node_modules`
 - Run `npm install`
-- Run `npm run release` or `npm run prerelease`
-- If you need to release after a alpha release on the same branch without changes: `npm i && npm run test && npx lerna version && npx lerna publish from-package`
+- ~~Run `npm run release` or `npm run prerelease`~~
+- Run `npm run test && npx lerna version && npx lerna publish from-package`
 - Lerna is going to ask you how to update the changed packages. Follow the instructions and keep in mind the semver rules: https://semver.org/


### PR DESCRIPTION
cross out  `npm run release` and `npm run prerelease`, because these commands have to be updated