### PR TITLE
Improve deployment notifier script by adding slash at the end of link

### DIFF
--- a/scripts/branch-deployment-notifier.sh
+++ b/scripts/branch-deployment-notifier.sh
@@ -11,6 +11,6 @@
 # source branch that we would be interested in.
 [[ $PR_SOURCE_BRANCH_NAME != *"$"* ]] && BRANCH_NAME="$PR_SOURCE_BRANCH_NAME" || BRANCH_NAME="$SOURCE_BRANCH_NAME"
 
-text="$BRANCH_NAME was deployed here: https://axa-ch.github.io/plib-feature/$BRANCH_NAME"
+text="$BRANCH_NAME was deployed here: https://axa-ch.github.io/plib-feature/$BRANCH_NAME/"
 
 curl -X POST -H "Content-type: application/json;charset=UTF-8" -H "Authorization: Bearer $SLACK_TOKEN" -d "{\"channel\":\"#plib-deployments\", \"text\": \"$text\", \"username\": \"Donald Duck\"}" https://slack.com/api/chat.postMessage


### PR DESCRIPTION
The old link that was posted to slack didn't have a `/` at the end.