### PR TITLE
Feature/cleanup tbd

### DIFF
--- a/scripts/create-a-m-o/functions.js
+++ b/scripts/create-a-m-o/functions.js
@@ -67,6 +67,7 @@ const createFiles = (store, a, m, o, done) => () => {
   templateJson.name = `@axa-ch/${fileName}`;
   templateJson.version = '0.0.0-beta.0';
   templateJson.homepage = `https://github.com/axa-ch/patterns-library/tree/develop/src/components/${folderMap[type]}/${fileName}#readme`;
+  templateJson.description = `The ${fileName} component for the AXA Pattern Library`;
 
   fs.writeFileSync(
     `${BASE_FOLDER}/package.json`,

--- a/scripts/create-a-m-o/templates/template-package.json
+++ b/scripts/create-a-m-o/templates/template-package.json
@@ -1,7 +1,7 @@
 {
   "name": "__",
   "version": "__",
-  "description": "> TODO: description",
+  "description": "The __ component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "__",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/00-materials/package.json
+++ b/src/components/00-materials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/materials",
   "version": "1.8.4",
-  "description": "Materials like typography, colors, grid, layout, icons...",
+  "description": "The AXA materials component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/00-materials/#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/00-materials/package.json
+++ b/src/components/00-materials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/materials",
   "version": "1.8.4",
-  "description": "The AXA materials component",
+  "description": "The materials component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/00-materials/#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/05-utils/polyfill/package.json
+++ b/src/components/05-utils/polyfill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/patterns-library-polyfill",
   "version": "1.4.19",
-  "description": "Polyfills for IE 11 and WCs in use in the plib",
+  "description": "The AXA polyfill component (Pattern Library - IE Support)",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/05-utils/polyfill/package.json
+++ b/src/components/05-utils/polyfill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/patterns-library-polyfill",
   "version": "1.4.19",
-  "description": "The AXA polyfill component (Pattern Library - IE Support)",
+  "description": "The polyfill component for the AXA Pattern Library (IE Support)",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/button-link/package.json
+++ b/src/components/10-atoms/button-link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/button-link",
   "version": "2.1.7",
-  "description": "The AXA Button Link component",
+  "description": "The button-link component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/button#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/button/package.json
+++ b/src/components/10-atoms/button/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/button",
   "version": "2.0.9",
-  "description": "The AXA Button component",
+  "description": "The button component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/button#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/carousel/package.json
+++ b/src/components/10-atoms/carousel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/carousel",
   "version": "1.0.2",
-  "description": "Every child is rendered as a slide. Only one child is visible at one time.",
+  "description": "The AXA carousel component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/carousel#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/carousel/package.json
+++ b/src/components/10-atoms/carousel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/carousel",
   "version": "1.0.2",
-  "description": "The AXA carousel component",
+  "description": "The carousel component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/carousel#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/checkbox/package.json
+++ b/src/components/10-atoms/checkbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/checkbox",
   "version": "1.1.13",
-  "description": "The AXA Checkbox component",
+  "description": "The checkbox component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/checkbox#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/fieldset/package.json
+++ b/src/components/10-atoms/fieldset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/fieldset",
   "version": "1.2.2",
-  "description": "The AXA Fieldset component",
+  "description": "The fieldset component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/fieldset#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/icon/package.json
+++ b/src/components/10-atoms/icon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/icon",
   "version": "1.2.20",
-  "description": "The AXA Icon component",
+  "description": "The icon component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/icon#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/input-file/package.json
+++ b/src/components/10-atoms/input-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/input-file",
   "version": "0.0.19",
-  "description": "The AXA Input File component",
+  "description": "The input-file component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/input-file#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/input-text/package.json
+++ b/src/components/10-atoms/input-text/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/input-text",
   "version": "2.4.3",
-  "description": "The AXA Input Text component",
+  "description": "The input-text component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/input-text#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/link/package.json
+++ b/src/components/10-atoms/link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/link",
   "version": "1.3.23",
-  "description": "The axa link for internal and external page navigation.",
+  "description": "The AXA link component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/link/README.md",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/link/package.json
+++ b/src/components/10-atoms/link/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/link",
   "version": "1.3.23",
-  "description": "The AXA link component",
+  "description": "The link component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/link/README.md",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/radio/package.json
+++ b/src/components/10-atoms/radio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/radio",
   "version": "1.1.6",
-  "description": "The AXA Radio-Button component",
+  "description": "The radio-button component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/radio#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/text/package.json
+++ b/src/components/10-atoms/text/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/text",
   "version": "1.0.10",
-  "description": "The AXA text component",
+  "description": "The text component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/text#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/text/package.json
+++ b/src/components/10-atoms/text/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/text",
   "version": "1.0.10",
-  "description": "Allows you to control all the possible axa text styles by a component",
+  "description": "The AXA text component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/text#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/textarea/package.json
+++ b/src/components/10-atoms/textarea/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/textarea",
   "version": "1.5.4",
-  "description": "The AXA Textarea component",
+  "description": "The textarea component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/textarea#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/title-primary/package.json
+++ b/src/components/10-atoms/title-primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/title-primary",
   "version": "0.0.0-beta.0",
-  "description": "Shows you an AXA conform title. A predefined size can be changed by setting a variant.",
+  "description": "The AXA title-primary component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/title-primary#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/title-primary/package.json
+++ b/src/components/10-atoms/title-primary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/title-primary",
   "version": "0.0.0-beta.0",
-  "description": "The AXA title-primary component",
+  "description": "The title-primary component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/title-primary#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/title-secondary/package.json
+++ b/src/components/10-atoms/title-secondary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/title-secondary",
   "version": "0.0.0-beta.0",
-  "description": "Shows you an AXA conform title. A predefined size can be changed by setting a variant.",
+  "description": "The AXA title-secondary component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/title-secondary#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/10-atoms/title-secondary/package.json
+++ b/src/components/10-atoms/title-secondary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/title-secondary",
   "version": "0.0.0-beta.0",
-  "description": "The AXA title-secondary component",
+  "description": "The title-secondary component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/title-secondary#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/cookie-disclaimer/package.json
+++ b/src/components/20-molecules/cookie-disclaimer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/cookie-disclaimer",
   "version": "0.0.13",
-  "description": "Shows a message that explains the conditions of the Data Protection Act and let you click and accept",
+  "description": "The AXA cookie-disclaimer component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/cookie-disclaimer#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/cookie-disclaimer/package.json
+++ b/src/components/20-molecules/cookie-disclaimer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/cookie-disclaimer",
   "version": "0.0.13",
-  "description": "The AXA cookie-disclaimer component",
+  "description": "The cookie-disclaimer component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/cookie-disclaimer#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/datepicker/package.json
+++ b/src/components/20-molecules/datepicker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/datepicker",
   "version": "3.1.5",
-  "description": "The AXA datepicker component",
+  "description": "The datepicker component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/20-molecules/datepicker#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/datepicker/package.json
+++ b/src/components/20-molecules/datepicker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/datepicker",
   "version": "3.1.5",
-  "description": "The datepicker for the AXA patterns library",
+  "description": "The AXA datepicker component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/20-molecules/datepicker#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/dropdown/package.json
+++ b/src/components/20-molecules/dropdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/dropdown",
   "version": "3.1.5",
-  "description": "The AXA dropdown component",
+  "description": "The dropdown component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/20-molecules/dropdown#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/dropdown/package.json
+++ b/src/components/20-molecules/dropdown/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/dropdown",
   "version": "3.1.5",
-  "description": "The dropdown for the AXA patterns library",
+  "description": "The AXA dropdown component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/20-molecules/dropdown#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/file-upload/package.json
+++ b/src/components/20-molecules/file-upload/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/file-upload",
   "version": "1.0.5",
-  "description": "The AXA file-upload component",
+  "description": "The file-upload component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/file-upload#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/file-upload/package.json
+++ b/src/components/20-molecules/file-upload/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/file-upload",
   "version": "1.0.5",
-  "description": "The file-upload for the AXA patterns library",
+  "description": "The AXA file-upload component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/file-upload#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/footer-small/package.json
+++ b/src/components/20-molecules/footer-small/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/footer-small",
   "version": "3.0.2",
-  "description": "The AXA footer-small component",
+  "description": "The footer-small component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/20-molecules/footer-small/README.md",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/footer-small/package.json
+++ b/src/components/20-molecules/footer-small/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/footer-small",
   "version": "3.0.2",
-  "description": "The small version of the axa footer.",
+  "description": "The AXA footer-small component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/blob/develop/src/components/20-molecules/footer-small/README.md",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/policy-features/package.json
+++ b/src/components/20-molecules/policy-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/policy-features",
   "version": "1.0.6",
-  "description": "Displays as much policy features as you want.",
+  "description": "The AXA policy-features component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/policy-features#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/policy-features/package.json
+++ b/src/components/20-molecules/policy-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/policy-features",
   "version": "1.0.6",
-  "description": "The AXA policy-features component",
+  "description": "The policy-features component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/policy-features#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/popup/package.json
+++ b/src/components/20-molecules/popup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/popup",
   "version": "1.1.4",
-  "description": "The Popup Component with button and content",
+  "description": "The AXA popup component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/popup#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/popup/package.json
+++ b/src/components/20-molecules/popup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/popup",
   "version": "1.1.4",
-  "description": "The AXA popup component",
+  "description": "The popup component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/popup#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/top-content-bar/package.json
+++ b/src/components/20-molecules/top-content-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/top-content-bar",
   "version": "1.0.20",
-  "description": "Used as top of the page Warning or info box that can show text and have a call to action button",
+  "description": "The AXA top-content-bar component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/top-content-bar#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/20-molecules/top-content-bar/package.json
+++ b/src/components/20-molecules/top-content-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/top-content-bar",
   "version": "1.0.20",
-  "description": "The AXA top-content-bar component",
+  "description": "The top-content-bar component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/20-molecules/top-content-bar#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/commercial-hero-banner/package.json
+++ b/src/components/30-organisms/commercial-hero-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/commercial-hero-banner",
   "version": "1.1.10",
-  "description": "The AXA commercial-hero-banner component",
+  "description": "The commercial-hero-banner component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/commercial-hero-banner#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/commercial-hero-banner/package.json
+++ b/src/components/30-organisms/commercial-hero-banner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/commercial-hero-banner",
   "version": "1.1.10",
-  "description": "The component to really set something into focus.",
+  "description": "The AXA commercial-hero-banner component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/commercial-hero-banner#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/container/package.json
+++ b/src/components/30-organisms/container/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/container",
   "version": "1.0.16",
-  "description": "> TODO: description",
+  "description": "The AXA container component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/container#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/container/package.json
+++ b/src/components/30-organisms/container/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/container",
   "version": "1.0.16",
-  "description": "The AXA container component",
+  "description": "The container component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/container#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/footer/package.json
+++ b/src/components/30-organisms/footer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/footer",
   "version": "2.0.11",
-  "description": "The big version of the footer.",
+  "description": "The AXA footer component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/footer#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/footer/package.json
+++ b/src/components/30-organisms/footer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/footer",
   "version": "2.0.11",
-  "description": "The AXA footer component",
+  "description": "The footer component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/footer#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/table-sortable/package.json
+++ b/src/components/30-organisms/table-sortable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/table-sortable",
   "version": "1.3.2",
-  "description": "Table with sorting functionalities, having a model as interface",
+  "description": "The AXA table-sortable component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/table-sortable#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/table-sortable/package.json
+++ b/src/components/30-organisms/table-sortable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/table-sortable",
   "version": "1.3.2",
-  "description": "The AXA table-sortable component",
+  "description": "The table-sortable component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/table-sortable#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/table/package.json
+++ b/src/components/30-organisms/table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/table",
   "version": "1.2.11",
-  "description": "The AXA table component",
+  "description": "The table component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/table#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/table/package.json
+++ b/src/components/30-organisms/table/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/table",
   "version": "1.2.11",
-  "description": "Basic pure UI Table",
+  "description": "The AXA table component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/table#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/testimonials/package.json
+++ b/src/components/30-organisms/testimonials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/testimonials",
   "version": "1.0.2",
-  "description": "Shows several information in a carousel or inline and sets title and subtitle above it.",
+  "description": "The AXA testimonials component",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/testimonials#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",

--- a/src/components/30-organisms/testimonials/package.json
+++ b/src/components/30-organisms/testimonials/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axa-ch/testimonials",
   "version": "1.0.2",
-  "description": "The AXA testimonials component",
+  "description": "The testimonials component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/30-organisms/testimonials#readme",
   "license": "Copyright 2019 AXA Versicherungen AG",


### PR DESCRIPTION
Fixes #1421

- We have no longer a "todo" in the package.json scaffolded file in the description, which was checked in like this or with a "tbd" mark.
- Now all descriptions have the same structure.
- The polyfill still has the hint, that it is for IE support.