### PR TITLE
Bugfix/carousel closing tag

### DIFF
--- a/src/components/05-utils/polyfill/package-lock.json
+++ b/src/components/05-utils/polyfill/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@axa-ch/patterns-library-polyfill",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/components/10-atoms/carousel/story.js
+++ b/src/components/10-atoms/carousel/story.js
@@ -23,25 +23,26 @@ storyAXACarousel.add('Carousel', () => {
 
   const wrapper = document.createElement('div');
   const template = html`
-<div id="colorWrapper" style="background: lightcoral; color: white;">
-    <axa-carousel
-    autorotatetime="${autorotatetime}"
-    ?autorotatedisabled="${autorotatedisabled}"
-    ?keysenabled="${keysenabled}"
-    >
-      <span>
-        Very helpful once I got through to the correct person but I was
-        constantly being transferred from person to person, in the end I called
-        into my local axa once in the city and got sorted in 10 minutes after 3
-        weeks of phone calls.
-      </span>
-      <span>
-      Some two million customers trust AXA. They rely on AXA's experience and advice in personal, property, liability and life insurance as well as healthcare and occupational benefits insurance. AXA is Switzerland's leading insurance company and has an ambitious vision: to create freedoms for its customers over and above financial protection and to make a care-free life possible – using innovative products and services, and simple, digital processes. Our 4,400 employees and 2,800 colleagues in 370 general agencies and agencies dedicate themselves to this vision day in, day out.
-      <br><br>
-      To be the top choice for all stakeholder groups: That's the goal of the AXA Group headquartered in Paris. To reach this goal, we focus our efforts every day on satisfying the needs of our customers. Reliable interaction with people and the environment form the basis for the trust accorded to the AXA Group day after day by our customers, employees, shareholders, suppliers and society. The AXA Group helps its customers lead as carefree a life as possible. It protects them and their families, their property, and their assets against risks.
-      </span>
-      <span>This is a small text.</span>
-   </div> 
+    <div id="colorWrapper" style="background: lightcoral; color: white;">
+        <axa-carousel
+        autorotatetime="${autorotatetime}"
+        ?autorotatedisabled="${autorotatedisabled}"
+        ?keysenabled="${keysenabled}"
+        >
+          <span>
+            Very helpful once I got through to the correct person but I was
+            constantly being transferred from person to person, in the end I called
+            into my local axa once in the city and got sorted in 10 minutes after 3
+            weeks of phone calls.
+          </span>
+          <span>
+          Some two million customers trust AXA. They rely on AXA's experience and advice in personal, property, liability and life insurance as well as healthcare and occupational benefits insurance. AXA is Switzerland's leading insurance company and has an ambitious vision: to create freedoms for its customers over and above financial protection and to make a care-free life possible – using innovative products and services, and simple, digital processes. Our 4,400 employees and 2,800 colleagues in 370 general agencies and agencies dedicate themselves to this vision day in, day out.
+          <br><br>
+          To be the top choice for all stakeholder groups: That's the goal of the AXA Group headquartered in Paris. To reach this goal, we focus our efforts every day on satisfying the needs of our customers. Reliable interaction with people and the environment form the basis for the trust accorded to the AXA Group day after day by our customers, employees, shareholders, suppliers and society. The AXA Group helps its customers lead as carefree a life as possible. It protects them and their families, their property, and their assets against risks.
+          </span>
+          <span>This is a small text.</span>
+        </axa-carousel>
+    </div> 
   `;
 
   render(template, wrapper);


### PR DESCRIPTION
The closing tag of `axa-carousel` was missing in a story.

# Done is when (DoD):
- [ ] I have added UI/Unit tests for my changes
- [ ] Design has been reviewed with (here name of reviewer)
- [x] Old tests and eslint rule are not broken
- [ ] My changes are well documented in the readme and showcased in the stories 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**)
- [ ] I have made corresponding changes to the documentation
