### PR TITLE
Fix cursor problem in safari

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -139,6 +139,7 @@
     "MutationObserver": true,
     "customElements": true,
     "document": true,
+    "navigator": true,
     "window": true,
     "ENV": true,
     "PROD": true,

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -194,15 +194,10 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
   };
 
   _isSafari() {
-    if (navigator && navigator.vendor && navigator.vendor.includes) {
-      console.log(
-        'navigator vendor: ',
-        navigator.vendor.includes('Apple Computer')
-      );
-    }
     return (
       navigator &&
       navigator.vendor &&
+      navigator.vendor.includes &&
       navigator.vendor.includes('Apple Computer')
     );
   }

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -252,8 +252,10 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
       <div class="a-input-text__input-wrapper">
         <div class="a-input-text__input-elements">
         ${
-          // Safari has a jumping cursor bug, which is fixed with this approach.
-          // Downside: After a user manipulated an input field, it cannot be visibly changed again by javascript.
+          // On Safari, the caret (cursor) jumps to the end of the value, which
+          // is fixed with this approach.
+          // Downside: After a user manipulated the value manually, it cannot
+          // be updated anymore by javascript (safari only).
           window.safari
             ? html`
                 <input

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -194,16 +194,16 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
   };
 
   _isSafari() {
-    if (navigator && navigator.vendor && navigator.vendor.contains) {
+    if (navigator && navigator.vendor && navigator.vendor.includes) {
       console.log(
         'navigator vendor: ',
-        navigator.vendor.contains('Apple Computer')
+        navigator.vendor.includes('Apple Computer')
       );
     }
     return (
       navigator &&
       navigator.vendor &&
-      navigator.vendor.contains('Apple Computer')
+      navigator.vendor.includes('Apple Computer')
     );
   }
 

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -256,7 +256,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
           // is fixed with this approach.
           // Downside: After a user manipulated the value manually, it cannot
           // be updated anymore by javascript (safari only).
-          window.safari
+          (window || global).safari
             ? html`
                 <input
                   id="${refId}"

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -257,7 +257,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
             class="${classMap(inputClasses)}"
             autocomplete="off"
             name="${name}"
-            .value="${value}"
+            value="${value}"
             placeholder="${placeholder}"
             aria-required="${required}"
             maxlength="${maxLength}"

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -251,21 +251,43 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
         `}
       <div class="a-input-text__input-wrapper">
         <div class="a-input-text__input-elements">
-          <input
-            id="${refId}"
-            type="${type}"
-            class="${classMap(inputClasses)}"
-            autocomplete="off"
-            name="${name}"
-            value="${value}"
-            placeholder="${placeholder}"
-            aria-required="${required}"
-            maxlength="${maxLength}"
-            ?disabled="${disabled}"
-            @input="${this.handleInput}"
-            @focus="${this.handleFocus}"
-            @blur="${this.handleBlur}"
-          />
+        ${
+          window.safari
+            ? html`
+                <input
+                  id="${refId}"
+                  type="${type}"
+                  class="${classMap(inputClasses)}"
+                  autocomplete="off"
+                  name="${name}"
+                  value="${value}"
+                  placeholder="${placeholder}"
+                  aria-required="${required}"
+                  maxlength="${maxLength}"
+                  ?disabled="${disabled}"
+                  @input="${this.handleInput}"
+                  @focus="${this.handleFocus}"
+                  @blur="${this.handleBlur}"
+                />
+              `
+            : html`
+                <input
+                  id="${refId}"
+                  type="${type}"
+                  class="${classMap(inputClasses)}"
+                  autocomplete="off"
+                  name="${name}"
+                  .value="${value}"
+                  placeholder="${placeholder}"
+                  aria-required="${required}"
+                  maxlength="${maxLength}"
+                  ?disabled="${disabled}"
+                  @input="${this.handleInput}"
+                  @focus="${this.handleFocus}"
+                  @blur="${this.handleBlur}"
+                />
+              `
+        }
           ${
             this.showCheckMark
               ? html`

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /* eslint-disable import/no-extraneous-dependencies */
 import { html } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -251,6 +251,9 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
         `}
       <div class="a-input-text__input-wrapper">
         <div class="a-input-text__input-elements">
+        <p>
+          Window.safari: ${(window || global).safari}
+        </p>
         ${
           // On Safari, the caret (cursor) jumps to the end of the value, which
           // is fixed with this approach.

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -22,7 +22,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
       label: { type: String },
       required: { type: Boolean },
       placeholder: { type: String },
-      value: { type: String, reflect: true, defaultValue: undefined }, // proper default for controlled-mode under React
+      value: { type: String, defaultValue: undefined }, // proper default for controlled-mode under React
       defaultValue: { type: String },
       type: { type: String, defaultValue: 'text' },
       error: { type: String },

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -272,7 +272,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
           // is fixed with this approach.
           // Downside: After a user manipulated the value manually, it cannot
           // be updated anymore by javascript (safari only).
-          _isSafari()
+          this._isSafari()
             ? html`
                 <input
                   id="${refId}"

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /* eslint-disable import/no-extraneous-dependencies */
 import { html } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
@@ -192,6 +193,18 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
     }
   };
 
+  _isSafari() {
+    console.log(
+      'navigator vendor: ',
+      navigator.vendor.contains('Apple Computer')
+    );
+    return (
+      navigator &&
+      navigator.vendor &&
+      navigator.vendor.contains('Apple Computer')
+    );
+  }
+
   firstUpdated() {
     const { defaultValue, isReact, value } = this;
 
@@ -259,7 +272,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
           // is fixed with this approach.
           // Downside: After a user manipulated the value manually, it cannot
           // be updated anymore by javascript (safari only).
-          (window || global).safari
+          _isSafari()
             ? html`
                 <input
                   id="${refId}"

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -194,10 +194,12 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
   };
 
   _isSafari() {
-    console.log(
-      'navigator vendor: ',
-      navigator.vendor.contains('Apple Computer')
-    );
+    if (navigator && navigator.vendor && navigator.vendor.contains) {
+      console.log(
+        'navigator vendor: ',
+        navigator.vendor.contains('Apple Computer')
+      );
+    }
     return (
       navigator &&
       navigator.vendor &&
@@ -265,7 +267,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
       <div class="a-input-text__input-wrapper">
         <div class="a-input-text__input-elements">
         <p>
-          Window.safari: ${(window || global).safari}
+          Window.safari: ${this._isSafari()}
         </p>
         ${
           // On Safari, the caret (cursor) jumps to the end of the value, which

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -261,9 +261,6 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
         `}
       <div class="a-input-text__input-wrapper">
         <div class="a-input-text__input-elements">
-        <p>
-          Window.safari: ${this._isSafari()}
-        </p>
         ${
           // On Safari, the caret (cursor) jumps to the end of the value, which
           // is fixed with this approach.

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -22,7 +22,7 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
       label: { type: String },
       required: { type: Boolean },
       placeholder: { type: String },
-      value: { type: String, defaultValue: undefined }, // proper default for controlled-mode under React
+      value: { type: String, reflect: true, defaultValue: undefined }, // proper default for controlled-mode under React
       defaultValue: { type: String },
       type: { type: String, defaultValue: 'text' },
       error: { type: String },
@@ -252,6 +252,8 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
       <div class="a-input-text__input-wrapper">
         <div class="a-input-text__input-elements">
         ${
+          // Safari has a jumping cursor bug, which is fixed with this approach.
+          // Downside: After a user manipulated an input field, it cannot be visibly changed again by javascript.
           window.safari
             ? html`
                 <input


### PR DESCRIPTION
Hi Markus

This fixes the bug on safari, that when you write into a text field, and move the cursor back to insert an additional word somewhere in between, the cursor would jump to the end again instead of staying at the location.

Reproduce:
- Open Safari
- Open an AEM form (for instance: https://acc.axa.ch/en/formulare/ikrk.html)
- Write `Hello, my name is Robert Robinho`
- Move the cursor to the left and correct the sentence to `Hello, my name is NOT Robert Robinho`

Since you introduced this (which makes sense) to fix another bug and nobody here remembers which one that was, I will await your opinion on this.