### PR TITLE
[Needs designer approval] Improve breakpoints to fix mobile design

### DIFF
--- a/src/components/00-materials/styles/30-layout.scss
+++ b/src/components/00-materials/styles/30-layout.scss
@@ -18,8 +18,12 @@ $mediaquery-lg: $breakpoint-large ($breakpoint-xlarge - 1px); // (min-width: 992
 $mediaquery-xlg-up: $breakpoint-xlarge; // (min-width: 1200px)
 
 @mixin max-width {
-  max-width: 540px;
+  max-width: 576px;
   margin: auto;
+
+  @include breakpoint($mediaquery-sm-up) {
+    max-width: 540px;
+  }
 
   @include breakpoint($mediaquery-md-up) {
     max-width: 720px;


### PR DESCRIPTION
Fixes #1060

Please have a look at the issue I wrote. I fixed that by keeping max-height at 100% on the mobile view, but decreased it back to 540px for the first breakpoint after "mobile" (small). Check the footer and adapt the sizes of it to check it. As soon as the feature branch deployment happened, I will add the link.

This should get at least one designer-approval.

This is also what the footer in the old pattern library is doing, as you can see here: https://axa-ch.github.io/patterns-library/components/o-footer/index.html

I tested all the components that we use. The design isn't broken anywhere.