### PR TITLE
Avoid findIndex polyfill by internalizing it and rewriting the dropdown implementation

### DIFF
--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -10,6 +10,7 @@ import defineOnce from '../../../utils/define-once';
 import fireCustomEvent from '../../../utils/custom-event';
 import createRefId from '../../../utils/create-ref-id';
 import typecheck from '../../../utils/typecheck';
+import findIndex from '../../../utils/find-index';
 
 // module constants
 const ARROW_ICON = svg([ExpandSvg]);
@@ -238,7 +239,7 @@ class AXADropdown extends NoShadowDOM {
 
   findByValue(value, indexOnly) {
     const { items } = this;
-    const itemIndex = items.findIndex(({ selected, value: selectedValue }) =>
+    const itemIndex = findIndex(items, ({ selected, value: selectedValue }) =>
       value === null
         ? selected
         : selectedValue === value || selectedValue === parseInt(value, 10)

--- a/src/components/20-molecules/dropdown/react/DemoDropdownReact.jsx
+++ b/src/components/20-molecules/dropdown/react/DemoDropdownReact.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import AXADropdownReact from './AXADropdownReact';
 import AXACheckboxReact from '../../../10-atoms/checkbox/react/AXACheckboxReact';
+import findIndex from '../../../../utils/find-index';
 
 const DemoDropdown = () => {
   const items = [
@@ -21,7 +22,7 @@ const DemoDropdown = () => {
   const [native, setNative] = useState(false);
 
   const findName = val =>
-    items[items.findIndex(item => item.value === val)].name;
+    items[findIndex(items, item => item.value === val)].name;
 
   const handleChange = event => {
     setValue(frozen ? value : event.target.value);

--- a/src/utils/find-index.js
+++ b/src/utils/find-index.js
@@ -1,0 +1,12 @@
+export default (array, predicate, self = null) => {
+  // for all array elements
+  for (let i = 0, n = array.length; i < n; i++) {
+    // if predicate returns a truthy value when applied to current array element...
+    if (predicate.call(self, array[i], i, array)) {
+      // return its index
+      return i;
+    }
+  }
+  // return failure index
+  return -1;
+};


### PR DESCRIPTION
Fixes #1499.

