### PR TITLE
Bugfix/small dropdown datepicker fixes

### DIFF
--- a/src/components/20-molecules/datepicker/index.scss
+++ b/src/components/20-molecules/datepicker/index.scss
@@ -69,6 +69,12 @@ axa-datepicker {
       fill: $color-prim-gray-dusty;
     }
   }
+
+  &[invaliddatetext=""] {
+    .m-datepicker__error {
+      display: none;
+    }
+  }
 }
 
 .m-datepicker {

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -238,7 +238,7 @@ class AXADropdown extends NoShadowDOM {
   }
 
   findByValue(value, indexOnly) {
-    const { items } = this;
+    const { items = [] } = this;
     const itemIndex = findIndex(items, ({ selected, value: selectedValue }) =>
       value === null
         ? selected


### PR DESCRIPTION
- Robustify axa-dropdown against missing .items
- Suppress axa-datepicker's own error message display if invaliddatetext is empty
