### PR TITLE
some browsers don't have the uk locale. defensive is to use just en

### DIFF
--- a/src/components/20-molecules/datepicker/utils/date.js
+++ b/src/components/20-molecules/datepicker/utils/date.js
@@ -32,7 +32,7 @@ const addLeadingZeroes = (rawNumber, numDigits) => {
   return `${leadingZeroesString}${number}`;
 };
 
-const parseLocalisedDateIfValid = (locale = 'en-UK', inputValue = '') => {
+const parseLocalisedDateIfValid = (locale = 'en', inputValue = '') => {
   const BLUEPRINT_YEAR = 2017;
   const BLUEPRINT_MONTH = 10; // 0-based index
   const BLUEPRINT_DAY = 23;


### PR DESCRIPTION
<img width="457" alt="Screenshot 2019-11-12 at 11 16 36" src="https://user-images.githubusercontent.com/275235/68662855-f59be500-053d-11ea-8632-085b923c5757.png">

https://en.wikipedia.org/wiki/Locale_(computer_software)