### PR TITLE
Changelog checkbox incorrect

### DIFF
--- a/src/components/10-atoms/checkbox/CHANGELOG.md
+++ b/src/components/10-atoms/checkbox/CHANGELOG.md
@@ -2,19 +2,16 @@
 
 ### Migration to version 2
 
-The implementation of the wrapper to make a component React-ready has
+- The implementation of the wrapper to make a component React-ready has
 fundamentally changed. In particular, unknown Boolean- or
 string-valued properties are now accepted and converted to HTML
 attributes. E.g. `data-seleniumid="my-id"` is now supported.
-
-### Version 1.1.15
-
-- Add `refId` [#1528](https://github.com/axa-ch/patterns-library/pull/1528)
-- Prevent doubled labels when `label` attribute isn't set [#1535](https://github.com/axa-ch/patterns-library/pull/1535)
-- Allow setting a label through children of the component
-All defined attributes attached to a component *before* component
+- All defined attributes attached to a component *before* component
 construction time are now taken into account. Conversely, all undefined
 component attributes are initialized with type-appropriate default
 values at this time. This may amount to a breaking change if the
 component consumer had previously assumed undefined or uninitialized
 behaviour.
+- Add `refId` [#1528](https://github.com/axa-ch/patterns-library/pull/1528)
+- Prevent doubled labels when `label` attribute isn't set [#1535](https://github.com/axa-ch/patterns-library/pull/1535)
+- Allow setting a label through children of the component


### PR DESCRIPTION
`All defined att...` and all other bulletpoints belong to version 2.0.0 because a version 1.1.15 doesn't exist

# Done is when (DoD):
- [ ] I have added UI/Unit tests for my changes
- [ ] I added modified component properties to the typescript typings
- [ ] Design has been reviewed with (here name of reviewer)
- [ ] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
- [ ] Old tests and eslint rule are not broken
- [ ] My changes are well documented in the README and showcased in the stories 
- [ ] Tested with IE

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**)
- [ ] I have made/updated the ChangeLog Section in the README 
