### PR TITLE
Bugfix/1555 width

### DIFF
--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -2,9 +2,9 @@
 ## 5.0.0
 * Change behavior of width:
     * **Breaking change:** Removed `auto` - new default is `100%`
-    * Percentage values are set to components css 
-    * Percentage values not set to childs because that make no sense
-    * Numeric values change the components width, no longer takes the whole width it gets from parent.
+    * Percentage values are set to component's inner CSS
+    * Percentage values not set to inner HTML because that makes no sense anymore
+    * Numeric values change the component's width, no longer inherits from parent.
 * Fixed behavior of height
 * Changed appearance from `inline-block` to `inline` to have possibility to arrange other elements next to datepicker
 

--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,8 +1,11 @@
-## [Unreleased]
+
+## 5.0.0
 * Change behavior of width:
+    * **Breaking change:** Removed `auto` - new default is `100%`
     * Percentage values are set to components css 
     * Percentage values not set to childs because that make no sense
     * Numeric values change the components width, no longer takes the whole width it gets from parent.
+* Fixed behavior of height
 
 ## 4.0.1 (Migration to version 4)
 

--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 * Change behavior of width:
-    * Percentage values are set to components css, not set to childs because that make no sense.
+    * Percentage values are set to components css 
+    * Percentage values not set to childs because that make no sense
     * Numeric values change the components width, no longer takes the whole width it gets from parent.
 
 ## 4.0.1 (Migration to version 4)

--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -6,6 +6,7 @@
     * Percentage values not set to childs because that make no sense
     * Numeric values change the components width, no longer takes the whole width it gets from parent.
 * Fixed behavior of height
+* Changed appearance from `inline-block` to `inline` to have possibility to arrange other elements next to datepicker
 
 ## 4.0.1 (Migration to version 4)
 

--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,13 +1,16 @@
-# Changelog
+## [Unreleased]
+* Change behavior of width:
+    * Percentage values are set to components css, not set to childs because that make no sense.
+    * Numeric values change the components width, no longer takes the whole width it gets from parent.
 
-### Migration to version 4
+## 4.0.1 (Migration to version 4)
 
-The implementation of the wrapper to make a component React-ready has
+* The implementation of the wrapper to make a component React-ready has
 fundamentally changed. In particular, unknown Boolean- or
 string-valued properties are now accepted and converted to HTML
 attributes. E.g. `data-seleniumid="my-id"` is now supported.
 
-All defined attributes attached to a component *before* component
+* All defined attributes attached to a component *before* component
 construction time are now taken into account. Conversely, all undefined
 component attributes are initialized with type-appropriate default
 values at this time. This may amount to a breaking change if the

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -141,7 +141,7 @@ The intended use case is to easily convey external validation failure, e.g. when
 
 ### width
 
-String-valued `width` allow to override the intrinsic dimensions of the datepicker. Default is `100%`.
+String-valued `width` allows to override the intrinsic dimensions of the datepicker. Default is `100%`.
 Note maximum of `260px` if you use it inline and minimum of `197px` if you use it as a inputfield.
 
 Allowed values:
@@ -151,7 +151,7 @@ Allowed values:
 
 ### height
 
-String-valued `height` allow to override the intrinsic dimensions of the datepicker. Default is `40`.
+String-valued `height` allows to override the intrinsic dimensions of the datepicker. Default is `40`.
 
 Allowed values:
 

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -143,9 +143,16 @@ The intended use case is to easily convey external validation failure, e.g. when
 
 String-valued `width` allow to override the intrinsic dimensions of the datepicker.
 
+#### Note the maximum width of visible elements:
+
+- 226px as a input field
+- 260px if you use it inline
+
+#### Allowed values:
+
 `auto`: Default. Sets the fully width of parent element.
 `90%`: Sets percentage value of width of parent element.
-`300`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
+`200`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
 
 ### height
 

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -139,13 +139,21 @@ Boolean `invalid`, when set to true, forces showing the error message set with `
 
 The intended use case is to easily convey external validation failure, e.g. when an application decides the entered date is outside a permissible date range.
 
-### width, height
+### width
 
-String-valued `width, height` allow to override the intrinsic dimensions of the datepicker (default: `auto`).
+String-valued `width` allow to override the intrinsic dimensions of the datepicker.
 
-For example, setting `width=100%` makes the datepicker assume its parent's width, whereas `height=45` sets the height of the input field to 45px.
+`auto`: Default. Sets the fully width of parent element.
+`90%`: Sets percentage value of width of parent element.
+`300`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
 
-Note that missing `px` is added to numeric values automatically.
+### height
+
+String-valued `height` allow to override the intrinsic dimensions of the datepicker.
+
+`auto`: Sets the fully height of parent element.
+`90%`: Sets percentage value of height of parent element.
+`300`: Default 40. Sets px value of height of parent element. Note that missing `px` is added to numeric values automatically.
 
 ### label
 

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -142,21 +142,22 @@ The intended use case is to easily convey external validation failure, e.g. when
 ### width
 
 String-valued `width` allows to override the intrinsic dimensions of the datepicker. Default is `100%`.
-Note maximum of `260px` if you use it inline and minimum of `197px` if you use it as a inputfield.
+Note minimum of `260px` if you use it inline and `197px` if you use it as a inputfield.
 
-Allowed values:
+Example values:
 
-* `90%`: Sets percentage value of width of parent element.
-* `200`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
+- `90%`: Sets percentage value of width of parent element.
+- `400`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
 
 ### height
 
 String-valued `height` allows to override the intrinsic dimensions of the datepicker. Default is `40`.
+Note minimum of `40px` if you use it as a inputfield. Note that you can't change height if you use it inline.
 
-Allowed values:
+Example values:
 
-* `90%`: Sets percentage value of height of parent element.
-* `300`: Sets px value of height of parent element. Note that missing `px` is added to numeric values automatically.
+- `90%`: Sets percentage value of height of parent element. Don't forget to set parent's height in this case.
+- `300`: Sets px value of height of parent element. Note that missing `px` is added to numeric values automatically.
 
 ### label
 

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -141,26 +141,22 @@ The intended use case is to easily convey external validation failure, e.g. when
 
 ### width
 
-String-valued `width` allow to override the intrinsic dimensions of the datepicker.
+String-valued `width` allow to override the intrinsic dimensions of the datepicker. Default is `100%`.
+Note maximum of `260px` if you use it inline and minimum of `197px` if you use it as a inputfield.
 
-#### Note the maximum width of visible elements:
+Allowed values:
 
-- 226px as a input field
-- 260px if you use it inline
-
-#### Allowed values:
-
-`auto`: Default. Sets the fully width of parent element.
-`90%`: Sets percentage value of width of parent element.
-`200`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
+* `90%`: Sets percentage value of width of parent element.
+* `200`: Sets px value of width of parent element. Note that missing `px` is added to numeric values automatically.
 
 ### height
 
-String-valued `height` allow to override the intrinsic dimensions of the datepicker.
+String-valued `height` allow to override the intrinsic dimensions of the datepicker. Default is `40`.
 
-`auto`: Sets the fully height of parent element.
-`90%`: Sets percentage value of height of parent element.
-`300`: Default 40. Sets px value of height of parent element. Note that missing `px` is added to numeric values automatically.
+Allowed values:
+
+* `90%`: Sets percentage value of height of parent element.
+* `300`: Sets px value of height of parent element. Note that missing `px` is added to numeric values automatically.
 
 ### label
 

--- a/src/components/20-molecules/datepicker/demo.js
+++ b/src/components/20-molecules/datepicker/demo.js
@@ -24,7 +24,7 @@ storiesOf('Molecules/Datepicker/Demos', module)
 
     const template = html`
       <form id="datepicker-form" @submit="${handleSubmit}">
-        <fieldset>
+        <fieldset width="589">
           <legend>Date</legend>
           <axa-datepicker
             data-test-id="datepicker-forms"

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -129,7 +129,7 @@ class AXADatepicker extends NoShadowDOM {
       invaliddatetext: { type: String, defaultValue: 'Invalid date' },
       error: { type: String, reflect: true },
       height: { type: String, reflect: true, defaultValue: '40' },
-      width: { type: String, reflect: true, defaultValue: 'auto' },
+      width: { type: String, reflect: true, defaultValue: '100%' },
       disabled: { type: Boolean, reflect: true },
       required: { type: Boolean, reflect: true },
       label: { type: String, reflect: true },
@@ -266,7 +266,7 @@ class AXADatepicker extends NoShadowDOM {
 
     this.setMonthAndYearItems(month, year);
 
-    const { width = 'auto', height = '40', error, invalid, style } = this;
+    const { width = '100%', height = '40', error, invalid, style } = this;
 
     const formattedStyle = parameter =>
       `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -266,26 +266,28 @@ class AXADatepicker extends NoShadowDOM {
 
     this.setMonthAndYearItems(month, year);
 
-    const { width = 'auto', height = '40', error, invalid } = this;
-
-    // % on html width attribute not allowed
-    if (width.indexOf('%') > -1) {
-      // TODO: setStyle
-      this.style.width = width;
-    } else {
-      this.style.width = null;
-    }
-    if (height.indexOf('%') > -1) {
-      this.style.height = height;
-    } else {
-      this.style.height = null;
-    }
+    const { width = 'auto', height = '40', error, invalid, style } = this;
 
     const formattedStyle = parameter =>
       `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;
 
-    const formattedWidth = `width:${formattedStyle(width)}`;
-    const formattedHeight = `height:${formattedStyle(height)}`;
+    let formattedWidth = `width:${formattedStyle(width)}`;
+    let formattedHeight = `height:${formattedStyle(height)}`;
+
+    // % on html width or height attribute not allowed, so set it as css attribute
+    if (width.indexOf('%') > -1) {
+      style.width = width;
+      formattedWidth = ''; // do not set width to childs in this case
+    } else {
+      style.width = null;
+    }
+
+    if (height.indexOf('%') > -1) {
+      style.height = height;
+      formattedHeight = ''; // do not set height to childs in this case
+    } else {
+      style.height = null;
+    }
 
     const needToShowError = error || invalid;
 

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -21,8 +21,7 @@ import Store from './utils/Store';
 
 // module constants
 const dateInputIcon = svg([DateInputSvg]);
-const EMPTY_FUNCTION = () => {
-};
+const EMPTY_FUNCTION = () => {};
 
 // module globals
 let openDatepickerInstance;
@@ -51,7 +50,7 @@ const applyEffect = self =>
       datepickerWrapper.classList[hasEffect ? 'remove' : 'add'](effect);
       setTimeout(
         () => resolve(),
-        250, /* effect duration - keep in sync with CSS */
+        250 /* effect duration - keep in sync with CSS */
       );
     }, 0 /* execute after render() */);
   });
@@ -187,7 +186,7 @@ class AXADatepicker extends NoShadowDOM {
         selected: index === _month,
         name: item.toString(),
         value: index.toString(),
-      }),
+      })
     );
 
     this.yearitems = this.allowedyears.map(item => ({
@@ -220,14 +219,14 @@ class AXADatepicker extends NoShadowDOM {
 
     this.debouncedHandleViewportCheck = debounce(
       () => this.handleViewportCheck(this.input),
-      250,
+      250
     );
   }
 
   // throttle re-rendering to once per frame (too many updates with default microtask timing before...)
   performUpdate() {
     new Promise(resolve => window.requestAnimationFrame(() => resolve())).then(
-      () => super.performUpdate(),
+      () => super.performUpdate()
     );
   }
 
@@ -243,7 +242,7 @@ class AXADatepicker extends NoShadowDOM {
     if (changedProperties.has('allowedyears')) {
       this.allowedyears = parseAndFormatAllowedYears(
         this.allowedyears,
-        this.year,
+        this.year
       );
     }
     return true;
@@ -270,7 +269,8 @@ class AXADatepicker extends NoShadowDOM {
     const { width = 'auto', height = '40', error, invalid } = this;
 
     // % on html width attribute not allowed
-    if (width.indexOf('%') > -1) { // TODO: setStyle
+    if (width.indexOf('%') > -1) {
+      // TODO: setStyle
       this.style.width = width;
     } else {
       this.style.width = null;
@@ -280,7 +280,6 @@ class AXADatepicker extends NoShadowDOM {
     } else {
       this.style.height = null;
     }
-
 
     const formattedStyle = parameter =>
       `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;
@@ -297,19 +296,19 @@ class AXADatepicker extends NoShadowDOM {
         style="${formattedWidth}"
       >
         ${label &&
-    html`
+          html`
             <label for="${refId}" class="m-datepicker__label">
               ${label}
               ${required
-      ? html`
+                ? html`
                     *
                   `
-      : ''}
+                : ''}
             </label>
           `}
         ${!this.inputfield
-      ? ''
-      : html`
+          ? ''
+          : html`
               <div class="m-datepicker__input-wrap" style="${formattedWidth}">
                 <input
                   id="${refId}"
@@ -333,16 +332,16 @@ class AXADatepicker extends NoShadowDOM {
                   ${dateInputIcon}
                 </button>
                 ${checkMark
-        ? html`
+                  ? html`
                       <span class="m-datepicker__check-wrapper">
                         <span class="m-datepicker__check"></span>
                       </span>
                     `
-        : ''}
+                  : ''}
               </div>
             `}
         ${(this.open && !disabled) || !this.inputfield
-      ? html`
+          ? html`
               <div class="m-datepicker__wrap js-datepicker__wrap">
                 <div class="m-datepicker__article">
                   <div class="m-datepicker__dropdown-wrap">
@@ -369,21 +368,21 @@ class AXADatepicker extends NoShadowDOM {
 
                   <div class="m-datepicker__weekdays">
                     ${this.weekdays &&
-      this.weekdays.map(
-        day =>
-          html`
+                      this.weekdays.map(
+                        day =>
+                          html`
                             <span class="m-datepicker__weekdays-day"
                               >${day}</span
                             >
-                          `,
-      )}
+                          `
+                      )}
                   </div>
 
                   <div class="m-datepicker__calendar js-datepicker__calendar">
                     ${this.cells &&
-      this.cells.map(
-        (cell, index) =>
-          html`
+                      this.cells.map(
+                        (cell, index) =>
+                          html`
                             <button
                               @click="${this.handleDatepickerCalendarCellClick}"
                               type="button"
@@ -395,8 +394,8 @@ class AXADatepicker extends NoShadowDOM {
                             >
                               ${cell.text}
                             </button>
-                          `,
-      )}
+                          `
+                      )}
                   </div>
                   <div class="m-datepicker__buttons">
                     <axa-button
@@ -415,12 +414,12 @@ class AXADatepicker extends NoShadowDOM {
                 </div>
               </div>
             `
-      : ''}
+          : ''}
         ${needToShowError
-      ? html`
+          ? html`
               <span class="m-datepicker__error">${this.invaliddatetext}</span>
             `
-      : html``}
+          : html``}
       </article>
     `;
   }
@@ -463,7 +462,7 @@ class AXADatepicker extends NoShadowDOM {
         null,
         year || startDate.getFullYear(),
         month || startDate.getMonth(),
-        day || startDate.getDate(),
+        day || startDate.getDate()
       );
     }
   }
@@ -652,7 +651,7 @@ class AXADatepicker extends NoShadowDOM {
     fireCustomEvent(
       'axa-input',
       { value: input.value, date: validDate, name },
-      this,
+      this
     );
     if (validDate) {
       onDateChange(validDate);

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -329,6 +329,7 @@ class AXADatepicker extends NoShadowDOM {
                 <button
                   type="button"
                   class="m-datepicker__input-button js-datepicker__input-button"
+                  style="${formattedHeight}"
                   @click="${this.handleInputButtonClick}"
                 >
                   ${dateInputIcon}

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -21,7 +21,8 @@ import Store from './utils/Store';
 
 // module constants
 const dateInputIcon = svg([DateInputSvg]);
-const EMPTY_FUNCTION = () => {};
+const EMPTY_FUNCTION = () => {
+};
 
 // module globals
 let openDatepickerInstance;
@@ -50,7 +51,7 @@ const applyEffect = self =>
       datepickerWrapper.classList[hasEffect ? 'remove' : 'add'](effect);
       setTimeout(
         () => resolve(),
-        250 /* effect duration - keep in sync with CSS */
+        250, /* effect duration - keep in sync with CSS */
       );
     }, 0 /* execute after render() */);
   });
@@ -128,7 +129,7 @@ class AXADatepicker extends NoShadowDOM {
       invalid: { type: Boolean, reflect: true },
       invaliddatetext: { type: String, defaultValue: 'Invalid date' },
       error: { type: String, reflect: true },
-      height: { type: String, reflect: true, defaultValue: '40px' },
+      height: { type: String, reflect: true, defaultValue: '40' },
       width: { type: String, reflect: true, defaultValue: 'auto' },
       disabled: { type: Boolean, reflect: true },
       required: { type: Boolean, reflect: true },
@@ -186,7 +187,7 @@ class AXADatepicker extends NoShadowDOM {
         selected: index === _month,
         name: item.toString(),
         value: index.toString(),
-      })
+      }),
     );
 
     this.yearitems = this.allowedyears.map(item => ({
@@ -219,14 +220,14 @@ class AXADatepicker extends NoShadowDOM {
 
     this.debouncedHandleViewportCheck = debounce(
       () => this.handleViewportCheck(this.input),
-      250
+      250,
     );
   }
 
   // throttle re-rendering to once per frame (too many updates with default microtask timing before...)
   performUpdate() {
     new Promise(resolve => window.requestAnimationFrame(() => resolve())).then(
-      () => super.performUpdate()
+      () => super.performUpdate(),
     );
   }
 
@@ -242,7 +243,7 @@ class AXADatepicker extends NoShadowDOM {
     if (changedProperties.has('allowedyears')) {
       this.allowedyears = parseAndFormatAllowedYears(
         this.allowedyears,
-        this.year
+        this.year,
       );
     }
     return true;
@@ -266,7 +267,20 @@ class AXADatepicker extends NoShadowDOM {
 
     this.setMonthAndYearItems(month, year);
 
-    const { width = 'auto', height = '40px', error, invalid } = this;
+    const { width = 'auto', height = '40', error, invalid } = this;
+
+    // % on html width attribute not allowed
+    if (width.indexOf('%') > -1) { // TODO: setStyle
+      this.style.width = width;
+    } else {
+      this.style.width = null;
+    }
+    if (height.indexOf('%') > -1) {
+      this.style.height = height;
+    } else {
+      this.style.height = null;
+    }
+
 
     const formattedStyle = parameter =>
       `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;
@@ -283,19 +297,19 @@ class AXADatepicker extends NoShadowDOM {
         style="${formattedWidth}"
       >
         ${label &&
-          html`
+    html`
             <label for="${refId}" class="m-datepicker__label">
               ${label}
               ${required
-                ? html`
+      ? html`
                     *
                   `
-                : ''}
+      : ''}
             </label>
           `}
         ${!this.inputfield
-          ? ''
-          : html`
+      ? ''
+      : html`
               <div class="m-datepicker__input-wrap" style="${formattedWidth}">
                 <input
                   id="${refId}"
@@ -319,16 +333,16 @@ class AXADatepicker extends NoShadowDOM {
                   ${dateInputIcon}
                 </button>
                 ${checkMark
-                  ? html`
+        ? html`
                       <span class="m-datepicker__check-wrapper">
                         <span class="m-datepicker__check"></span>
                       </span>
                     `
-                  : ''}
+        : ''}
               </div>
             `}
         ${(this.open && !disabled) || !this.inputfield
-          ? html`
+      ? html`
               <div class="m-datepicker__wrap js-datepicker__wrap">
                 <div class="m-datepicker__article">
                   <div class="m-datepicker__dropdown-wrap">
@@ -355,21 +369,21 @@ class AXADatepicker extends NoShadowDOM {
 
                   <div class="m-datepicker__weekdays">
                     ${this.weekdays &&
-                      this.weekdays.map(
-                        day =>
-                          html`
+      this.weekdays.map(
+        day =>
+          html`
                             <span class="m-datepicker__weekdays-day"
                               >${day}</span
                             >
-                          `
-                      )}
+                          `,
+      )}
                   </div>
 
                   <div class="m-datepicker__calendar js-datepicker__calendar">
                     ${this.cells &&
-                      this.cells.map(
-                        (cell, index) =>
-                          html`
+      this.cells.map(
+        (cell, index) =>
+          html`
                             <button
                               @click="${this.handleDatepickerCalendarCellClick}"
                               type="button"
@@ -381,8 +395,8 @@ class AXADatepicker extends NoShadowDOM {
                             >
                               ${cell.text}
                             </button>
-                          `
-                      )}
+                          `,
+      )}
                   </div>
                   <div class="m-datepicker__buttons">
                     <axa-button
@@ -401,12 +415,12 @@ class AXADatepicker extends NoShadowDOM {
                 </div>
               </div>
             `
-          : ''}
+      : ''}
         ${needToShowError
-          ? html`
+      ? html`
               <span class="m-datepicker__error">${this.invaliddatetext}</span>
             `
-          : html``}
+      : html``}
       </article>
     `;
   }
@@ -449,7 +463,7 @@ class AXADatepicker extends NoShadowDOM {
         null,
         year || startDate.getFullYear(),
         month || startDate.getMonth(),
-        day || startDate.getDate()
+        day || startDate.getDate(),
       );
     }
   }
@@ -638,7 +652,7 @@ class AXADatepicker extends NoShadowDOM {
     fireCustomEvent(
       'axa-input',
       { value: input.value, date: validDate, name },
-      this
+      this,
     );
     if (validDate) {
       onDateChange(validDate);

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -268,35 +268,17 @@ class AXADatepicker extends NoShadowDOM {
 
     const { width = '100%', height = '40', error, invalid, style } = this;
 
-    const formattedStyle = parameter =>
-      `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;
+    const setFormattedStyle = (parameter, dimension) => {
+      style[dimension] = `${parameter}${/^\d+$/.test(parameter) ? 'px' : ''}`;
+    };
 
-    let formattedWidth = `width:${formattedStyle(width)}`;
-    let formattedHeight = `height:${formattedStyle(height)}`;
-
-    // % on html width or height attribute not allowed, so set it as css attribute
-    if (width.indexOf('%') > -1) {
-      style.width = width;
-      formattedWidth = ''; // do not set width to childs in this case
-    } else {
-      style.width = null;
-    }
-
-    if (height.indexOf('%') > -1) {
-      style.height = height;
-      formattedHeight = ''; // do not set height to childs in this case
-    } else {
-      style.height = null;
-    }
+    setFormattedStyle(width, 'width');
+    setFormattedStyle(height, 'height');
 
     const needToShowError = error || invalid;
 
     return html`
-      <article
-        class="m-datepicker"
-        @click="${this.handleDatepickerClick}"
-        style="${formattedWidth}"
-      >
+      <article class="m-datepicker" @click="${this.handleDatepickerClick}">
         ${label &&
           html`
             <label for="${refId}" class="m-datepicker__label">
@@ -311,7 +293,7 @@ class AXADatepicker extends NoShadowDOM {
         ${!this.inputfield
           ? ''
           : html`
-              <div class="m-datepicker__input-wrap" style="${formattedWidth}">
+              <div class="m-datepicker__input-wrap">
                 <input
                   id="${refId}"
                   @input="${this.handleInputChange}"
@@ -322,14 +304,12 @@ class AXADatepicker extends NoShadowDOM {
                   type="text"
                   name="${this.name}"
                   placeholder="${this.placeholder}"
-                  style="${formattedHeight}"
                   .value="${isControlled ? value : this.outputdate}"
                   ?disabled="${disabled}"
                 />
                 <button
                   type="button"
                   class="m-datepicker__input-button js-datepicker__input-button"
-                  style="${formattedHeight}"
                   @click="${this.handleInputButtonClick}"
                 >
                   ${dateInputIcon}

--- a/src/components/20-molecules/datepicker/index.scss
+++ b/src/components/20-molecules/datepicker/index.scss
@@ -85,8 +85,10 @@ axa-datepicker {
   &__input-wrap {
     position: relative;
     display: flex;
-    min-width: 197px;
     align-items: center;
+    min-width: 197px;
+    min-height: 40px;
+    height: 100%;
   }
 
   &__input-button {
@@ -100,9 +102,9 @@ axa-datepicker {
     border-left: none;
     line-height: 0;
     margin-left: 0; /* suppress Safari 2px margin */
-    min-width: 40px;
-    height: 40px;
     box-sizing: border-box;
+    height: 100%;
+    min-height: 40px;
 
     &:focus {
       outline: 2px solid $color-axa-blue;
@@ -127,6 +129,8 @@ axa-datepicker {
     padding: 0 10px 0 20px;
     min-width: 0;
     width: 100%;
+    height: 100%;
+    min-height: 40px;
     box-sizing: border-box;
 
     &::placeholder,
@@ -154,7 +158,7 @@ axa-datepicker {
 
   &__wrap {
     background: $color-prim-white;
-    max-width: 260px;
+    min-width: 260px;
     margin-top: 1px;
     padding: 20px 30px;
     background: $color-prim-white;

--- a/src/components/20-molecules/datepicker/index.scss
+++ b/src/components/20-molecules/datepicker/index.scss
@@ -37,10 +37,6 @@ axa-datepicker {
     }
   }
 
-  &[width="auto"] {
-    display: flex;
-  }
-
   &[label] {
     vertical-align: bottom;
 
@@ -79,7 +75,7 @@ axa-datepicker {
 
 .m-datepicker {
   position: relative;
-  display: inline-block;
+  display: inline;
 
   &,
   &__calendar-cell {
@@ -89,8 +85,7 @@ axa-datepicker {
   &__input-wrap {
     position: relative;
     display: flex;
-    width: 197px;
-    max-width: 226px;
+    min-width: 197px;
     align-items: center;
   }
 

--- a/src/components/20-molecules/datepicker/index.scss
+++ b/src/components/20-molecules/datepicker/index.scss
@@ -37,7 +37,7 @@ axa-datepicker {
     }
   }
 
-  &[width] {
+  &[width="auto"] {
     display: flex;
   }
 

--- a/src/components/20-molecules/datepicker/story.js
+++ b/src/components/20-molecules/datepicker/story.js
@@ -41,35 +41,39 @@ story.add('Datepicker', () => {
   const yeartitle = text('yeartitle', 'Choose Year');
   const invaliddatetext = text('invaliddatetext', 'Invalid date');
   const placeholder = text('placeholder', 'Please select a date');
-  const width = text('width (note max-length)', 'auto');
+  const width = text('width', '400');
   const height = text('height', '40');
 
   const wrapper = document.createElement('div');
 
   const template = html`
-    <axa-datepicker
-      locale="${locale}"
-      ?inputfield="${inputfield}"
-      ?autofocus="${autofocus}"
-      ?checkMark="${checkMark}"
-      ?disabled="${disabled}"
-      allowedyears='["1971-2000", 2012, 2014, "2018-2022"]'
-      year="${year}"
-      month="${month}"
-      day="${day}"
-      placeholder="${placeholder}"
-      invaliddatetext="${invaliddatetext}"
-      label="${label}"
-      monthtitle="${monthtitle}"
-      yeartitle="${yeartitle}"
-      labelbuttoncancel="${labelbuttoncancel}"
-      labelbuttonok="${labelbuttonok}"
-      width="${width}"
-      height="${height}"
-      data-test-id="datepicker"
-    ></axa-datepicker>
-    <span>This is a simple text next to datepicker element. You can check
-      datapickers width with me.</span>
+    <div style="background-color: lightgray">
+      <axa-datepicker
+        locale="${locale}"
+        ?inputfield="${inputfield}"
+        ?autofocus="${autofocus}"
+        ?checkMark="${checkMark}"
+        ?disabled="${disabled}"
+        allowedyears='["1971-2000", 2012, 2014, "2018-2022"]'
+        year="${year}"
+        month="${month}"
+        day="${day}"
+        placeholder="${placeholder}"
+        invaliddatetext="${invaliddatetext}"
+        label="${label}"
+        monthtitle="${monthtitle}"
+        yeartitle="${yeartitle}"
+        labelbuttoncancel="${labelbuttoncancel}"
+        labelbuttonok="${labelbuttonok}"
+        width="${width}"
+        height="${height}"
+        data-test-id="datepicker"
+      ></axa-datepicker>
+      <span
+        >This is a simple text next to datepicker element. You can check
+        datapickers width with me.</span
+      >
+    </div>
   `;
 
   render(template, wrapper);

--- a/src/components/20-molecules/datepicker/story.js
+++ b/src/components/20-molecules/datepicker/story.js
@@ -41,6 +41,8 @@ story.add('Datepicker', () => {
   const yeartitle = text('yeartitle', 'Choose Year');
   const invaliddatetext = text('invaliddatetext', 'Invalid date');
   const placeholder = text('placeholder', 'Please select a date');
+  const width = text('width (note max-length)', 'auto');
+  const height = text('height', '40');
 
   const wrapper = document.createElement('div');
 
@@ -62,8 +64,12 @@ story.add('Datepicker', () => {
       yeartitle="${yeartitle}"
       labelbuttoncancel="${labelbuttoncancel}"
       labelbuttonok="${labelbuttonok}"
+      width="${width}"
+      height="${height}"
       data-test-id="datepicker"
     ></axa-datepicker>
+    <span>This is a simple text next to datepicker element. You can check
+      datapickers width with me.</span>
   `;
 
   render(template, wrapper);

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -445,14 +445,23 @@ test('should fire the right events', async t => {
     .contains(`\n\n{"name":"date","value":"29.2.1976"}\n\n`);
 });
 
-fixture('Datepicker as inputfield with 200px width').page(
-  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose%20Month&knob-yeartitle=Choose%20Year&knob-invaliddatetext=Invalid%20date&knob-placeholder=Please%20select%20a%20date&knob-width=227&knob-height=40&knob-width%20(note%20max-length)=200`
+fixture('Datepicker as inputfield with fixed width and height').page(
+  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose%20Month&knob-yeartitle=Choose%20Year&knob-invaliddatetext=Invalid%20date&knob-placeholder=Please%20select%20a%20date&knob-width=227&knob-height=80&knob-width%20(note%20max-length)=200`
 );
 
 test('should have 200px width', async t => {
   const datepicker = await Selector(() =>
     document.querySelector('axa-datepicker')
   );
-
   await t.expect(datepicker.clientWidth).eql(200);
+});
+
+test('button should have correct height', async t => {
+  const expectedHeightWithBorderAndPadding = 78;
+  const datepicker = await Selector(() =>
+    document.querySelector('axa-datepicker')
+  ).find('.js-datepicker__input-button');
+  await t
+    .expect(datepicker.clientHeight)
+    .eql(expectedHeightWithBorderAndPadding);
 });

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -444,3 +444,15 @@ test('should fire the right events', async t => {
     .expect((await Selector('.event-log')).value)
     .contains(`\n\n{"name":"date","value":"29.2.1976"}\n\n`);
 });
+
+fixture('Datepicker as inputfield with 200px width').page(
+  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose%20Month&knob-yeartitle=Choose%20Year&knob-invaliddatetext=Invalid%20date&knob-placeholder=Please%20select%20a%20date&knob-width=227&knob-height=40&knob-width%20(note%20max-length)=200`
+);
+
+test('should have 200px width', async t => {
+  const datepicker = await Selector(() =>
+    document.querySelector('axa-datepicker')
+  );
+
+  await t.expect(datepicker.clientWidth).eql(200);
+});

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -473,12 +473,26 @@ test('button should have correct height', async t => {
     .eql(expectedHeightWithBorderAndPadding);
 });
 
-fixture('Datepicker as inputfield with 196px width').page(
-  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-disabled=&knob-autofocus=&knob-checkMark=&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose Month&knob-yeartitle=Choose Year&knob-invaliddatetext=Invalid date&knob-placeholder=Please select a date&knob-width=196&knob-height=40`
+fixture('Datepicker as inputfield with 196px width and 10px height').page(
+  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-disabled=&knob-autofocus=&knob-checkMark=&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose Month&knob-yeartitle=Choose Year&knob-invaliddatetext=Invalid date&knob-placeholder=Please select a date&knob-width=196&knob-height=10`
 );
 test('should have a minimum width', async t => {
   const datepicker = await Selector(() =>
     document.querySelector('axa-datepicker')
   );
-  await t.expect(datepicker.clientWidth).eql(197);
+  const datepickerInputWrap = await datepicker.find(
+    '.m-datepicker__input-wrap'
+  );
+  await t.expect(datepicker.clientWidth).eql(196); // component has no min-width
+  await t.expect(datepickerInputWrap.clientWidth).eql(197); // input wrapper has min-width
+});
+test('should have a minimum height', async t => {
+  const datepicker = await Selector(() =>
+    document.querySelector('axa-datepicker')
+  );
+  const datepickerInputWrap = await datepicker.find(
+    '.m-datepicker__input-wrap'
+  );
+  await t.expect(datepicker.clientHeight).eql(10); // component has no min-height
+  await t.expect(datepickerInputWrap.clientHeight).eql(40); // input wrapper has min-height
 });

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -410,6 +410,13 @@ test('should submit datepicker correctly in form', async t => {
     .eql('date = 29.2.2020 (of 1 submittable elements)');
 });
 
+test('should have default width', async t => {
+  const datepicker = await Selector(() =>
+    document.querySelector('axa-datepicker')
+  );
+  await t.expect(datepicker.getAttribute('width')).eql('100%');
+});
+
 fixture('Datepicker with onchange handler').page(
   `${host}/iframe.html?id=molecules-datepicker-demos--feature-datepicker-with-onchange-handler`
 );
@@ -446,7 +453,7 @@ test('should fire the right events', async t => {
 });
 
 fixture('Datepicker as inputfield with fixed width and height').page(
-  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose%20Month&knob-yeartitle=Choose%20Year&knob-invaliddatetext=Invalid%20date&knob-placeholder=Please%20select%20a%20date&knob-width=227&knob-height=80&knob-width%20(note%20max-length)=200`
+  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-disabled=&knob-autofocus=&knob-checkMark=&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose Month&knob-yeartitle=Choose Year&knob-invaliddatetext=Invalid date&knob-placeholder=Please select a date&knob-width=200&knob-height=80`
 );
 
 test('should have 200px width', async t => {
@@ -464,4 +471,14 @@ test('button should have correct height', async t => {
   await t
     .expect(datepicker.clientHeight)
     .eql(expectedHeightWithBorderAndPadding);
+});
+
+fixture('Datepicker as inputfield with 196px width').page(
+  `${host}/iframe.html?id=molecules-datepicker--datepicker&knob-inputfield=true&knob-locale=de-CH&knob-year=2020&knob-month=4&knob-day=22&knob-disabled=&knob-autofocus=&knob-checkMark=&knob-label=&knob-labelbuttoncancel=Cancel&knob-labelbuttonok=Ok&knob-monthtitle=Choose Month&knob-yeartitle=Choose Year&knob-invaliddatetext=Invalid date&knob-placeholder=Please select a date&knob-width=196&knob-height=40`
+);
+test('should have a minimum width', async t => {
+  const datepicker = await Selector(() =>
+    document.querySelector('axa-datepicker')
+  );
+  await t.expect(datepicker.clientWidth).eql(197);
 });


### PR DESCRIPTION
Fixes #1555 and fixes #1110

**Ansatz dieses Fixes:**

Als html attribut darf nur eine Zahl gesetzt werden. width=40. Es wird aber auto und % auch gesetzt. Diese Werte gehen aber nur im CSS. 

Wir haben folgende Anforderungen (wenn ich das richtig verstanden habe):
- Verhalten analog zu Input-text
- 100%: Soll z.b. 100% vom parent nehmen
- 400: z.b. 400px breite


# Done is when (DoD):
- [x] I have added UI/Unit tests for my changes
- [x] I added modified component properties to the typescript typings
- [x] Design has been reviewed with Thomas
- [x] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
- [x] Old tests and eslint rule are not broken
- [x] My changes are well documented in the README and showcased in the stories 
- [x] Tested with IE

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**)
- [x] I have made/updated the ChangeLog Section in the README 
