### PR TITLE
Remove changelog from build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ src
 package-lock.json
 .tmp-lib
 .tmp-dist
+CHANGELOG.md
 
 # Logs
 logs


### PR DESCRIPTION
Currently we are bundling the changelog into the npm module, which is a practice that I have not seen anywhere so far. It probably was just forgotten to be added to the npmignore.

But the changelog does not belong into the bundle, the bundle should be as small as possible and the users would need the changelog before updating a version, so it makes sense to keep it as documentation, but obviously not to also bundle it and install it on every of our users' computer.

If you agree, please approve. I will only merge if everyone approved this.