### PR TITLE
Feature/axa heading

### DIFF
--- a/src/components/10-atoms/heading/CHANGELOG.md
+++ b/src/components/10-atoms/heading/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/src/components/10-atoms/heading/README.md
+++ b/src/components/10-atoms/heading/README.md
@@ -2,7 +2,7 @@
 
 [Changelog](./CHANGELOG.md)
 
-TODO Description
+The title component provides a way to conveniently use headings and titles, that are in line with the style guide. Keep in mind that you need to import the fonts separately.
 
 ## Usage
 
@@ -15,7 +15,7 @@ npm install @axa-ch/heading
 ```js
 import '@axa-ch/heading';
 ...
-<axa-heading></axa-heading>
+<axa-heading rank="1">H1 Heading</axa-heading>
 ```
 
 ### React
@@ -32,7 +32,7 @@ export default AXAHeadingReact;
 ```
 
 ```js
-<AXAHeadingReact onClick={handler} />
+<AXAHeadingReact rank="1">H1 Heading</AXAHeadingReact>
 ```
 
 ### Pure HTML pages
@@ -49,7 +49,7 @@ Import the heading-defining script and use a heading like this:
     <title>Your awesome title</title>
   </head>
   <body>
-    <axa-heading></axa-heading>
+    <axa-heading rank="1">H1 Heading</axa-heading>
     <script src="node_modules/@axa-ch/heading/dist/index.js"></script>
   </body>
 </html>
@@ -59,18 +59,7 @@ Import the heading-defining script and use a heading like this:
 
 ### Variant
 
-| Attribute       | Details         |
-| --------------- | --------------- |
-| `variant="foo"` | Desc of Variant |
-
-### Bar
-
-The attribute `bar` specifies...
-
-### onClick
-
-The function-valued attribute `onClick` can be used as a callback prop for React and other frameworks.
-
-### Migration Notes
-
-You don't have to pay attention to anything for upgrading to newer version.
+| Attribute             | Details                                                                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `variant="secondary"` | Secondary variant will use publico as font. Default: "primary"                                                                 |
+| `rank="1"`            | Rank holds a number from one to six, which represents the underlying html heading tag. `rank="1"` will lead to a `h1` element. |

--- a/src/components/10-atoms/heading/README.md
+++ b/src/components/10-atoms/heading/README.md
@@ -1,0 +1,76 @@
+# Heading
+
+[Changelog](./CHANGELOG.md)
+
+TODO Description
+
+## Usage
+
+**Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
+
+```bash
+npm install @axa-ch/heading
+```
+
+```js
+import '@axa-ch/heading';
+...
+<axa-heading></axa-heading>
+```
+
+### React
+
+Create a React-ified heading with the createElement function from your React version and then use it like this:
+
+```js
+import { createElement } from 'react';
+import createAXAHeadingReact from '@axa-ch/heading/lib/index.react';
+
+const AXAHeadingReact = createAXAHeadingReact(createElement);
+
+export default AXAHeadingReact;
+```
+
+```js
+<AXAHeadingReact onClick={handler} />
+```
+
+### Pure HTML pages
+
+Import the heading-defining script and use a heading like this:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Your awesome title</title>
+  </head>
+  <body>
+    <axa-heading></axa-heading>
+    <script src="node_modules/@axa-ch/heading/dist/index.js"></script>
+  </body>
+</html>
+```
+
+## Properties
+
+### Variant
+
+| Attribute       | Details         |
+| --------------- | --------------- |
+| `variant="foo"` | Desc of Variant |
+
+### Bar
+
+The attribute `bar` specifies...
+
+### onClick
+
+The function-valued attribute `onClick` can be used as a callback prop for React and other frameworks.
+
+### Migration Notes
+
+You don't have to pay attention to anything for upgrading to newer version.

--- a/src/components/10-atoms/heading/README.md
+++ b/src/components/10-atoms/heading/README.md
@@ -1,7 +1,5 @@
 # Heading
 
-[Changelog](./CHANGELOG.md)
-
 The title component provides a way to conveniently use headings and titles, that are in line with the style guide. Keep in mind that you need to import the fonts separately.
 
 ## Usage

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -32,54 +32,53 @@ class AXAHeading extends LitElement {
     applyDefaults(this);
   }
 
-  firstUpdated() {
-    // Add DOM changes here
-    // This will be rendered when the component is connected to the DOM
-  }
-
   render() {
     // eslint-disable-next-line prefer-destructuring
     const variant = this.variant;
-    const isSize2 = variant.includes('size-2');
-    const isSize3 = variant.includes('size-3');
-    const isSize4 = variant.includes('size-4');
-    const isSize5 = variant.includes('size-5');
-    const isSize6 = variant.includes('size-6');
 
     const classes = classMap({
-      'a-heading--size-2': isSize2,
-      'a-heading--size-3': isSize3,
-      'a-heading--size-4': isSize4,
-      'a-heading--size-5': isSize5,
-      'a-heading--size-6': isSize6,
+      'a-heading--secondary': this.variant === 'secondary',
     });
 
-    // switch (this.rank) {
-    //   case 1:
-    //     return html`
-    //       <h${this.rank} class="a-heading ${classes}">
-    //         <slot></slot>
-    //       </h${this.rank}>
-    //     `;
-    //     break;
-    //   case 2:
-    //     break;
-    //   case 3:
-    //     break;
-    //   case 4:
-    //     break;
-    //   case 5:
-    //     break;
-    //   case 6:
-    //   default:
-    //     break;
-    // }
-
-    return html`
-      <h${this.rank} class="a-heading a-heading--h${this.rank}">
-        <slot></slot>
-      </h${this.rank}>
-    `;
+    switch (this.rank) {
+      case 1:
+        return html`
+          <h1 class="a-heading ${classes}">
+            <slot></slot>
+          </h1>
+        `;
+      case 2:
+        return html`
+          <h2 class="a-heading ${classes}">
+            <slot></slot>
+          </h2>
+        `;
+      case 3:
+        return html`
+          <h3 class="a-heading ${classes}">
+            <slot></slot>
+          </h3>
+        `;
+      case 4:
+        return html`
+          <h4 class="a-heading ${classes}">
+            <slot></slot>
+          </h4>
+        `;
+      case 5:
+        return html`
+          <h5 class="a-heading ${classes}">
+            <slot></slot>
+          </h5>
+        `;
+      case 6:
+      default:
+        return html`
+          <h6 class="a-heading ${classes}">
+            <slot></slot>
+          </h6>
+        `;
+    }
   }
 
   disconnectedCallback() {

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -33,9 +33,6 @@ class AXAHeading extends LitElement {
   }
 
   render() {
-    // eslint-disable-next-line prefer-destructuring
-    const variant = this.variant;
-
     const classes = classMap({
       'a-heading--secondary': this.variant === 'secondary',
     });

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -77,12 +77,6 @@ class AXAHeading extends LitElement {
         `;
     }
   }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-
-    // Cleanup and reset (i.e event listeners)
-  }
 }
 
 defineOnce(AXAHeading.tagName, AXAHeading);

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css, unsafeCSS } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
 
 /* eslint-disable import/no-extraneous-dependencies */
 import defineOnce from '../../../utils/define-once';
@@ -19,8 +20,8 @@ class AXAHeading extends LitElement {
   static get properties() {
     // Define properties and types
     return {
-      onClick: { type: Function },
-      foo: { type: String, defaultValue: 'bar' },
+      variant: { type: String },
+      rank: { type: Number },
     };
   }
 
@@ -29,7 +30,6 @@ class AXAHeading extends LitElement {
     // this functions applies default values per type and verifies if
     // the HTML attribute has been set before defining the custom element
     applyDefaults(this);
-    this.onClick = () => {};
   }
 
   firstUpdated() {
@@ -38,10 +38,47 @@ class AXAHeading extends LitElement {
   }
 
   render() {
+    // eslint-disable-next-line prefer-destructuring
+    const variant = this.variant;
+    const isSize2 = variant.includes('size-2');
+    const isSize3 = variant.includes('size-3');
+    const isSize4 = variant.includes('size-4');
+    const isSize5 = variant.includes('size-5');
+    const isSize6 = variant.includes('size-6');
+
+    const classes = classMap({
+      'a-heading--size-2': isSize2,
+      'a-heading--size-3': isSize3,
+      'a-heading--size-4': isSize4,
+      'a-heading--size-5': isSize5,
+      'a-heading--size-6': isSize6,
+    });
+
+    // switch (this.rank) {
+    //   case 1:
+    //     return html`
+    //       <h${this.rank} class="a-heading ${classes}">
+    //         <slot></slot>
+    //       </h${this.rank}>
+    //     `;
+    //     break;
+    //   case 2:
+    //     break;
+    //   case 3:
+    //     break;
+    //   case 4:
+    //     break;
+    //   case 5:
+    //     break;
+    //   case 6:
+    //   default:
+    //     break;
+    // }
+
     return html`
-      <article class="a-heading">
+      <h${this.rank} class="a-heading a-heading--h${this.rank}">
         <slot></slot>
-      </article>
+      </h${this.rank}>
     `;
   }
 

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css, unsafeCSS } from 'lit-element';
-import { classMap } from 'lit-html/directives/class-map';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 
 /* eslint-disable import/no-extraneous-dependencies */
 import defineOnce from '../../../utils/define-once';
@@ -33,49 +33,18 @@ class AXAHeading extends LitElement {
   }
 
   render() {
-    const classes = classMap({
-      'a-heading--secondary': this.variant === 'secondary',
-    });
+    const secondaryVariant =
+      this.variant === 'secondary' ? 'a-heading--secondary' : '';
 
-    switch (this.rank) {
-      case 1:
-        return html`
-          <h1 class="a-heading ${classes}">
-            <slot></slot>
-          </h1>
-        `;
-      case 2:
-        return html`
-          <h2 class="a-heading ${classes}">
-            <slot></slot>
-          </h2>
-        `;
-      case 3:
-        return html`
-          <h3 class="a-heading ${classes}">
-            <slot></slot>
-          </h3>
-        `;
-      case 4:
-        return html`
-          <h4 class="a-heading ${classes}">
-            <slot></slot>
-          </h4>
-        `;
-      case 5:
-        return html`
-          <h5 class="a-heading ${classes}">
-            <slot></slot>
-          </h5>
-        `;
-      case 6:
-      default:
-        return html`
-          <h6 class="a-heading ${classes}">
-            <slot></slot>
-          </h6>
-        `;
-    }
+    const template = `
+      <h${this.rank} class="a-heading ${secondaryVariant}">
+        <slot></slot>
+      </h${this.rank}>
+    `;
+
+    return html`
+      ${unsafeHTML(template)}
+    `;
   }
 }
 

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -1,0 +1,57 @@
+import { LitElement, html, css, unsafeCSS } from 'lit-element';
+
+/* eslint-disable import/no-extraneous-dependencies */
+import defineOnce from '../../../utils/define-once';
+import { applyDefaults } from '../../../utils/with-react';
+import styles from './index.scss';
+
+class AXAHeading extends LitElement {
+  static get tagName() {
+    return 'axa-heading';
+  }
+
+  static get styles() {
+    return css`
+      ${unsafeCSS(styles)}
+    `;
+  }
+
+  static get properties() {
+    // Define properties and types
+    return {
+      onClick: { type: Function },
+      foo: { type: String, defaultValue: 'bar' },
+    };
+  }
+
+  constructor() {
+    super();
+    // this functions applies default values per type and verifies if
+    // the HTML attribute has been set before defining the custom element
+    applyDefaults(this);
+    this.onClick = () => {};
+  }
+
+  firstUpdated() {
+    // Add DOM changes here
+    // This will be rendered when the component is connected to the DOM
+  }
+
+  render() {
+    return html`
+      <article class="a-heading">
+        <slot></slot>
+      </article>
+    `;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    // Cleanup and reset (i.e event listeners)
+  }
+}
+
+defineOnce(AXAHeading.tagName, AXAHeading);
+
+export default AXAHeading;

--- a/src/components/10-atoms/heading/index.react.d.ts
+++ b/src/components/10-atoms/heading/index.react.d.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export type Variant = 'foo' | 'bar';
+
+export interface AXAHeadingProps {
+  className?: string;
+  variant?: Variant;
+  onClick?: () => void;
+}
+
+declare function createAXAHeading(
+  createElement: typeof React.createElement
+): React.ComponentType<AXAHeadingProps>;
+
+export default createAXAHeading;

--- a/src/components/10-atoms/heading/index.react.d.ts
+++ b/src/components/10-atoms/heading/index.react.d.ts
@@ -1,11 +1,12 @@
 import React from 'react';
 
 export type Variant = 'foo' | 'bar';
+export type Rank = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface AXAHeadingProps {
   className?: string;
   variant?: Variant;
-  onClick?: () => void;
+  rank: Rank;
 }
 
 declare function createAXAHeading(

--- a/src/components/10-atoms/heading/index.react.d.ts
+++ b/src/components/10-atoms/heading/index.react.d.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 
-export type Variant = 'foo' | 'bar';
+export type Variant = 'primary' | 'secondary';
 export type Rank = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface AXAHeadingProps {
+  rank: Rank;
   className?: string;
   variant?: Variant;
-  rank: Rank;
 }
 
 declare function createAXAHeading(

--- a/src/components/10-atoms/heading/index.react.d.ts
+++ b/src/components/10-atoms/heading/index.react.d.ts
@@ -5,7 +5,6 @@ export type Rank = 1 | 2 | 3 | 4 | 5 | 6;
 
 export interface AXAHeadingProps {
   rank: Rank;
-  className?: string;
   variant?: Variant;
 }
 

--- a/src/components/10-atoms/heading/index.react.js
+++ b/src/components/10-atoms/heading/index.react.js
@@ -1,16 +1,4 @@
 import withReact from '../../../utils/with-react';
 import AXAHeading from './index';
 
-export default createElement => ({
-  /* props here, same as in the constructor of index.js */
-  className = '',
-  children,
-}) =>
-  withReact(createElement)(
-    AXAHeading.tagName,
-    {
-      /* props here, same as in the constructor of index.js */
-      className,
-    },
-    children
-  );
+export default createElement => withReact(createElement, AXAHeading);

--- a/src/components/10-atoms/heading/index.react.js
+++ b/src/components/10-atoms/heading/index.react.js
@@ -1,0 +1,16 @@
+import withReact from '../../../utils/with-react';
+import AXAHeading from './index';
+
+export default createElement => ({
+  /* props here, same as in the constructor of index.js */
+  className = '',
+  children,
+}) =>
+  withReact(createElement)(
+    AXAHeading.tagName,
+    {
+      /* props here, same as in the constructor of index.js */
+      className,
+    },
+    children
+  );

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,3 +1,80 @@
 .a-heading {
   display: block;
 }
+
+h1.a-heading {
+  // font-family: Source Sans Pro;
+  // font-style: normal;
+  // font-weight: bold;
+  // font-size: 24px;
+  // line-height: 28px;
+  @include typo-title(large-1);
+
+  @include breakpoint($mediaquery-md) {
+    @include typo-title(huge-1);
+  }
+
+  @include breakpoint($mediaquery-lg-up) {
+    @include typo-title(huge-3);
+  }
+}
+
+h2.a-heading {
+  @include typo-title(large-1);
+
+  @include breakpoint($mediaquery-md) {
+    @include typo-title(huge);
+  }
+
+  @include breakpoint($mediaquery-lg-up) {
+    @include typo-title(huge-2);
+  }
+}
+
+h3.a-heading {
+  @include typo-title(large);
+
+  @include breakpoint($mediaquery-md) {
+    @include typo-title(large-3);
+  }
+
+  @include breakpoint($mediaquery-lg-up) {
+    @include typo-title(huge-1);
+  }
+}
+
+h4.a-heading {
+  @include typo-title(large);
+
+  @include breakpoint($mediaquery-md) {
+    @include typo-title(large-2);
+  }
+
+  @include breakpoint($mediaquery-lg-up) {
+    @include typo-title(large-3);
+  }
+}
+
+h5.a-heading {
+  @include typo-title(medium-1);
+
+  @include breakpoint($mediaquery-md) {
+    @include typo-title(large);
+  }
+
+  @include breakpoint($mediaquery-lg-up) {
+    @include typo-title(large-1);
+  }
+}
+
+h6.a-heading {
+  @include typo-title(medium);
+
+  @include breakpoint($mediaquery-md) {
+    @include typo-title(medium-1);
+  }
+
+  @include breakpoint($mediaquery-lg-up) {
+    @include typo-title(large);
+  }
+}

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,0 +1,3 @@
+.a-heading {
+  display: block;
+}

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,7 +1,3 @@
-.a-heading {
-  display: block;
-}
-
 h1.a-heading {
   @include typo-title(large-1);
 

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -3,11 +3,6 @@
 }
 
 h1.a-heading {
-  // font-family: Source Sans Pro;
-  // font-style: normal;
-  // font-weight: bold;
-  // font-size: 24px;
-  // line-height: 28px;
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -16,6 +11,18 @@ h1.a-heading {
 
   @include breakpoint($mediaquery-lg-up) {
     @include typo-title(huge-3);
+  }
+
+  &.a-heading--secondary {
+    @include typo-title(large-1, secondary);
+
+    @include breakpoint($mediaquery-md) {
+      @include typo-title(huge-1, secondary);
+    }
+
+    @include breakpoint($mediaquery-lg-up) {
+      @include typo-title(huge-3, secondary);
+    }
   }
 }
 
@@ -29,6 +36,18 @@ h2.a-heading {
   @include breakpoint($mediaquery-lg-up) {
     @include typo-title(huge-2);
   }
+
+  &.a-heading--secondary {
+    @include typo-title(large-1, secondary);
+
+    @include breakpoint($mediaquery-md) {
+      @include typo-title(huge, secondary);
+    }
+
+    @include breakpoint($mediaquery-lg-up) {
+      @include typo-title(huge-2, secondary);
+    }
+  }
 }
 
 h3.a-heading {
@@ -40,6 +59,18 @@ h3.a-heading {
 
   @include breakpoint($mediaquery-lg-up) {
     @include typo-title(huge-1);
+  }
+
+  &.a-heading--secondary {
+    @include typo-title(large, secondary);
+
+    @include breakpoint($mediaquery-md) {
+      @include typo-title(large-3, secondary);
+    }
+
+    @include breakpoint($mediaquery-lg-up) {
+      @include typo-title(huge-1, secondary);
+    }
   }
 }
 
@@ -53,6 +84,18 @@ h4.a-heading {
   @include breakpoint($mediaquery-lg-up) {
     @include typo-title(large-3);
   }
+
+  &.a-heading--secondary {
+    @include typo-title(large, secondary);
+
+    @include breakpoint($mediaquery-md) {
+      @include typo-title(large-2, secondary);
+    }
+
+    @include breakpoint($mediaquery-lg-up) {
+      @include typo-title(large-3, secondary);
+    }
+  }
 }
 
 h5.a-heading {
@@ -65,6 +108,18 @@ h5.a-heading {
   @include breakpoint($mediaquery-lg-up) {
     @include typo-title(large-1);
   }
+
+  &.a-heading--secondary {
+    @include typo-title(medium-1, secondary);
+
+    @include breakpoint($mediaquery-md) {
+      @include typo-title(large, secondary);
+    }
+
+    @include breakpoint($mediaquery-lg-up) {
+      @include typo-title(large-1, secondary);
+    }
+  }
 }
 
 h6.a-heading {
@@ -76,5 +131,17 @@ h6.a-heading {
 
   @include breakpoint($mediaquery-lg-up) {
     @include typo-title(large);
+  }
+
+  &.a-heading--secondary {
+    @include typo-title(medium, secondary);
+
+    @include breakpoint($mediaquery-md) {
+      @include typo-title(medium-1, secondary);
+    }
+
+    @include breakpoint($mediaquery-lg-up) {
+      @include typo-title(large, secondary);
+    }
   }
 }

--- a/src/components/10-atoms/heading/package-lock.json
+++ b/src/components/10-atoms/heading/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@axa-ch/heading",
+  "version": "0.0.0-beta.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@axa-ch/materials": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-4.0.1.tgz",
+      "integrity": "sha512-DQQksMUJWRR+pPgePNjdfwhayo855CZsynHpraPKSmQkkG/NZ/heUp7okkGM62JNkX7sH4i6gucgs2dzKkmZlw=="
+    }
+  }
+}

--- a/src/components/10-atoms/heading/package.json
+++ b/src/components/10-atoms/heading/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@axa-ch/heading",
+  "version": "0.0.0-beta.0",
+  "description": "The heading component for the AXA Pattern Library",
+  "author": "Pattern Warriors",
+  "homepage": "https://github.com/axa-ch/patterns-library/tree/develop/src/components/10-atoms/heading#readme",
+  "license": "Copyright 2019 AXA Versicherungen AG",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "rollup --silent --config ../../../../rollup.config.js",
+    "watch": "rollup --watch --silent --config ../../../../rollup.config.js"
+  },
+  "files": [
+    "lib",
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/axa-ch/patterns-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/axa-ch/patterns-library/issues"
+  },
+  "dependencies": {
+    "@skatejs/val": "^0.4.0",
+    "lit-element": "^2.2.0",
+    "lit-html": "^1.1.0"
+  }
+}

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -19,7 +19,7 @@ storyAXAHeading.add('Heading', () => {
 
   const wrapper = document.createElement('div');
   const template = html`
-    <axa-heading>${children}<axa-heading> </axa-heading></axa-heading>
+    <axa-heading rank="5">hallo</axa-heading>
   `;
 
   render(template, wrapper);

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -19,7 +19,12 @@ storyAXAHeading.add('Heading', () => {
 
   const wrapper = document.createElement('div');
   const template = html`
-    <axa-heading rank="5">hallo</axa-heading>
+    <axa-heading rank="1">H1 Heading</axa-heading>
+    <axa-heading rank="2">H2 Heading</axa-heading>
+    <axa-heading rank="3">H3 Heading</axa-heading>
+    <axa-heading rank="4">H4 Heading</axa-heading>
+    <axa-heading rank="5">H5 Heading</axa-heading>
+    <axa-heading rank="6">H6 Heading</axa-heading>
   `;
 
   render(template, wrapper);

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -1,0 +1,27 @@
+/* global document */
+import { storiesOf } from '@storybook/html';
+// if your need more boolean, select, radios
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { html, render } from 'lit-html';
+import './index';
+import Readme from './README.md';
+
+const storyAXAHeading = storiesOf('Atoms/Heading', module);
+storyAXAHeading.addDecorator(withKnobs);
+storyAXAHeading.addParameters({
+  readme: {
+    sidebar: Readme,
+  },
+});
+
+storyAXAHeading.add('Heading', () => {
+  const children = text('Text', 'Some Children');
+
+  const wrapper = document.createElement('div');
+  const template = html`
+    <axa-heading>${children}<axa-heading> </axa-heading></axa-heading>
+  `;
+
+  render(template, wrapper);
+  return wrapper;
+});

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -1,7 +1,7 @@
 /* global document */
 import { storiesOf } from '@storybook/html';
 // if your need more boolean, select, radios
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
@@ -15,8 +15,6 @@ storyAXAHeading.addParameters({
 });
 
 storyAXAHeading.add('Heading', () => {
-  const children = text('Text', 'Some Children');
-
   const wrapper = document.createElement('div');
   const template = html`
     <axa-heading rank="1">H1 Primary Heading</axa-heading>

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -19,12 +19,19 @@ storyAXAHeading.add('Heading', () => {
 
   const wrapper = document.createElement('div');
   const template = html`
-    <axa-heading rank="1">H1 Heading</axa-heading>
-    <axa-heading rank="2">H2 Heading</axa-heading>
-    <axa-heading rank="3">H3 Heading</axa-heading>
-    <axa-heading rank="4">H4 Heading</axa-heading>
-    <axa-heading rank="5">H5 Heading</axa-heading>
-    <axa-heading rank="6">H6 Heading</axa-heading>
+    <axa-heading rank="1">H1 Primary Heading</axa-heading>
+    <axa-heading rank="2">H2 Primary Heading</axa-heading>
+    <axa-heading rank="3">H3 Primary Heading</axa-heading>
+    <axa-heading rank="4">H4 Primary Heading</axa-heading>
+    <axa-heading rank="5">H5 Primary Heading</axa-heading>
+    <axa-heading rank="6">H6 Primary Heading</axa-heading>
+
+    <axa-heading variant="secondary" rank="1">H1 Secondary Heading</axa-heading>
+    <axa-heading variant="secondary" rank="2">H2 Secondary Heading</axa-heading>
+    <axa-heading variant="secondary" rank="3">H3 Secondary Heading</axa-heading>
+    <axa-heading variant="secondary" rank="4">H4 Secondary Heading</axa-heading>
+    <axa-heading variant="secondary" rank="5">H5 Secondary Heading</axa-heading>
+    <axa-heading variant="secondary" rank="6">H6 Secondary Heading</axa-heading>
   `;
 
   render(template, wrapper);

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -21,16 +21,17 @@ async function _getHeadingElement(t) {
   return $axaElemShadowEl;
 }
 
-test('should render h1 primary correctly', async t => {
+test('should render h1 primary correctly on desktop', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t);
 
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
-  // font-family: "Source Sans Pro", Arial, sans-serif;
-  //   font-weight: 400;
-  //   font-style: normal;
-  //   font-size: 24px;
-  //   line-height: 29px;
-  //   letter-spacing: -0.01em;
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('62px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('72px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.62px');
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -2,9 +2,9 @@ import { Selector } from 'testcafe';
 
 const host = process.env.TEST_HOST_STORYBOOK_URL;
 
-fixture('Heading - Desktop').page(
-  `${host}/iframe.html?id=atoms-heading--heading`
-);
+fixture
+  .only('Heading - Desktop')
+  .page(`${host}/iframe.html?id=atoms-heading--heading`);
 
 const TAG = 'axa-heading';
 const CLASS = '.a-heading';
@@ -20,7 +20,7 @@ async function _getHeadingElement(t, rank, variant) {
             variant ? `[variant="${variant}"]` : ''
           }`
         )
-        .shadowRoot.querySelector('.a-heading'),
+        .shadowRoot.querySelector(CLASS),
     { dependencies: { rank, variant } }
   );
   const $nativeHeadingElement = $axaElemShadow;

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -9,12 +9,28 @@ fixture('Heading - basic functionality').page(
 const TAG = 'axa-heading';
 const CLASS = '.a-heading';
 
-test('should render heading', async t => {
+async function _getHeadingElement(t) {
   const $axaElem = await Selector(TAG);
   await t.expect($axaElem.exists).ok();
-  const $axaElemShadow = await Selector(
-    () => document.querySelector('axa-heading').shadowRoot
+  const $axaElemShadow = await Selector(() =>
+    document.querySelector('axa-heading').shadowRoot.querySelector('.a-heading')
   );
-  const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
+  // const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
+  const $axaElemShadowEl = $axaElemShadow;
   await t.expect($axaElemShadowEl.exists).ok();
+  return $axaElemShadowEl;
+}
+
+test('should render h1 primary correctly', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t);
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  // font-family: "Source Sans Pro", Arial, sans-serif;
+  //   font-weight: 400;
+  //   font-style: normal;
+  //   font-size: 24px;
+  //   line-height: 29px;
+  //   letter-spacing: -0.01em;
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -10,6 +10,10 @@ fixture('Heading - Desktop')
 
 const TAG = 'axa-heading';
 
+const mobileBreakpoint = '767px';
+const tabletBreakpoint = '991px';
+const desktopBreakpoint = '992px';
+
 async function _getHeadingElement(t, rank, variant) {
   const $headingElement = await Selector(TAG);
   await t.expect($headingElement.exists).ok();
@@ -43,7 +47,7 @@ test('should render h1 primary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.62px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h2 primary correctly on desktop', async t => {
@@ -60,7 +64,7 @@ test('should render h2 primary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.48px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h3 primary correctly on desktop', async t => {
@@ -77,7 +81,7 @@ test('should render h3 primary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h4 primary correctly on desktop', async t => {
@@ -94,7 +98,7 @@ test('should render h4 primary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.28px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h5 primary correctly on desktop', async t => {
@@ -111,7 +115,7 @@ test('should render h5 primary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.24px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h6 primary correctly on desktop', async t => {
@@ -128,7 +132,7 @@ test('should render h6 primary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.2px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h1 secondary correctly on desktop', async t => {
@@ -145,7 +149,7 @@ test('should render h1 secondary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.62px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h2 secondary correctly on desktop', async t => {
@@ -162,7 +166,7 @@ test('should render h2 secondary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.48px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h3 secondary correctly on desktop', async t => {
@@ -179,7 +183,7 @@ test('should render h3 secondary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h4 secondary correctly on desktop', async t => {
@@ -196,7 +200,7 @@ test('should render h4 secondary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.28px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h5 secondary correctly on desktop', async t => {
@@ -213,7 +217,7 @@ test('should render h5 secondary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.24px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h6 secondary correctly on desktop', async t => {
@@ -230,7 +234,7 @@ test('should render h6 secondary correctly on desktop', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.2px');
 }).before(async t => {
-  await t.resizeWindow(992, 992);
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
 test('should render h1 primary correctly on tablet', async t => {
@@ -247,7 +251,7 @@ test('should render h1 primary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h2 primary correctly on tablet', async t => {
@@ -264,7 +268,7 @@ test('should render h2 primary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.3px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h3 primary correctly on tablet', async t => {
@@ -281,7 +285,7 @@ test('should render h3 primary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.28px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h4 primary correctly on tablet', async t => {
@@ -298,7 +302,7 @@ test('should render h4 primary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.25px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h5 primary correctly on tablet', async t => {
@@ -315,7 +319,7 @@ test('should render h5 primary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.2px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h6 primary correctly on tablet', async t => {
@@ -332,7 +336,7 @@ test('should render h6 primary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.18px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h1 secondary correctly on tablet', async t => {
@@ -349,7 +353,7 @@ test('should render h1 secondary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h2 secondary correctly on tablet', async t => {
@@ -366,7 +370,7 @@ test('should render h2 secondary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.3px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h3 secondary correctly on tablet', async t => {
@@ -383,7 +387,7 @@ test('should render h3 secondary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.28px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h4 secondary correctly on tablet', async t => {
@@ -400,7 +404,7 @@ test('should render h4 secondary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.25px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h5 secondary correctly on tablet', async t => {
@@ -417,7 +421,7 @@ test('should render h5 secondary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.2px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h6 secondary correctly on tablet', async t => {
@@ -434,5 +438,5 @@ test('should render h6 secondary correctly on tablet', async t => {
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.18px');
 }).before(async t => {
-  await t.resizeWindow(991, 991);
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -2,7 +2,7 @@ import { Selector } from 'testcafe';
 
 const host = process.env.TEST_HOST_STORYBOOK_URL;
 
-fixture('Heading - Desktop')
+fixture('Heading - Correct CSS attributes')
   .page(`${host}/iframe.html?id=atoms-heading--heading`)
   .afterEach(async t => {
     await t.maximizeWindow();
@@ -10,9 +10,9 @@ fixture('Heading - Desktop')
 
 const TAG = 'axa-heading';
 
-const mobileBreakpoint = '767px';
-const tabletBreakpoint = '991px';
-const desktopBreakpoint = '992px';
+const mobileBreakpoint = 767;
+const tabletBreakpoint = 991;
+const desktopBreakpoint = 992;
 
 async function _getHeadingElement(t, rank, variant) {
   const $headingElement = await Selector(TAG);
@@ -439,4 +439,208 @@ test('should render h6 secondary correctly on tablet', async t => {
     .eql('-0.18px');
 }).before(async t => {
   await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
+test('should render h1 primary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h2 primary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h3 primary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h4 primary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h5 primary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.18px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h6 primary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('16px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('18px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.16px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h1 secondary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h2 secondary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h3 secondary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h4 secondary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h5 secondary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.18px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+test('should render h6 secondary correctly on mobile', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('16px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('18px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.16px');
+}).before(async t => {
+  await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -2,27 +2,34 @@ import { Selector } from 'testcafe';
 
 const host = process.env.TEST_HOST_STORYBOOK_URL;
 
-fixture('Heading - basic functionality').page(
+fixture('Heading - Desktop').page(
   `${host}/iframe.html?id=atoms-heading--heading`
 );
 
 const TAG = 'axa-heading';
 const CLASS = '.a-heading';
 
-async function _getHeadingElement(t) {
-  const $axaElem = await Selector(TAG);
-  await t.expect($axaElem.exists).ok();
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-heading').shadowRoot.querySelector('.a-heading')
+async function _getHeadingElement(t, rank, variant) {
+  const $headingElement = await Selector(TAG);
+  await t.expect($headingElement.exists).ok();
+  const $axaElemShadow = await Selector(
+    () =>
+      document
+        .querySelector(
+          `axa-heading[rank='${rank}']${
+            variant ? `[variant="${variant}"]` : ''
+          }`
+        )
+        .shadowRoot.querySelector('.a-heading'),
+    { dependencies: { rank, variant } }
   );
-  // const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
-  const $axaElemShadowEl = $axaElemShadow;
-  await t.expect($axaElemShadowEl.exists).ok();
-  return $axaElemShadowEl;
+  const $nativeHeadingElement = $axaElemShadow;
+  await t.expect($nativeHeadingElement.exists).ok();
+  return $nativeHeadingElement;
 }
 
 test('should render h1 primary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t);
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
 
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
@@ -34,4 +41,169 @@ test('should render h1 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.62px');
+});
+
+test('should render h2 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('48px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('54px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.48px');
+});
+
+test('should render h3 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+});
+
+test('should render h4 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+});
+
+test('should render h5 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+});
+
+test('should render h6 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+});
+
+test('should render h1 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('62px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('72px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.62px');
+});
+
+test('should render h2 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('48px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('54px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.48px');
+});
+
+test('should render h3 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+});
+
+test('should render h4 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+});
+
+test('should render h5 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+});
+
+test('should render h6 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -2,12 +2,13 @@ import { Selector } from 'testcafe';
 
 const host = process.env.TEST_HOST_STORYBOOK_URL;
 
-fixture
-  .only('Heading - Desktop')
-  .page(`${host}/iframe.html?id=atoms-heading--heading`);
+fixture('Heading - Desktop')
+  .page(`${host}/iframe.html?id=atoms-heading--heading`)
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
 
 const TAG = 'axa-heading';
-const CLASS = '.a-heading';
 
 async function _getHeadingElement(t, rank, variant) {
   const $headingElement = await Selector(TAG);
@@ -20,7 +21,7 @@ async function _getHeadingElement(t, rank, variant) {
             variant ? `[variant="${variant}"]` : ''
           }`
         )
-        .shadowRoot.querySelector(CLASS),
+        .shadowRoot.querySelector('.a-heading'),
     { dependencies: { rank, variant } }
   );
   const $nativeHeadingElement = $axaElemShadow;
@@ -41,6 +42,8 @@ test('should render h1 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.62px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h2 primary correctly on desktop', async t => {
@@ -56,6 +59,8 @@ test('should render h2 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.48px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h3 primary correctly on desktop', async t => {
@@ -71,6 +76,8 @@ test('should render h3 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h4 primary correctly on desktop', async t => {
@@ -86,6 +93,8 @@ test('should render h4 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h5 primary correctly on desktop', async t => {
@@ -101,6 +110,8 @@ test('should render h5 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h6 primary correctly on desktop', async t => {
@@ -116,6 +127,8 @@ test('should render h6 primary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h1 secondary correctly on desktop', async t => {
@@ -131,6 +144,8 @@ test('should render h1 secondary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.62px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h2 secondary correctly on desktop', async t => {
@@ -146,6 +161,8 @@ test('should render h2 secondary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.48px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h3 secondary correctly on desktop', async t => {
@@ -161,6 +178,8 @@ test('should render h3 secondary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h4 secondary correctly on desktop', async t => {
@@ -176,6 +195,8 @@ test('should render h4 secondary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h5 secondary correctly on desktop', async t => {
@@ -191,6 +212,8 @@ test('should render h5 secondary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
 });
 
 test('should render h6 secondary correctly on desktop', async t => {
@@ -206,4 +229,210 @@ test('should render h6 secondary correctly on desktop', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(992, 992);
+});
+
+test('should render h1 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h2 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.3px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h3 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h4 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('25px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.25px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h5 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h6 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.18px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h1 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h2 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.3px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h3 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h4 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('25px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.25px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h5 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
+});
+
+test('should render h6 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.18px');
+}).before(async t => {
+  await t.resizeWindow(991, 991);
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -1,0 +1,20 @@
+import { Selector } from 'testcafe';
+
+const host = process.env.TEST_HOST_STORYBOOK_URL;
+
+fixture('Heading - basic functionality').page(
+  `${host}/iframe.html?id=atoms-heading--heading`
+);
+
+const TAG = 'axa-heading';
+const CLASS = '.a-heading';
+
+test('should render heading', async t => {
+  const $axaElem = await Selector(TAG);
+  await t.expect($axaElem.exists).ok();
+  const $axaElemShadow = await Selector(
+    () => document.querySelector('axa-heading').shadowRoot
+  );
+  const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
+  await t.expect($axaElemShadowEl.exists).ok();
+});


### PR DESCRIPTION
fixes #1088 

- [x] Implement axa-heading
- [x] Write first UI Test
- [x] Add UI-Tests for all screen sizes and variants
- [ ] ~Write better stories with knobs~ Not needed.
- [x] Maybe fix design incongruencies. @TommyHoliday told me that we could discuss it. I took the style from the old axa-title and axa-title-secondary. He has a slightly adapted version on figma: https://www.figma.com/file/6zurYk3bJpzUg0H2THSxGF/AXA-UI-Kit?node-id=0%3A58 - Status: We will implement the changes later.