### PR TITLE
Create a default Storybook Landingpage and add ChangeLog Tab

### DIFF
--- a/.storybook/.babelrc.js
+++ b/.storybook/.babelrc.js
@@ -8,6 +8,7 @@ module.exports = {
         },
       },
     ],
+    "@babel/preset-react"
   ],
   plugins: ['@babel/plugin-proposal-class-properties'],
 };

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,7 +1,8 @@
 import 'storybook-readme/register';
 import '@storybook/addon-knobs/register';
-import { STORIES_CONFIGURED, STORY_MISSING } from '@storybook/core-events'
-import addonAPI from '@storybook/addons'
+import './addons/changelog/register.js';
+import { STORIES_CONFIGURED, STORY_MISSING } from '@storybook/core-events';
+import addonAPI from '@storybook/addons';
 
 addonAPI.register('axa-ch/defaultpage', storybookAPI => {
   storybookAPI.on(STORIES_CONFIGURED, (kind, story) => {

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,6 +1,6 @@
 import 'storybook-readme/register';
-import '@storybook/addon-knobs/register';
 import './addons/changelog/register.js';
+import '@storybook/addon-knobs/register';
 import { STORIES_CONFIGURED, STORY_MISSING } from '@storybook/core-events';
 import addonAPI from '@storybook/addons';
 

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,15 @@
 import 'storybook-readme/register';
 import '@storybook/addon-knobs/register';
+import { STORIES_CONFIGURED, STORY_MISSING } from '@storybook/core-events'
+import addonAPI from '@storybook/addons'
+
+addonAPI.register('my-organisation/first-page', storybookAPI => {
+  storybookAPI.on(STORIES_CONFIGURED, (kind, story) => {
+    if (storybookAPI.getUrlState().path === '/story/*') {
+      storybookAPI.selectStory('Welcome', 'to Patterns Library')
+    }
+  });
+  storybookAPI.on(STORY_MISSING, (kind, story) => {
+    storybookAPI.selectStory('Welcome', 'to Patterns Library')
+  })
+});

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -7,10 +7,10 @@ import addonAPI from '@storybook/addons';
 addonAPI.register('axa-ch/defaultpage', storybookAPI => {
   storybookAPI.on(STORIES_CONFIGURED, (kind, story) => {
     if (storybookAPI.getUrlState().path === '/story/*') {
-      storybookAPI.selectStory('Welcome', 'to Patterns Library')
+      storybookAPI.selectStory('Welcome', 'to Pattern Library')
     }
   });
   storybookAPI.on(STORY_MISSING, (kind, story) => {
-    storybookAPI.selectStory('Welcome', 'to Patterns Library')
+    storybookAPI.selectStory('Welcome', 'to Pattern Library')
   })
 });

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -3,7 +3,7 @@ import '@storybook/addon-knobs/register';
 import { STORIES_CONFIGURED, STORY_MISSING } from '@storybook/core-events'
 import addonAPI from '@storybook/addons'
 
-addonAPI.register('my-organisation/first-page', storybookAPI => {
+addonAPI.register('axa-ch/defaultpage', storybookAPI => {
   storybookAPI.on(STORIES_CONFIGURED, (kind, story) => {
     if (storybookAPI.getUrlState().path === '/story/*') {
       storybookAPI.selectStory('Welcome', 'to Patterns Library')

--- a/.storybook/addons/changelog/register.js
+++ b/.storybook/addons/changelog/register.js
@@ -20,8 +20,8 @@ const MyPanel = () => {
     return 'No ChangeLog found.';
   };
 
-  return <div
-    dangerouslySetInnerHTML={{ __html: replaceUnneeded(value) }}></div>;
+  return <div style={{ margin: '8px' }}
+              dangerouslySetInnerHTML={{ __html: replaceUnneeded(value) }}></div>;
 };
 
 addonAPI.register(ADDON_ID, api => {

--- a/.storybook/addons/changelog/register.js
+++ b/.storybook/addons/changelog/register.js
@@ -1,0 +1,40 @@
+import { types } from '@storybook/addons';
+import { useParameter } from '@storybook/api';
+import { AddonPanel } from '@storybook/components';
+import addonAPI, { addons } from '@storybook/addons';
+import React from 'react';
+
+const ADDON_ID = 'axa-ch/changelog';
+const PANEL_ID = `${ADDON_ID}/panel`;
+
+const MyPanel = () => {
+  const value = useParameter('changelog', null);
+
+  const replaceUnneeded = (value) => {
+    if (value) {
+      return value
+        .replace('module.exports = "', '')
+        .replace(/\\n";/g, '<br>')
+        .replace(/\\n/g, '<br>');
+    }
+    return 'No ChangeLog found.';
+  };
+
+  return <div
+    dangerouslySetInnerHTML={{ __html: replaceUnneeded(value) }}></div>;
+};
+
+addonAPI.register(ADDON_ID, api => {
+  const render = ({ active, key }) => (
+    <AddonPanel active={active} key={key}>
+      <MyPanel/>
+    </AddonPanel>
+  );
+  const title = 'ChangeLog';
+
+  addons.add(PANEL_ID, {
+    type: types.PANEL,
+    title,
+    render,
+  });
+});

--- a/.storybook/addons/changelog/register.js
+++ b/.storybook/addons/changelog/register.js
@@ -17,7 +17,7 @@ const MyPanel = () => {
         .replace(/\\n";/g, '<br>')
         .replace(/\\n/g, '<br>');
     }
-    return 'No ChangeLog found.';
+    return 'No Changelog found.';
   };
 
   return <div style={{ margin: '8px' }}
@@ -30,7 +30,7 @@ addonAPI.register(ADDON_ID, api => {
       <MyPanel/>
     </AddonPanel>
   );
-  const title = 'ChangeLog';
+  const title = 'Changelog';
 
   addons.add(PANEL_ID, {
     type: types.PANEL,

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -20,10 +20,12 @@ addParameters({
 
 addDecorator(addReadme);
 
+const landingpage = require.context('../src/landingpage', true, /(story\.(js|jsx)|demo.(js|jsx))$/);
 const components = require.context('../src/components', true, /(story\.(js|jsx)|demo.(js|jsx))$/);
 const demos = require.context('../src/demo', true, /(story\.(js|jsx)|demo.(js|jsx))$/);
 
 configure(() => {
+  landingpage.keys().forEach(landingpage);
   components.keys().forEach(components);
   demos.keys().forEach(demos);
 }, module);

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -51,7 +51,11 @@ module.exports = ({ config }) => {
           loader: "html-loader"
         },
         {
-          loader: "markdown-loader"
+          loader: "markdown-loader",
+          options: {
+            gfm: true,
+            breaks: false // TODO: make it work
+          }
         }
       ]
     }

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -42,7 +42,18 @@ module.exports = ({ config }) => {
       test: /\.jsx/,
       exclude: /node_modules\/(?!lit\-element|lit\-html|@axa\-ch)/,
       loader: 'babel-loader',
-      options: {...babelOptions, presets: [...babelOptions.presets, '@babel/preset-react']},
+      options: {...babelOptions, presets: [...babelOptions.presets]},
+    },
+    {
+      test: /\CHANGELOG.md$/,
+      use: [
+        {
+          loader: "html-loader"
+        },
+        {
+          loader: "markdown-loader"
+        }
+      ]
     }
   );
 

--- a/scripts/create-a-m-o/functions.js
+++ b/scripts/create-a-m-o/functions.js
@@ -92,8 +92,6 @@ const createFiles = (store, a, m, o, done) => () => {
     outdent`
     # ${compTitle}
 
-    [Changelog](./CHANGELOG.md)
-
     TODO Description
 
     ## Usage
@@ -199,6 +197,7 @@ const createFiles = (store, a, m, o, done) => () => {
     import { html, render } from 'lit-html';
     import './index';
     import Readme from './README.md';
+    import Changelog from './CHANGELOG.md';
 
     const story = storiesOf('${titleMap[type]}/${compTitle}', module);
     story.addDecorator(withKnobs);
@@ -206,6 +205,7 @@ const createFiles = (store, a, m, o, done) => () => {
       readme: {
         sidebar: Readme,
       },
+      changelog: Changelog
     });
 
     story.add('${compTitle}', () => {

--- a/src/components/00-materials/CHANGELOG.md
+++ b/src/components/00-materials/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 - 3.0.0
   - no breaking changes here. Release is needed for the other components.
 

--- a/src/components/00-materials/CHANGELOG.md
+++ b/src/components/00-materials/CHANGELOG.md
@@ -1,8 +1,7 @@
-- 3.0.0
-  - no breaking changes here. Release is needed for the other components.
+## 3.0.0
 
-- 2.0.0
-  - removed Axa logos from `/icons` (please use logos from `/images`)
-  
+- no breaking changes here. Release is needed for the other components.
 
-	
+## 2.0.0
+
+- removed Axa logos from `/icons` (please use logos from `/images`)

--- a/src/components/00-materials/README.md
+++ b/src/components/00-materials/README.md
@@ -1,7 +1,5 @@
 # AXA Materials
 
-[Changelog](./CHANGELOG.md)
-
 ### Usage
 
 ## Install Icons

--- a/src/components/10-atoms/button-link/CHANGELOG.md
+++ b/src/components/10-atoms/button-link/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### 3.0.2
 
 When attribute `disabled` is set and a consumer has a click-listener, the click event is NOT triggered.

--- a/src/components/10-atoms/button-link/README.md
+++ b/src/components/10-atoms/button-link/README.md
@@ -1,7 +1,5 @@
 # AXA Button Link
 
-[Changelog](./CHANGELOG.md)
-
 Button links provide link functionality, but in the style of a button. They may display text, icons, or both. Button links can be styled via several properties to change their look-and-feel.
 If you need a semantically correct button, use [axa-button](https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/button/README.md) instead.
 

--- a/src/components/10-atoms/button-link/story.js
+++ b/src/components/10-atoms/button-link/story.js
@@ -11,6 +11,7 @@ import { html, render } from 'lit-html';
 import './index';
 import { iconList } from '../icon/icon-list';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const variantOptions = {
   default: '',
@@ -45,6 +46,7 @@ storyButtonLink.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyButtonLink.add('Button Link', () => {

--- a/src/components/10-atoms/button/CHANGELOG.md
+++ b/src/components/10-atoms/button/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### 4.0.2
 
 When attribute disabled is set and a consumer has a click-listener, the click event is NOT triggered.

--- a/src/components/10-atoms/button/README.md
+++ b/src/components/10-atoms/button/README.md
@@ -1,7 +1,5 @@
 # AXA Button
 
-[Changelog](./CHANGELOG.md)
-
 Buttons provide a clickable element, which can be used in forms, or anywhere else where simple, standard call-to-action functionality is needed. They may display text, icons, or both. Buttons can be styled via several properties to change their look-and-feel.
 If you need a link with button styling, use [axa-button-link](https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/button-link/README.md) instead.
 

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -11,6 +11,7 @@ import { html, render } from 'lit-html';
 import './index';
 import { iconList } from '../icon/icon-list';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const storyButton = storiesOf('Atoms/Button', module);
 storyButton.addDecorator(withKnobs);
@@ -18,6 +19,7 @@ storyButton.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 export const variantOptions = {

--- a/src/components/10-atoms/carousel/CHANGELOG.md
+++ b/src/components/10-atoms/carousel/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/carousel/README.md
+++ b/src/components/10-atoms/carousel/README.md
@@ -1,7 +1,5 @@
 # Carousel
 
-[Changelog](./CHANGELOG.md)
-
 Every child is rendered as a slide. Only one child is visible at one time.
 
 ## Usage

--- a/src/components/10-atoms/carousel/story.js
+++ b/src/components/10-atoms/carousel/story.js
@@ -5,6 +5,7 @@ import { boolean, number, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 
 const storyAXACarousel = storiesOf('Atoms/Carousel', module);
@@ -14,6 +15,7 @@ storyAXACarousel.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyAXACarousel.add('Carousel', () => {

--- a/src/components/10-atoms/checkbox/CHANGELOG.md
+++ b/src/components/10-atoms/checkbox/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### 2.0.2
 
 Adjust error state to styleguide requirements [#1572](https://github.com/axa-ch/patterns-library/issues/1572)

--- a/src/components/10-atoms/checkbox/README.md
+++ b/src/components/10-atoms/checkbox/README.md
@@ -1,7 +1,5 @@
 # AXA Checkbox
 
-[Changelog](./CHANGELOG.md)
-
 Checkboxes provide a UI element for toggling between two visual states, checked and unchecked.
 They can be labelled with text to explain the semantics of the checked state to users. Checkboxes
 can be used in HTML forms as well as [React controlled components](https://reactjs.org/docs/forms.html#controlled-components).

--- a/src/components/10-atoms/checkbox/story.js
+++ b/src/components/10-atoms/checkbox/story.js
@@ -4,6 +4,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 import createRefId from '../../../utils/create-ref-id';
 
 const storyCheckbox = storiesOf('Atoms/Checkbox', module);
@@ -12,6 +13,7 @@ storyCheckbox.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyCheckbox.add('Checkbox', () => {

--- a/src/components/10-atoms/fieldset/CHANGELOG.md
+++ b/src/components/10-atoms/fieldset/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/fieldset/README.md
+++ b/src/components/10-atoms/fieldset/README.md
@@ -1,7 +1,5 @@
 # Fieldset
 
-[Changelog](./CHANGELOG.md)
-
 The &lt;axa-fieldset&gt; component is used to group several controls within a web form. Compared to its native HTML counterpart, its function is mainly restricted to styling: the element ensures that the grouped controls
 obey correct spacing as per the style guide.
 

--- a/src/components/10-atoms/fieldset/story.js
+++ b/src/components/10-atoms/fieldset/story.js
@@ -10,9 +10,9 @@ storiesOf('Atoms/Fieldset', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add(
     'Fieldset', () => {

--- a/src/components/10-atoms/fieldset/story.js
+++ b/src/components/10-atoms/fieldset/story.js
@@ -4,13 +4,15 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 storiesOf('Atoms/Fieldset', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add(
     'Fieldset', () => {

--- a/src/components/10-atoms/icon/CHANGELOG.md
+++ b/src/components/10-atoms/icon/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/icon/README.md
+++ b/src/components/10-atoms/icon/README.md
@@ -1,7 +1,5 @@
 # AXA Icon
 
-[Changelog](./CHANGELOG.md)
-
 &lt;axa-icon&gt; renders an icon, given an icon name, a resource path or a string to a suitable SVG image.
 
 ## Usage

--- a/src/components/10-atoms/icon/story.js
+++ b/src/components/10-atoms/icon/story.js
@@ -11,6 +11,7 @@ import { html, render } from 'lit-html';
 import { iconList } from '../icon/icon-list';
 import AXAIcon from './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const storyIcon = storiesOf('Atoms/Icon', module);
 storyIcon.addDecorator(withKnobs);
@@ -18,6 +19,7 @@ storyIcon.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyIcon.add(

--- a/src/components/10-atoms/input-file/CHANGELOG.md
+++ b/src/components/10-atoms/input-file/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/input-file/README.md
+++ b/src/components/10-atoms/input-file/README.md
@@ -1,7 +1,5 @@
 # Input file
 
-[Changelog](./CHANGELOG.md)
-
 Input-File provides a clickable element, which can be used in forms to upload files. The upload function can be restricted with several attributes. They may display text, icons, or both. Input-File can be styled via properties like the [axa-button](https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/button/README.md) or [axa-button-link](https://github.com/axa-ch/patterns-library/blob/develop/src/components/10-atoms/button-link/README.md).
 
 ## Usage

--- a/src/components/10-atoms/input-file/story.js
+++ b/src/components/10-atoms/input-file/story.js
@@ -5,13 +5,15 @@ import { html, render } from 'lit-html';
 import { iconList } from '../icon/icon-list';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 storiesOf('Atoms/Input File', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Input File', () => {
     const inputText = text('text', 'Upload');

--- a/src/components/10-atoms/input-file/story.js
+++ b/src/components/10-atoms/input-file/story.js
@@ -11,9 +11,9 @@ storiesOf('Atoms/Input File', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Input File', () => {
     const inputText = text('text', 'Upload');

--- a/src/components/10-atoms/input-text/CHANGELOG.md
+++ b/src/components/10-atoms/input-text/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Version 3.0.4
 
 - Fix: When using the autocomplete for form elements in Safari on macOs and iOS, the maxlength check had no effect.

--- a/src/components/10-atoms/input-text/README.md
+++ b/src/components/10-atoms/input-text/README.md
@@ -1,7 +1,5 @@
 # AXA Input Text
 
-[Changelog](./CHANGELOG.md)
-
 The &lt;axa-input-text&gt; component is a wrapper for the HTML &lt;input&gt; element with custom styling and additional functionality.
 It accepts most of the same properties as HTML &lt;input&gt;, but with `type`restricted to `type=text`, `type=email`, or `type=password`.
 

--- a/src/components/10-atoms/input-text/story.js
+++ b/src/components/10-atoms/input-text/story.js
@@ -4,6 +4,7 @@ import { boolean, text, radios, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const storyInputText = storiesOf('Atoms/Input Text', module);
 storyInputText.addDecorator(withKnobs);
@@ -11,6 +12,7 @@ storyInputText.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 const typeOptions = {

--- a/src/components/10-atoms/link/CHANGELOG.md
+++ b/src/components/10-atoms/link/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/link/README.md
+++ b/src/components/10-atoms/link/README.md
@@ -1,7 +1,5 @@
 # Link
 
-[Changelog](./CHANGELOG.md)
-
 The link component meant for hyper and simple links. Links can be styled via several properties to change their look-and-feel.
 
 All links support the colors "red" and "white" if declared within the `variant` attribute. See the explanation below.

--- a/src/components/10-atoms/link/story.js
+++ b/src/components/10-atoms/link/story.js
@@ -37,9 +37,9 @@ storiesOf('Atoms/Link', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Hyperlink', () => {
     const link = text('link', 'https://axa.ch/en/private-customers.html');

--- a/src/components/10-atoms/link/story.js
+++ b/src/components/10-atoms/link/story.js
@@ -6,6 +6,7 @@ import { iconList } from '../icon/icon-list';
 import './index';
 
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const variantOptions = {
   none: '',
@@ -36,8 +37,9 @@ storiesOf('Atoms/Link', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Hyperlink', () => {
     const link = text('link', 'https://axa.ch/en/private-customers.html');

--- a/src/components/10-atoms/radio/CHANGELOG.md
+++ b/src/components/10-atoms/radio/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/radio/README.md
+++ b/src/components/10-atoms/radio/README.md
@@ -1,7 +1,5 @@
 # Radio
 
-[Changelog](./CHANGELOG.md)
-
 Radio buttons provide a UI element for selecting one out of several visible choices.
 One may label them with text to explain the semantics of the selected choice to users.
 

--- a/src/components/10-atoms/radio/story.js
+++ b/src/components/10-atoms/radio/story.js
@@ -22,9 +22,9 @@ storiesOf('Atoms/Radio', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Radio', () => {
     const wrapper = document.createElement('div');

--- a/src/components/10-atoms/radio/story.js
+++ b/src/components/10-atoms/radio/story.js
@@ -5,6 +5,7 @@ import { html, render } from 'lit-html';
 import './index';
 
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const iconSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="60.2" height="34.74">
     <defs/>
@@ -21,8 +22,9 @@ storiesOf('Atoms/Radio', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Radio', () => {
     const wrapper = document.createElement('div');

--- a/src/components/10-atoms/text/CHANGELOG.md
+++ b/src/components/10-atoms/text/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/text/README.md
+++ b/src/components/10-atoms/text/README.md
@@ -1,7 +1,5 @@
 # Text
 
-[Changelog](./CHANGELOG.md)
-
 Allows you to control all the possible axa text styles by a component.
 
 It accepts a simple text as children or a HTML tag like `<p>` or `<span>`. Please make sure that only one direct HTML child is provided.

--- a/src/components/10-atoms/text/story.js
+++ b/src/components/10-atoms/text/story.js
@@ -18,9 +18,9 @@ storiesOf('Atoms/Text', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Text', () => {
     const variant = select('variant', variantOptions, '');

--- a/src/components/10-atoms/text/story.js
+++ b/src/components/10-atoms/text/story.js
@@ -4,6 +4,7 @@ import { select, boolean, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const variantOptions = {
   default: '',
@@ -17,8 +18,9 @@ storiesOf('Atoms/Text', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Text', () => {
     const variant = select('variant', variantOptions, '');

--- a/src/components/10-atoms/textarea/CHANGELOG.md
+++ b/src/components/10-atoms/textarea/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/10-atoms/textarea/README.md
+++ b/src/components/10-atoms/textarea/README.md
@@ -1,7 +1,5 @@
 # Textarea
 
-[Changelog](./CHANGELOG.md)
-
 The &lt;axa-textarea&gt; component is a wrapper for the HTML &lt;textarea&gt; element with custom styling and additional functionality, e.g. a character counter.
 
 ## Usage

--- a/src/components/10-atoms/textarea/story.js
+++ b/src/components/10-atoms/textarea/story.js
@@ -4,6 +4,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const storyTextarea = storiesOf('Atoms/Textarea', module);
 storyTextarea.addDecorator(withKnobs);
@@ -11,6 +12,7 @@ storyTextarea.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyTextarea.add('Textarea', () => {

--- a/src/components/20-molecules/cookie-disclaimer/CHANGELOG.md
+++ b/src/components/20-molecules/cookie-disclaimer/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/20-molecules/cookie-disclaimer/README.md
+++ b/src/components/20-molecules/cookie-disclaimer/README.md
@@ -1,7 +1,5 @@
 # Cookie disclaimer
 
-[Changelog](./CHANGELOG.md)
-
 Shows a message that explains the conditions of the Data Protection Act. By
 clicking on the button, the component stores the date and time as an identifier in the local storage, tracking when the user has clicked. If an identifier is stored, the cookie disclaimer wont show anymore till the user deletes its cache.
 

--- a/src/components/20-molecules/cookie-disclaimer/story.js
+++ b/src/components/20-molecules/cookie-disclaimer/story.js
@@ -12,9 +12,9 @@ storiesOf('Molecules/Cookie disclaimer', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Cookie disclaimer', () => {
     const buttonname = text('buttonname', 'Accept');

--- a/src/components/20-molecules/cookie-disclaimer/story.js
+++ b/src/components/20-molecules/cookie-disclaimer/story.js
@@ -4,6 +4,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 
 storiesOf('Molecules/Cookie disclaimer', module)
@@ -11,8 +12,9 @@ storiesOf('Molecules/Cookie disclaimer', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Cookie disclaimer', () => {
     const buttonname = text('buttonname', 'Accept');

--- a/src/components/20-molecules/datepicker/README.md
+++ b/src/components/20-molecules/datepicker/README.md
@@ -1,7 +1,5 @@
 # AXA Datepicker
 
-[Changelog](./CHANGELOG.md)
-
 ## Usage
 
 ```bash

--- a/src/components/20-molecules/datepicker/story.js
+++ b/src/components/20-molecules/datepicker/story.js
@@ -9,6 +9,7 @@ import {
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const localeOptions = {
   'de-CH': 'de-CH',
@@ -23,6 +24,7 @@ story.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 story.add('Datepicker', () => {

--- a/src/components/20-molecules/dropdown/CHANGELOG.md
+++ b/src/components/20-molecules/dropdown/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 4
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/20-molecules/dropdown/README.md
+++ b/src/components/20-molecules/dropdown/README.md
@@ -1,7 +1,5 @@
 # AXA Dropdown
 
-[Changelog](./CHANGELOG.md)
-
 ## Usage
 
 **Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -4,6 +4,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const storyDropdown = storiesOf('Molecules/Dropdown', module);
 storyDropdown.addDecorator(withKnobs);
@@ -11,6 +12,7 @@ storyDropdown.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyDropdown.add('Dropdown', () => {

--- a/src/components/20-molecules/file-upload/CHANGELOG.md
+++ b/src/components/20-molecules/file-upload/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/20-molecules/file-upload/README.md
+++ b/src/components/20-molecules/file-upload/README.md
@@ -1,7 +1,5 @@
 # File upload
 
-[Changelog](./CHANGELOG.md)
-
 A component used for uploading files in forms.
 
 ## Requirements

--- a/src/components/20-molecules/file-upload/story.js
+++ b/src/components/20-molecules/file-upload/story.js
@@ -4,6 +4,7 @@ import { html, render } from 'lit-html';
 import { iconList } from '../../10-atoms/icon/icon-list';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const story = storiesOf('Molecules/File Upload', module);
 story.addDecorator(withKnobs);
@@ -11,6 +12,7 @@ story.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 story.add('File upload', () => {

--- a/src/components/20-molecules/footer-small/CHANGELOG.md
+++ b/src/components/20-molecules/footer-small/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 4
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/20-molecules/footer-small/README.md
+++ b/src/components/20-molecules/footer-small/README.md
@@ -1,7 +1,5 @@
 # Footer - Small
 
-[Changelog](./CHANGELOG.md)
-
 This is the small version of the footer. This footer belongs to the very bottom of the webpage.
 
 ## Usage

--- a/src/components/20-molecules/footer-small/story.js
+++ b/src/components/20-molecules/footer-small/story.js
@@ -5,14 +5,16 @@ import { html, render } from 'lit-html';
 import './index';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 storiesOf('Molecules/Footer Small', module)
   .addDecorator(withNoBorder)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Footer Small', () => {
     const language1 = text('First language', `DE`);

--- a/src/components/20-molecules/footer-small/story.js
+++ b/src/components/20-molecules/footer-small/story.js
@@ -12,9 +12,9 @@ storiesOf('Molecules/Footer Small', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Footer Small', () => {
     const language1 = text('First language', `DE`);

--- a/src/components/20-molecules/policy-features/README.md
+++ b/src/components/20-molecules/policy-features/README.md
@@ -1,7 +1,5 @@
 # Policy features
 
-[Changelog](./CHANGELOG.md)
-
 With this component you can highlight as much `features` as you want. You can set a main title and put `features` items as childs to it.
 
 ## Usage

--- a/src/components/20-molecules/policy-features/story.js
+++ b/src/components/20-molecules/policy-features/story.js
@@ -6,6 +6,7 @@ import { CarSvg, UmbrellaSvg, TickSvg } from '@axa-ch/materials/images';
 import { html, render } from 'lit-html';
 import { STYLE_WHITELIST } from './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 
 const story = storiesOf('Molecules/Policy features', module);
@@ -15,6 +16,7 @@ story.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 story.add('Policy features', () => {

--- a/src/components/20-molecules/popup/CHANGELOG.md
+++ b/src/components/20-molecules/popup/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/20-molecules/popup/README.md
+++ b/src/components/20-molecules/popup/README.md
@@ -1,7 +1,5 @@
 # Popup
 
-[Changelog](./CHANGELOG.md)
-
 ## Usage
 
 **Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).

--- a/src/components/20-molecules/popup/popup-button/story.js
+++ b/src/components/20-molecules/popup/popup-button/story.js
@@ -10,7 +10,7 @@ storyPopupButton.addDecorator(withKnobs);
 storyPopupButton.addParameters({
   readme: {
     sidebar: Readme,
-  },
+  }
 });
 
 storyPopupButton.add('Popup Button', () => {

--- a/src/components/20-molecules/popup/popup-content/story.js
+++ b/src/components/20-molecules/popup/popup-content/story.js
@@ -10,7 +10,7 @@ storyPopupContent.addDecorator(withKnobs);
 storyPopupContent.addParameters({
   readme: {
     sidebar: Readme,
-  },
+  }
 });
 
 const children = html`<h4 style="margin-top: 0">Zeitspanne bis zur Pensionierung</h4>

--- a/src/components/20-molecules/top-content-bar/CHANGELOG.md
+++ b/src/components/20-molecules/top-content-bar/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/20-molecules/top-content-bar/README.md
+++ b/src/components/20-molecules/top-content-bar/README.md
@@ -1,7 +1,5 @@
 # Top content bar
 
-[Changelog](./CHANGELOG.md)
-
 Used as top of the page Warning or info box that can show text and have a call to action button
 
 ## Usage

--- a/src/components/20-molecules/top-content-bar/story.js
+++ b/src/components/20-molecules/top-content-bar/story.js
@@ -17,9 +17,9 @@ storiesOf('Molecules/Top content bar', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add(
     'Top content bar',

--- a/src/components/20-molecules/top-content-bar/story.js
+++ b/src/components/20-molecules/top-content-bar/story.js
@@ -4,6 +4,7 @@ import { text, select, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 
 const variantOptions = {
@@ -16,8 +17,9 @@ storiesOf('Molecules/Top content bar', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add(
     'Top content bar',

--- a/src/components/30-organisms/commercial-hero-banner/CHANGELOG.md
+++ b/src/components/30-organisms/commercial-hero-banner/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/30-organisms/commercial-hero-banner/README.md
+++ b/src/components/30-organisms/commercial-hero-banner/README.md
@@ -1,7 +1,5 @@
 # Commercial Hero Banner
 
-[Changelog](./CHANGELOG.md)
-
 The commercial hero banner is a component to set something into the focus of the user.
 
 ## Usage

--- a/src/components/30-organisms/commercial-hero-banner/story.js
+++ b/src/components/30-organisms/commercial-hero-banner/story.js
@@ -7,6 +7,7 @@ import { html, render } from 'lit-html';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const storyAXACommercialHeroBanner = storiesOf(
   'Organisms/Commercial Hero Banner',
@@ -18,6 +19,7 @@ storyAXACommercialHeroBanner.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 storyAXACommercialHeroBanner.add('Commercial Hero Banner', () => {

--- a/src/components/30-organisms/container/CHANGELOG.md
+++ b/src/components/30-organisms/container/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/30-organisms/container/README.md
+++ b/src/components/30-organisms/container/README.md
@@ -1,7 +1,5 @@
 # Container
 
-[Changelog](./CHANGELOG.md)
-
 Adds a max-with and margin auto according to Style Guide
 
 ## Usage

--- a/src/components/30-organisms/container/story.js
+++ b/src/components/30-organisms/container/story.js
@@ -10,9 +10,9 @@ storiesOf('Organisms/Container', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add(
     'Container - default',

--- a/src/components/30-organisms/container/story.js
+++ b/src/components/30-organisms/container/story.js
@@ -4,13 +4,15 @@ import { text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 storiesOf('Organisms/Container', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add(
     'Container - default',

--- a/src/components/30-organisms/footer/CHANGELOG.md
+++ b/src/components/30-organisms/footer/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 3
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/30-organisms/footer/README.md
+++ b/src/components/30-organisms/footer/README.md
@@ -1,7 +1,5 @@
 # Footer
 
-[Changelog](./CHANGELOG.md)
-
 The big version of the footer. It is SEO friendly, can take custom links and also allows displaying social-media buttons to the user.
 
 ## Usage

--- a/src/components/30-organisms/footer/story.js
+++ b/src/components/30-organisms/footer/story.js
@@ -6,6 +6,7 @@ import { html, render } from 'lit-html';
 import './index';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 storiesOf('Organisms/Footer', module)
   .addDecorator(withNoBorder)
@@ -13,8 +14,9 @@ storiesOf('Organisms/Footer', module)
 
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add(
     'Footer',

--- a/src/components/30-organisms/footer/story.js
+++ b/src/components/30-organisms/footer/story.js
@@ -14,9 +14,9 @@ storiesOf('Organisms/Footer', module)
 
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add(
     'Footer',

--- a/src/components/30-organisms/table-sortable/CHANGELOG.md
+++ b/src/components/30-organisms/table-sortable/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/30-organisms/table-sortable/README.md
+++ b/src/components/30-organisms/table-sortable/README.md
@@ -1,7 +1,5 @@
 # AXA Table Sortable
 
-[Changelog](./CHANGELOG.md)
-
 _WARNING: For mobile use, currently the innerscroll property must be set. This restriction will be lifted in the future._
 
 ## Usage

--- a/src/components/30-organisms/table-sortable/story.js
+++ b/src/components/30-organisms/table-sortable/story.js
@@ -56,9 +56,9 @@ storiesOf('Organisms/Table Sortable', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add(
     'Table Sortable',

--- a/src/components/30-organisms/table-sortable/story.js
+++ b/src/components/30-organisms/table-sortable/story.js
@@ -3,6 +3,7 @@ import { text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 const model = {
   thead: [
@@ -55,8 +56,9 @@ storiesOf('Organisms/Table Sortable', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add(
     'Table Sortable',

--- a/src/components/30-organisms/table/CHANGELOG.md
+++ b/src/components/30-organisms/table/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/30-organisms/table/README.md
+++ b/src/components/30-organisms/table/README.md
@@ -1,7 +1,5 @@
 # AXA Table
 
-[Changelog](./CHANGELOG.md)
-
 Install it with your CLI:
 `npm install @axa-ch/table`
 

--- a/src/components/30-organisms/table/story.js
+++ b/src/components/30-organisms/table/story.js
@@ -3,13 +3,15 @@ import { text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 
 storiesOf('Organisms/Table', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add(
     'Table',

--- a/src/components/30-organisms/table/story.js
+++ b/src/components/30-organisms/table/story.js
@@ -9,9 +9,9 @@ storiesOf('Organisms/Table', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add(
     'Table',

--- a/src/components/30-organisms/testimonials/CHANGELOG.md
+++ b/src/components/30-organisms/testimonials/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has

--- a/src/components/30-organisms/testimonials/README.md
+++ b/src/components/30-organisms/testimonials/README.md
@@ -1,7 +1,5 @@
 # Testimonials
 
-[Changelog](./CHANGELOG.md)
-
 Shows several information in a carousel or inline and sets title and subtitle over it.
 
 ## Usage

--- a/src/components/30-organisms/testimonials/story.js
+++ b/src/components/30-organisms/testimonials/story.js
@@ -4,6 +4,7 @@ import { boolean, text, withKnobs, number } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+import Changelog from './CHANGELOG.md';
 import withNoBorder from '../../../../.storybook/addons/no-border';
 
 const story = storiesOf('Organisms/Testimonials', module);
@@ -13,6 +14,7 @@ story.addParameters({
   readme: {
     sidebar: Readme,
   },
+  changelog: Changelog
 });
 
 story.add('Testimonials', () => {

--- a/src/demo/native/story.js
+++ b/src/demo/native/story.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/html';
 import { html, render, svg } from 'lit-html';
 import { select, withKnobs } from '@storybook/addon-knobs';
 import Readme from '../../components/00-materials/README.md';
+import Changelog from '../../components/00-materials/CHANGELOG.md';
 
 const reqSvgsIcons = require.context(
   './../../components/00-materials/icons',
@@ -34,8 +35,9 @@ storiesOf('Demos', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-      sidebar: Readme,
-    },
+    sidebar: Readme,
+  },
+  changelog: Changelog
   })
   .add('Icons and Images overview', () => {
     const backgrounds = select(

--- a/src/demo/native/story.js
+++ b/src/demo/native/story.js
@@ -35,9 +35,9 @@ storiesOf('Demos', module)
   .addDecorator(withKnobs)
   .addParameters({
     readme: {
-    sidebar: Readme,
-  },
-  changelog: Changelog
+      sidebar: Readme,
+    },
+    changelog: Changelog
   })
   .add('Icons and Images overview', () => {
     const backgrounds = select(

--- a/src/demo/story.js
+++ b/src/demo/story.js
@@ -1,0 +1,24 @@
+import { storiesOf } from '@storybook/html';
+import { html, render } from 'lit-html';
+import Readme from '../../README.md';
+
+const story = storiesOf('Welcome', module);
+story.addParameters({
+  readme: {
+    sidebar: Readme,
+  },
+});
+
+story.add('to Patterns Library', () => {
+  const wrapper = document.createElement('div');
+
+  const template = html`
+    <h1>Welcome to Patterns Library</h1>
+    <p>
+      You can find all our Webcomponents here. Check out our Readme above.
+    </p>
+  `;
+
+  render(template, wrapper);
+  return wrapper;
+});

--- a/src/demo/story.js
+++ b/src/demo/story.js
@@ -6,7 +6,7 @@ const story = storiesOf('Welcome', module);
 story.addParameters({
   readme: {
     sidebar: Readme,
-  },
+  }
 });
 
 story.add('to Patterns Library', () => {

--- a/src/demo/story.js
+++ b/src/demo/story.js
@@ -6,7 +6,7 @@ const story = storiesOf('Welcome', module);
 story.addParameters({
   readme: {
     sidebar: Readme,
-  }
+  },
 });
 
 story.add('to Patterns Library', () => {

--- a/src/landingpage/story.js
+++ b/src/landingpage/story.js
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/html';
 import { html, render } from 'lit-html';
 import Readme from '../../README.md';
+import '../components/10-atoms/text';
 
 const story = storiesOf('Welcome', module);
 story.addParameters({
@@ -9,14 +10,14 @@ story.addParameters({
   },
 });
 
-story.add('to Patterns Library', () => {
+story.add('to Pattern Library', () => {
   const wrapper = document.createElement('div');
 
   const template = html`
-    <h1>Welcome to Patterns Library</h1>
-    <p>
+    <axa-text>Welcome to Pattern Library</axa-text>
+    <axa-text variant="size-3">
       You can find all our Webcomponents here. Check out our Readme above.
-    </p>
+    </axa-text>
   `;
 
   render(template, wrapper);

--- a/src/landingpage/story.js
+++ b/src/landingpage/story.js
@@ -14,9 +14,9 @@ story.add('to Pattern Library', () => {
   const wrapper = document.createElement('div');
 
   const template = html`
-    <axa-text>Welcome to Pattern Library</axa-text>
+    <axa-text>Welcome to the Pattern Library!</axa-text>
     <axa-text variant="size-3">
-      You can find all our Webcomponents here. Check out our Readme above.
+      You can find all our Webcomponents here. Check out our Readme below.
     </axa-text>
   `;
 


### PR DESCRIPTION
fixes #1562 (from closed PR https://github.com/axa-ch/patterns-library/pull/1578)

This is a try to add a landingpage to SB. We need content and style here :)

# Done is when (DoD):
- [ ] I have added UI/Unit tests for my changes
- [ ] I added modified component properties to the typescript typings
- [ ] Design has been reviewed with (here name of reviewer)
- [x] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
- [x] Old tests and eslint rule are not broken
- [ ] My changes are well documented in the README and showcased in the stories 
- [x] Tested with IE

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**)
- [ ] I have made/updated the ChangeLog Section in the README 
