### PR TITLE
Make axa text variants mutually exclusive

### DIFF
--- a/src/components/10-atoms/text/CHANGELOG.md
+++ b/src/components/10-atoms/text/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 3.0.0
+
+The variants are now mutually exclusive, which means that you cannot combine multiple of them. E.g. `<axa-text variant="size-1 bold"></...>`
+
 ### Migration to version 2
 
 The implementation of the wrapper to make a component React-ready has
@@ -5,7 +9,7 @@ fundamentally changed. In particular, unknown Boolean- or
 string-valued properties are now accepted and converted to HTML
 attributes. E.g. `data-seleniumid="my-id"` is now supported.
 
-All defined attributes attached to a component *before* component
+All defined attributes attached to a component _before_ component
 construction time are now taken into account. Conversely, all undefined
 component attributes are initialized with type-appropriate default
 values at this time. This may amount to a breaking change if the

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -31,18 +31,18 @@ class AXAText extends NoShadowDOM {
   render() {
     // eslint-disable-next-line prefer-destructuring
     const variant = this.variant;
-    const isSize2 = variant.includes('size-2');
-    const isSize3 = variant.includes('size-3');
-    const isBold = variant.includes('bold');
+    const isSize2 = variant.indexOf('size-2');
+    const isSize3 = variant.indexOf('size-3');
+    const isBold = variant.indexOf('bold');
 
     const classes = ['a-text'];
-    if (isSize2) {
+    if (isSize2 === 0) {
       classes.push('a-text--size-2');
     }
-    if (isSize3) {
+    if (isSize3 === 0) {
       classes.push('a-text--size-3');
     }
-    if (isBold) {
+    if (isBold === 0) {
       classes.push('a-text--bold');
     }
 

--- a/src/components/10-atoms/text/index.react.d.ts
+++ b/src/components/10-atoms/text/index.react.d.ts
@@ -3,8 +3,6 @@ import React from 'react';
 type Variant = 'size-2' | 'size-3' | 'size-4' | 'bold';
 
 export interface AXATextProps {
-  className?: string;
-  slot?: string;
   variant?: Variant;
 }
 

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -14,8 +14,8 @@ const CLASS = '.a-text';
 test('should render text', async t => {
   const $axaElem = await Selector(TAG);
   await t.expect($axaElem.exists).ok();
-  const $axaElemShadow = await Selector(
-    () => document.querySelector('axa-text')
+  const $axaElemShadow = await Selector(() =>
+    document.querySelector('axa-text')
   );
   const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
   await t.expect($axaElemShadowEl.exists).ok();
@@ -110,7 +110,9 @@ test('should have correct font definitions for text size 3', async t => {
 });
 
 fixture('Text - Size 2 with custom tag')
-  .page(`${host}/iframe.html?id=atoms-text--text&knob-variant=size-2&knob-add%20<p>%20Tag=true`)
+  .page(
+    `${host}/iframe.html?id=atoms-text--text&knob-variant=size-2&knob-add%20<p>%20Tag=true`
+  )
   .beforeEach(async t => {
     await t.resizeWindow(380, 680);
   });
@@ -141,7 +143,6 @@ test('should have correct font definitions for text size 2 with custom span tag'
     .eql('27px');
 });
 
-
 fixture('Text - Bold')
   .page(`${host}/iframe.html?id=atoms-text--text&knob-variant=bold`)
   .beforeEach(async t => {
@@ -150,12 +151,37 @@ fixture('Text - Bold')
 
 test('should have correct font weight for text bold', async t => {
   const $axaElemShadow = await Selector(() =>
-    document
-      .querySelector('axa-text[variant="bold"]')
-      .querySelector('.a-text')
+    document.querySelector('axa-text[variant="bold"]').querySelector('.a-text')
   );
 
   await t
     .expect(await $axaElemShadow.getStyleProperty('font-weight'))
     .eql('700');
+});
+
+fixture('Text - Variant')
+  .page(`${host}/iframe.html?id=atoms-text--text&knob-variant=size-1%20bold`)
+  .beforeEach(async t => {
+    await t.resizeWindow(800, 600);
+  });
+
+test('should be mutually exclusive', async t => {
+  const $axaElemShadow = await Selector(() =>
+    document
+      .querySelector('axa-text[variant="size-1 bold"]')
+      .querySelector('.a-text')
+  );
+
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .eql('20px');
+
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .eql('30px');
+
+  // 'size-1' attributes should be set, but not the 'bold' ones.
+  await t
+    .expect(await $axaElemShadow.getStyleProperty('font-weight'))
+    .notEql('700');
 });

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -143,7 +143,7 @@ fixture('Text - Bold')
     await t.resizeWindow(380, 680);
   });
 
-test.only('should have correct font weight for text bold', async t => {
+test('should have correct font weight for text bold', async t => {
   const $axaElemShadow = await Selector(() =>
     document.querySelector('axa-text[variant="bold"] .a-text')
   );

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -23,7 +23,7 @@ test('should render text', async t => {
 
 test('should have correct font definitions for text size 1', async t => {
   const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text').querySelector('.a-text')
+    document.querySelector('axa-text .a-text')
   );
 
   await t
@@ -53,9 +53,7 @@ fixture('Text - Size 2')
 
 test('should have correct font definitions for text size 2', async t => {
   const $axaElemShadow = await Selector(() =>
-    document
-      .querySelector('axa-text[variant="size-2"]')
-      .querySelector('.a-text')
+    document.querySelector('axa-text[variant="size-2"] .a-text')
   );
 
   await t
@@ -85,9 +83,7 @@ fixture('Text - Size 3')
 
 test('should have correct font definitions for text size 3', async t => {
   const $axaElemShadow = await Selector(() =>
-    document
-      .querySelector('axa-text[variant="size-3"]')
-      .querySelector('.a-text')
+    document.querySelector('axa-text[variant="size-3"] .a-text')
   );
 
   await t
@@ -119,9 +115,7 @@ fixture('Text - Size 2 with custom tag')
 
 test('should have correct font definitions for text size 2 with custom span tag', async t => {
   const $axaElemShadow = await Selector(() =>
-    document
-      .querySelector('axa-text[variant="size-2"]')
-      .querySelector('.a-text')
+    document.querySelector('axa-text[variant="size-2"] .a-text')
   );
 
   await t
@@ -149,9 +143,9 @@ fixture('Text - Bold')
     await t.resizeWindow(380, 680);
   });
 
-test('should have correct font weight for text bold', async t => {
+test.only('should have correct font weight for text bold', async t => {
   const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text[variant="bold"]').querySelector('.a-text')
+    document.querySelector('axa-text[variant="bold"] .a-text')
   );
 
   await t
@@ -167,9 +161,7 @@ fixture('Text - Variant')
 
 test('should be mutually exclusive', async t => {
   const $axaElemShadow = await Selector(() =>
-    document
-      .querySelector('axa-text[variant="size-1 bold"]')
-      .querySelector('.a-text')
+    document.querySelector('axa-text[variant="size-1 bold"] .a-text')
   );
 
   await t


### PR DESCRIPTION
Fixes #1587

# Done is when (DoD):
- [x] I have added UI/Unit tests for my changes
- [x] Old tests and eslint rule are not broken
- [x] I added modified component properties to the typescript typings
- [ ] Design has been reviewed with (here name of reviewer)
- [x] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
- [x] My changes are well documented in the README and showcased in the stories 
- [x] My changes are shortly added to CHANGELOG.md with the issue number
- [x] Tested with IE

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**)
- [x] I have made/updated the ChangeLog Section in the README 
