### PR TITLE
Tighten Storybook's component-gathering regExp so as to ignore node_modules

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -21,7 +21,9 @@ addParameters({
 addDecorator(addReadme);
 
 const landingpage = require.context('../src/landingpage', true, /(story\.(js|jsx)|demo.(js|jsx))$/);
-const components = require.context('../src/components', true, /(story\.(js|jsx)|demo.(js|jsx))$/);
+// N.B. don't-look-into-node-modules behaviour uses negative lookbehind (?<!) as part of its regular expression
+// (https://v8.dev/blog/regexp-lookbehind-assertions), which is supported for node 9 and greater
+const components = require.context('../src/components', true, /(?<!node_modules.*)(story|demo)\.(js|jsx)$/);
 const demos = require.context('../src/demo', true, /(story\.(js|jsx)|demo.(js|jsx))$/);
 
 configure(() => {


### PR DESCRIPTION
Fixes #1606.

Please verify whether this resolves all within-component-dependencies woes such as the dropdown within the datepicker not always being the latest version etc.