### PR TITLE
axa-datepicker: Fix invalid-date error 

### DIFF
--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -150,7 +150,6 @@ class AXADatepicker extends NoShadowDOM {
     }
     // update state
     state.value = newValue;
-    this.validate(newValue);
     // manual re-render, necessary for custom setters
     this.requestUpdate('value', value);
   }
@@ -231,6 +230,12 @@ class AXADatepicker extends NoShadowDOM {
   }
 
   shouldUpdate(changedProperties) {
+    if (changedProperties.has('allowedyears')) {
+      this.allowedyears = parseAndFormatAllowedYears(
+        this.allowedyears,
+        this.year
+      );
+    }
     if (changedProperties.has('value')) {
       const {
         isReact,
@@ -238,12 +243,7 @@ class AXADatepicker extends NoShadowDOM {
       } = this;
       // controlledness is a React-only concept
       this.state.isControlled = isReact && isControlled;
-    }
-    if (changedProperties.has('allowedyears')) {
-      this.allowedyears = parseAndFormatAllowedYears(
-        this.allowedyears,
-        this.year
-      );
+      this.validate(this.value);
     }
     return true;
   }

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -171,6 +171,25 @@ test('datepicker should behave correctly when controlled', async t => {
 
   await t.expect(await getInputValue()).eql('4.6.2019');
 
+  const getError = ClientFunction(
+    () =>
+      document.querySelector(
+        `axa-datepicker[data-test-id="datepicker-controlled-react"]`
+      ).error
+  );
+
+  // no error on initial render
+  await t.expect(await getError()).eql(null);
+
+  // deliberately wrong user input...
+  await t.typeText(
+    `axa-datepicker[data-test-id="datepicker-controlled-react"] .js-datepicker__input`,
+    '28.wrong2.2019',
+    { replace: true }
+  );
+  // ... triggers expected error
+  await t.expect(await getError()).eql('Invalid date');
+
   await t.typeText(
     `axa-datepicker[data-test-id="datepicker-controlled-react"] .js-datepicker__input`,
     '28.2.2019',


### PR DESCRIPTION
Fixes #1604.

The fix pushed inputfield-value validation to as late as possible before render, so that updates to allowedyears - which affects whether a value is valid - can be taken into account.

It also includes tests to show the issue is fixed, yet later input errors can be detected and shown.