### PR TITLE
Update DOD so that all PRs can select all the checks

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Fixes #(issue)
 # Done is when (DoD):
 - [ ] My changes ship with tests, if needed.
 - [ ] I added modified component properties to the typescript typings, if needed.
-- [ ] Design changes have been reviewed with a designer.
+- [ ] Design changes have been reviewed with a designer, if needed.
 - [ ] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
 - [ ] My changes are well documented and showcased in the stories.
 - [ ] My changes are shortly added to CHANGELOG.md with the issue number.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,11 @@
 Fixes #(issue)
 
 # Done is when (DoD):
-- [ ] My changes ship with tests, if needed.
-- [ ] I added modified component properties to the typescript typings, if needed.
-- [ ] Design changes have been reviewed with a designer, if needed.
-- [ ] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
-- [ ] My changes are well documented and showcased in the stories.
-- [ ] My changes are shortly added to CHANGELOG.md with the issue number.
-- [ ] Tested with IE, if affected.
-
-# Checklist:
-- [ ] My code follows the style guidelines of this project.
-- [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**), if comments are needed.
+- [ ] The modifications are reflected locked tested.
+- [ ] A self-review of the code has been performed.
+- [ ] The modified component properties have been added to the typescript typings.
+- [ ] Potential design changes have been reviewed by a designer.
+- [ ] The modifications are well documented and showcased in the stories.
+- [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
+- [ ] The modifications still work in IE.
+- [ ] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,15 @@
-Fixes #(issue).
+Fixes #(issue)
 
 # Done is when (DoD):
-- [ ] I have added UI/Unit tests for my changes
-- [ ] Old tests and eslint rule are not broken
-- [ ] I added modified component properties to the typescript typings
-- [ ] Design has been reviewed with (here name of reviewer)
+- [ ] My changes ship with tests, if needed.
+- [ ] I added modified component properties to the typescript typings, if needed.
+- [ ] Design changes have been reviewed with a designer.
 - [ ] My changes are accordingly to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
-- [ ] My changes are well documented in the README and showcased in the stories 
-- [ ] My changes are shortly added to CHANGELOG.md with the issue number
-- [ ] Tested with IE
+- [ ] My changes are well documented and showcased in the stories.
+- [ ] My changes are shortly added to CHANGELOG.md with the issue number.
+- [ ] Tested with IE, if affected.
 
 # Checklist:
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**)
+- [ ] My code follows the style guidelines of this project.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented my code, particularly in hard-to-understand areas (focus on **WHY**), if comments are needed.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 Fixes #(issue)
 
 # Done is when (DoD):
-- [ ] The modifications are reflected locked tested.
+- [ ] Modifications within components are reflected by tests.
 - [ ] A self-review of the code has been performed.
 - [ ] The modified component properties have been added to the typescript typings.
 - [ ] Potential design changes have been reviewed by a designer.
-- [ ] The modifications are well documented and showcased in the stories.
+- [ ] The modifications are well documented (README.md, etc.) and showcased in the stories.
 - [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
 - [ ] The modifications still work in IE.
 - [ ] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Fixes #(issue)
 - [ ] The modified component properties have been added to the typescript typings.
 - [ ] Potential design changes have been reviewed by a designer.
 - [ ] The modifications are well documented (README.md, etc.) and showcased in the stories.
+- [ ] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
 - [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
 - [ ] The modifications still work in IE.
 - [ ] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)


### PR DESCRIPTION
Opinionated PR:
============

In my opinion, in a DOD, you should select EVERYTHING before the PR is ready to merge. This was not the case before, because not all bullet points could be checked in all the cases. But this is true now. When you are ready to have your PR reviewed, you can first make sure that you checked the whole list and signed every point.

Some stuff was redundant (like the changelog things), one point was useless (because the pipeline makes sure that nobody can merge something not compatible with eslint rules or that breaks tests) and some others needed a bit more text so that they can be marked as done without lying.