### PR TITLE
Replace travis build badge with azures'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pattern Library v2
 
-[![Build Status](https://travis-ci.org/axa-ch/patterns-library.svg?branch=develop)](https://travis-ci.org/axa-ch/patterns-library)
+[![Build Status](https://ach-azureforge-iss.visualstudio.com/Patterns-Library/_apis/build/status/CI_patterns-library?branchName=develop)](https://ach-azureforge-iss.visualstudio.com/Patterns-Library/_build/latest?definitionId=115&branchName=develop)
 ![Deployment Status](https://ach-azureforge-iss.vsrm.visualstudio.com/_apis/public/Release/badge/4ad0f0a6-2ec1-465f-99a1-4c3726de6d35/1/3)
 
 ## [>> Pattern Library Demo](https://patterns.axa.ch)


### PR DESCRIPTION
Problem: Travis is unreliable and often displays an incorrect state. Since the deployment badge was already from azure (and the build badge from travis), I replaced the travis one with azure. This leads to faster response times and a more reliable and correct status update.

Result: https://github.com/axa-ch/patterns-library/blob/raphaellueckl-patch-1/README.md

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
