### PR TITLE
Rework axa-text to facilitate dynamic child updates

### DIFF
--- a/scripts/build/fix.js
+++ b/scripts/build/fix.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/*
+*  Fix incorrect component package.json files left over by a broken build.
+*  Example invocation:
+*  patterns-library$ ./scripts/build/fix.js
+*/
+
+// imports
+const { cwd } = process;
+const fs = require("fs");
+const path = require('path');
+
+// synchronous directory-walker iterator
+function *walkSync(dir, filter = /.*/, acceptable = () => true) {
+    const files = fs.readdirSync(dir);
+
+    for (const file of files) {
+        const pathToFile = path.join(dir, file);
+        const isDirectory = fs.statSync(pathToFile).isDirectory();
+        if (isDirectory) {
+            yield *walkSync(pathToFile, filter, acceptable);
+        } else if (filter.test(pathToFile) && acceptable(dir, file, pathToFile)) {
+            yield pathToFile.split(path.sep);
+        }
+    }
+}
+
+// helpers
+const requirePackageJSON = dir => fs.existsSync(path.join(dir, 'package.json'));
+
+const currentDirectory = cwd();
+
+// find all importable components ...
+for (const file of walkSync(`src${path.sep}components`, /(?<!node_modules.*)package\.json$/, requirePackageJSON)) {
+    // construct full path to component package.json
+     const filePath = [currentDirectory, ...file].join(path.sep);
+     // load package.json's content
+     const packageJSON = require(filePath);
+     // remove 'main' key
+     delete packageJSON.main;
+     // write it back, properly formatted
+     fs.writeFileSync(filePath, JSON.stringify(packageJSON, /* no custom replacer */ null, /* number of spaces for formatting */ 2) + '\n');
+     // tell user
+     console.log('FIXED:', filePath);
+}

--- a/src/components/10-atoms/checkbox/ui.test.js
+++ b/src/components/10-atoms/checkbox/ui.test.js
@@ -172,7 +172,7 @@ test('should update checkbox when its children change', async t => {
   const checkboxChildLabel = await Selector(() =>
     document.querySelector('.second')
   )
-    .find('.a-text--size-3')
+    .find('axa-text[variant="size-3"] > *')
     .addCustomDOMProperties({
       innerHTML: el => el.innerHTML,
     });

--- a/src/components/10-atoms/text/CHANGELOG.md
+++ b/src/components/10-atoms/text/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 3.0.3
+
+- bugfix to satisfy user expectation of dynamic child updates being reflected, plus general improvements of
+  implementation.
+
 ## Version 3.0.0
 
 - The variants are now mutually exclusive, which means that you cannot combine multiple of them. E.g. `<axa-text variant="size-1 bold"></...>`

--- a/src/components/10-atoms/text/README.md
+++ b/src/components/10-atoms/text/README.md
@@ -1,8 +1,8 @@
 # Text
 
-Allows you to control all the possible axa text styles by a component.
+A convenience component to apply possible AXA text styles to a piece of text.
 
-It accepts a simple text as children or a HTML tag like `<p>` or `<span>`. Please make sure that only one direct HTML child is provided.
+It accepts simple text strings as children or top-level HTML tags like `<p>` or `<span>`. Nested HTML tags are not supported.
 
 ## Usage
 

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -1,4 +1,3 @@
-/* global Text */
 import { css, unsafeCSS } from 'lit-element';
 import NoShadowDOM from '../../../utils/no-shadow';
 
@@ -6,6 +5,8 @@ import NoShadowDOM from '../../../utils/no-shadow';
 import defineOnce from '../../../utils/define-once';
 import { applyDefaults } from '../../../utils/with-react';
 import styles from './index.scss';
+
+const TEXT_NODE_TYPE = 3;
 
 // N.B. This custom element is 'open' (no ShadowDOM) so that screen readers can discover
 // p(aragraph) tags inside
@@ -54,7 +55,7 @@ class AXAText extends NoShadowDOM {
   render() {
     // do we have 'pure', non-empty text, e.g. <axa-text>Hello, World</axa-text>?
     const nonWhitespaceTextNodes = [...this.childNodes].filter(
-      node => node instanceof Text && node.textContent.trim()
+      node => node.nodeType === TEXT_NODE_TYPE && node.textContent.trim()
     );
     if (nonWhitespaceTextNodes.length) {
       // yes, wrap it in 1 <p> node to keep screenreaders happy (they offer

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -1,3 +1,4 @@
+/* global Text */
 import { css, unsafeCSS } from 'lit-element';
 import NoShadowDOM from '../../../utils/no-shadow';
 
@@ -6,6 +7,8 @@ import defineOnce from '../../../utils/define-once';
 import { applyDefaults } from '../../../utils/with-react';
 import styles from './index.scss';
 
+// N.B. This custom element is 'open' (no ShadowDOM) so that screen readers can discover
+// p(aragraph) tags inside
 class AXAText extends NoShadowDOM {
   static get tagName() {
     return 'axa-text';
@@ -26,6 +29,52 @@ class AXAText extends NoShadowDOM {
   constructor() {
     super();
     applyDefaults(this);
+  }
+
+  watch(mode) {
+    switch (mode) {
+      case 'stop':
+        if (this._observer) {
+          this._observer.disconnect();
+        }
+        break;
+      case 'start':
+        if (!this._observer) {
+          this._observer = new MutationObserver(() => this.render());
+        }
+        this._observer.observe(this, {
+          childList: true,
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  render() {
+    // do we have 'pure', non-empty text, e.g. <axa-text>Hello, World</axa-text>?
+    const nonWhitespaceTextNodes = [...this.childNodes].filter(
+      node => node instanceof Text && node.textContent.trim()
+    );
+    if (nonWhitespaceTextNodes.length) {
+      // yes, wrap it in 1 <p> node to keep screenreaders happy (they offer
+      // paragraph-to-paragraph-jumping keyboard shortcuts that work by detecting <p>s):
+      const paragraph = document.createElement('p');
+      paragraph.textContent = this.textContent;
+      // pause child-update watcher
+      this.watch('stop');
+      // delete the children, now that their content has been harvested
+      this.innerHTML = '';
+      // add the <p> node
+      this.appendChild(paragraph);
+      // restart child-update watcher
+      this.watch('start');
+    }
+  }
+
+  disconnectedCallback() {
+    // remove installed observer
+    this.watch('stop');
   }
 }
 

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -38,9 +38,12 @@ class AXAText extends NoShadowDOM {
       'a-text--bold': variant.indexOf('bold') > -1,
     };
 
-    Object.keys(classes).forEach(
-      _class => classes[_class] && this.classList.add(_class)
-    );
+    Object.keys(classes).forEach(_class => {
+      this.classList.remove(_class);
+      if (classes[_class]) {
+        this.classList.add(_class);
+      }
+    });
   }
 }
 

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -29,36 +29,18 @@ class AXAText extends NoShadowDOM {
   }
 
   render() {
-    // eslint-disable-next-line prefer-destructuring
-    const variant = this.variant;
-    const isSize2 = variant.indexOf('size-2');
-    const isSize3 = variant.indexOf('size-3');
-    const isBold = variant.indexOf('bold');
+    const { variant } = this;
 
-    const classes = ['a-text'];
-    if (isSize2 === 0) {
-      classes.push('a-text--size-2');
-    }
-    if (isSize3 === 0) {
-      classes.push('a-text--size-3');
-    }
-    if (isBold === 0) {
-      classes.push('a-text--bold');
-    }
+    const classes = {
+      'a-text': true,
+      'a-text--size-2': variant.indexOf('size-2') > -1,
+      'a-text--size-3': variant.indexOf('size-3') > -1,
+      'a-text--bold': variant.indexOf('bold') > -1,
+    };
 
-    const { firstChild, firstElementChild } = this;
-
-    // nodeType === 3 is Text
-    if (firstChild && firstChild.nodeType === 3 && firstElementChild === null) {
-      const p = document.createElement('p');
-      p.innerHTML = firstChild.textContent;
-      p.className = classes.join(' ');
-      this.innerHTML = '';
-      this.appendChild(p);
-      // if firstElementChild is there, apply classes on the first element
-    } else if (firstElementChild) {
-      classes.forEach(_class => firstElementChild.classList.add(_class));
-    }
+    Object.keys(classes).forEach(
+      _class => classes[_class] && this.classList.add(_class)
+    );
   }
 }
 

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -19,31 +19,13 @@ class AXAText extends NoShadowDOM {
 
   static get properties() {
     return {
-      variant: { type: String },
+      variant: { type: String, reflect: true },
     };
   }
 
   constructor() {
     super();
     applyDefaults(this);
-  }
-
-  render() {
-    const { variant } = this;
-
-    const classes = {
-      'a-text': true,
-      'a-text--size-2': variant.indexOf('size-2') > -1,
-      'a-text--size-3': variant.indexOf('size-3') > -1,
-      'a-text--bold': variant.indexOf('bold') > -1,
-    };
-
-    Object.keys(classes).forEach(_class => {
-      this.classList.remove(_class);
-      if (classes[_class]) {
-        this.classList.add(_class);
-      }
-    });
   }
 }
 

--- a/src/components/10-atoms/text/index.scss
+++ b/src/components/10-atoms/text/index.scss
@@ -1,4 +1,4 @@
-.a-text, .a-text > * {
+axa-text, axa-text > * {
   @include typo(primary, medium-1);
 
   @include breakpoint($mediaquery-md-up) {
@@ -8,7 +8,7 @@
   margin: 0;
 }
 
-.a-text--size-2, .a-text--size-2 > * {
+axa-text[variant="size-2"], axa-text[variant="size-2"] > * {
   @include typo(primary, medium);
 
   @include breakpoint($mediaquery-md-up) {
@@ -16,7 +16,7 @@
   }
 }
 
-.a-text--size-3, .a-text--size-3 > * {
+axa-text[variant="size-3"], axa-text[variant="size-3"] > * {
   @include typo(primary, small-1);
 
   @include breakpoint($mediaquery-md-up) {
@@ -24,6 +24,6 @@
   }
 }
 
-.a-text--bold, .a-text--bold > * {
+axa-text[variant="bold"], axa-text[variant="bold"] > *{
   @include _font(primary, bold);
 }

--- a/src/components/10-atoms/text/index.scss
+++ b/src/components/10-atoms/text/index.scss
@@ -1,16 +1,14 @@
-.a-text {
+.a-text, .a-text > * {
   @include typo(primary, medium-1);
 
   @include breakpoint($mediaquery-md-up) {
     @include typo(primary, large);
   }
-}
 
-p.a-text {
   margin: 0;
 }
 
-.a-text--size-2 {
+.a-text--size-2, .a-text--size-2 > * {
   @include typo(primary, medium);
 
   @include breakpoint($mediaquery-md-up) {
@@ -18,7 +16,7 @@ p.a-text {
   }
 }
 
-.a-text--size-3 {
+.a-text--size-3, .a-text--size-3 > * {
   @include typo(primary, small-1);
 
   @include breakpoint($mediaquery-md-up) {
@@ -26,14 +24,6 @@ p.a-text {
   }
 }
 
-.a-text--size-4 {
-  @include typo(primary, small);
-
-  @include breakpoint($mediaquery-md-up) {
-    @include typo(primary, small-1);
-  }
-}
-
-.a-text--bold {
+.a-text--bold, .a-text--bold > * {
   @include _font(primary, bold);
 }

--- a/src/components/10-atoms/text/index.scss
+++ b/src/components/10-atoms/text/index.scss
@@ -1,4 +1,4 @@
-axa-text, axa-text > * {
+axa-text > * {
   @include typo(primary, medium-1);
 
   @include breakpoint($mediaquery-md-up) {
@@ -8,7 +8,7 @@ axa-text, axa-text > * {
   margin: 0;
 }
 
-axa-text[variant="size-2"], axa-text[variant="size-2"] > * {
+axa-text[variant="size-2"] > * {
   @include typo(primary, medium);
 
   @include breakpoint($mediaquery-md-up) {
@@ -16,7 +16,7 @@ axa-text[variant="size-2"], axa-text[variant="size-2"] > * {
   }
 }
 
-axa-text[variant="size-3"], axa-text[variant="size-3"] > * {
+axa-text[variant="size-3"] > * {
   @include typo(primary, small-1);
 
   @include breakpoint($mediaquery-md-up) {
@@ -24,6 +24,6 @@ axa-text[variant="size-3"], axa-text[variant="size-3"] > * {
   }
 }
 
-axa-text[variant="bold"], axa-text[variant="bold"] > *{
+axa-text[variant="bold"] > *{
   @include _font(primary, bold);
 }

--- a/src/components/10-atoms/text/story.js
+++ b/src/components/10-atoms/text/story.js
@@ -1,6 +1,6 @@
 /* global document */
 import { storiesOf } from '@storybook/html';
-import { select, boolean, withKnobs } from '@storybook/addon-knobs';
+import { select, boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
@@ -25,27 +25,23 @@ storiesOf('Components|Atoms/Text', module)
   .add('Text', () => {
     const variant = select('variant', variantOptions, '');
     const addSpanTag = boolean('Add <span> tag', false);
+    const content = text(
+      'text',
+      `Is your car your pride and joy, or just a means of getting from A to
+    B ? Whichever applies to you, it'll certainly have the best
+    insurance with us. Calculate your premium online – You keep your
+    advisor even when you purchase from us online.`
+    );
     const wrapper = document.createElement('div');
-    const template = addSpanTag // setting variables in the axaText tag does not work, therefore text is hardcoded twice
+    const template = addSpanTag
       ? html`
           <axa-text variant="${variant}">
-            Is your car your pride and joy, or just a means of getting from A to
-            B ? Whichever applies to you, it'll certainly have the best
-            insurance with us. Calculate your premium online – You keep your
-            advisor even when you purchase from us online.
+            <span>${content}</span>
           </axa-text>
         `
       : html`
-          <axa-text variant="${variant}">
-            <span
-              >Is your car your pride and joy, or just a means of getting from A
-              to B ? Whichever applies to you, it'll certainly have the best
-              insurance with us. Calculate your premium online – You keep your
-              advisor even when you purchase from us online.</span
-            >
-          </axa-text>
+          <axa-text variant="${variant}">${content}</axa-text>
         `;
-
     render(template, wrapper);
     return wrapper;
   });

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -1,4 +1,4 @@
-import { Selector } from 'testcafe';
+import { Selector, ClientFunction } from 'testcafe';
 
 const host = process.env.TEST_HOST_STORYBOOK_URL;
 
@@ -20,9 +20,7 @@ test('should have correct font definitions for text size 1', async t => {
     document.querySelector('axa-text > *')
   );
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('18px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('18px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -30,9 +28,7 @@ test('should have correct font definitions for text size 1', async t => {
 
   await t.resizeWindow(800, 600);
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('20px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('20px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -52,9 +48,7 @@ test('should have correct font definitions for text size 2', async t => {
     document.querySelector('axa-text[variant="size-2"] > *')
   );
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('16px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('16px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -62,9 +56,7 @@ test('should have correct font definitions for text size 2', async t => {
 
   await t.resizeWindow(800, 600);
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('18px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('18px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -84,9 +76,7 @@ test('should have correct font definitions for text size 3', async t => {
     document.querySelector('axa-text[variant="size-3"] > *')
   );
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('14px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('14px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -94,9 +84,7 @@ test('should have correct font definitions for text size 3', async t => {
 
   await t.resizeWindow(800, 600);
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('16px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('16px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -116,9 +104,7 @@ test('should have correct font definitions for text size 2 with custom span tag'
     document.querySelector('axa-text[variant="size-2"] > *')
   );
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('16px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('16px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -126,9 +112,7 @@ test('should have correct font definitions for text size 2 with custom span tag'
 
   await t.resizeWindow(800, 600);
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('18px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('18px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -161,12 +145,10 @@ fixture('Text - Variant')
 
 test('should be mutually exclusive', async t => {
   const $axaElemChild = await Selector(() =>
-    document.querySelector('axa-text[variant="size-1 bold"] > *')
+    document.querySelector('axa-text[variant] > *')
   );
 
-  await t
-    .expect(await $axaElemChild.getStyleProperty('font-size'))
-    .eql('20px');
+  await t.expect(await $axaElemChild.getStyleProperty('font-size')).eql('20px');
 
   await t
     .expect(await $axaElemChild.getStyleProperty('line-height'))
@@ -176,4 +158,29 @@ test('should be mutually exclusive', async t => {
   await t
     .expect(await $axaElemChild.getStyleProperty('font-weight'))
     .notEql('700');
+});
+
+test('should update pure text dynamically and wrap in <p>', async t => {
+  const $axaElem = await Selector(() =>
+    document.querySelector('axa-text[variant]')
+  ).addCustomDOMProperties({
+    innerHTML: el => el.innerHTML,
+  });
+
+  const setText = ClientFunction(text => {
+    const node = document.querySelector('axa-text');
+    node.textContent = text;
+    return text;
+  });
+
+  const oldText = $axaElem.textContent;
+  const newText = 'Hello, world.';
+
+  await setText(newText);
+  await t.expect(await $axaElem.innerText).contains(newText);
+  await t.expect(await $axaElem.innerHTML).contains('<p>');
+
+  await setText(oldText);
+  await t.expect(await $axaElem.innerText).contains(oldText);
+  await t.expect(await $axaElem.innerHTML).contains('<p>');
 });

--- a/src/components/10-atoms/text/ui.test.js
+++ b/src/components/10-atoms/text/ui.test.js
@@ -9,39 +9,33 @@ fixture('Text - basic functionality')
   });
 
 const TAG = 'axa-text';
-const CLASS = '.a-text';
 
 test('should render text', async t => {
   const $axaElem = await Selector(TAG);
   await t.expect($axaElem.exists).ok();
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text')
-  );
-  const $axaElemShadowEl = await $axaElemShadow.find(CLASS);
-  await t.expect($axaElemShadowEl.exists).ok();
 });
 
 test('should have correct font definitions for text size 1', async t => {
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text .a-text')
+  const $axaElemChild = await Selector(() =>
+    document.querySelector('axa-text > *')
   );
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('18px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('27px');
 
   await t.resizeWindow(800, 600);
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('20px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('30px');
 });
 
@@ -54,26 +48,26 @@ fixture('Text - Size 2')
   });
 
 test('should have correct font definitions for text size 2', async t => {
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text[variant="size-2"] .a-text')
+  const $axaElemChild = await Selector(() =>
+    document.querySelector('axa-text[variant="size-2"] > *')
   );
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('16px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('24px');
 
   await t.resizeWindow(800, 600);
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('18px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('27px');
 });
 
@@ -86,26 +80,26 @@ fixture('Text - Size 3')
   });
 
 test('should have correct font definitions for text size 3', async t => {
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text[variant="size-3"] .a-text')
+  const $axaElemChild = await Selector(() =>
+    document.querySelector('axa-text[variant="size-3"] > *')
   );
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('14px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('17px');
 
   await t.resizeWindow(800, 600);
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('16px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('24px');
 });
 
@@ -118,26 +112,26 @@ fixture('Text - Size 2 with custom tag')
   });
 
 test('should have correct font definitions for text size 2 with custom span tag', async t => {
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text[variant="size-2"] .a-text')
+  const $axaElemChild = await Selector(() =>
+    document.querySelector('axa-text[variant="size-2"] > *')
   );
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('16px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('24px');
 
   await t.resizeWindow(800, 600);
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('18px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('27px');
 });
 
@@ -148,12 +142,12 @@ fixture('Text - Bold')
   });
 
 test('should have correct font weight for text bold', async t => {
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text[variant="bold"] .a-text')
+  const $axaElemChild = await Selector(() =>
+    document.querySelector('axa-text[variant="bold"] > *')
   );
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-weight'))
+    .expect(await $axaElemChild.getStyleProperty('font-weight'))
     .eql('700');
 });
 
@@ -166,20 +160,20 @@ fixture('Text - Variant')
   });
 
 test('should be mutually exclusive', async t => {
-  const $axaElemShadow = await Selector(() =>
-    document.querySelector('axa-text[variant="size-1 bold"] .a-text')
+  const $axaElemChild = await Selector(() =>
+    document.querySelector('axa-text[variant="size-1 bold"] > *')
   );
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-size'))
+    .expect(await $axaElemChild.getStyleProperty('font-size'))
     .eql('20px');
 
   await t
-    .expect(await $axaElemShadow.getStyleProperty('line-height'))
+    .expect(await $axaElemChild.getStyleProperty('line-height'))
     .eql('30px');
 
   // 'size-1' attributes should be set, but not the 'bold' ones.
   await t
-    .expect(await $axaElemShadow.getStyleProperty('font-weight'))
+    .expect(await $axaElemChild.getStyleProperty('font-weight'))
     .notEql('700');
 });

--- a/src/other/landingpage/story.js
+++ b/src/other/landingpage/story.js
@@ -1,8 +1,8 @@
 import { storiesOf } from '@storybook/html';
 import { html, render } from 'lit-html';
 import Readme from '../../../README.md';
-import '../../components/10-atoms/text/lib';
-import '../../components/10-atoms/heading/lib';
+import '../../components/10-atoms/text';
+import '../../components/10-atoms/heading';
 
 const story = storiesOf('Welcome', module);
 story.addParameters({


### PR DESCRIPTION
Fixes #1619.
Fixes #1673 en passant (it hindered development of axa-text).

This is a clean re-implementation that allows us to sidestep all dynamic update issues that plagued axa-text. It uses the same approach as axa-fieldset.