### PR TITLE
CodePreview: show framework specific code

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -3,6 +3,7 @@ import './addons/changelog/register.js';
 import '@storybook/addon-knobs/register';
 import { STORIES_CONFIGURED, STORY_MISSING } from '@storybook/core-events';
 import addonAPI from '@storybook/addons';
+import "storybook-addon-preview/register";
 
 addonAPI.register('axa-ch/defaultpage', storybookAPI => {
   storybookAPI.on(STORIES_CONFIGURED, (kind, story) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.8.3"
 			}
@@ -209,7 +208,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
 			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -323,7 +321,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -959,7 +956,6 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
 			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -996,7 +992,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 			"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -1017,7 +1012,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.27.tgz",
 			"integrity": "sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==",
-			"dev": true,
 			"requires": {
 				"@emotion/sheet": "0.9.4",
 				"@emotion/stylis": "0.8.5",
@@ -1029,7 +1023,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.27.tgz",
 			"integrity": "sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/cache": "^10.0.27",
@@ -1043,7 +1036,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
 			"integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-			"dev": true,
 			"requires": {
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3",
@@ -1053,14 +1045,12 @@
 		"@emotion/hash": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
-			"integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==",
-			"dev": true
+			"integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
 		},
 		"@emotion/is-prop-valid": {
 			"version": "0.8.6",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz",
 			"integrity": "sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==",
-			"dev": true,
 			"requires": {
 				"@emotion/memoize": "0.7.4"
 			}
@@ -1068,14 +1058,12 @@
 		"@emotion/memoize": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-			"dev": true
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
 		},
 		"@emotion/serialize": {
 			"version": "0.11.15",
 			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.15.tgz",
 			"integrity": "sha512-YE+qnrmGwyR+XB5j7Bi+0GT1JWsdcjM/d4POu+TXkcnrRs4RFCCsi3d/Ebf+wSStHqAlTT2+dfd+b9N9EO2KBg==",
-			"dev": true,
 			"requires": {
 				"@emotion/hash": "0.7.4",
 				"@emotion/memoize": "0.7.4",
@@ -1087,14 +1075,12 @@
 		"@emotion/sheet": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
-			"dev": true
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
 		},
 		"@emotion/styled": {
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
 			"integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
-			"dev": true,
 			"requires": {
 				"@emotion/styled-base": "^10.0.27",
 				"babel-plugin-emotion": "^10.0.27"
@@ -1104,7 +1090,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.27.tgz",
 			"integrity": "sha512-ufHM/HhE3nr309hJG9jxuFt71r6aHn7p+bwXduFxcwPFEfBIqvmZUMtZ9YxIsY61PVwK3bp4G1XhaCzy9smVvw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/is-prop-valid": "0.8.6",
@@ -1115,26 +1100,22 @@
 		"@emotion/stylis": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-			"dev": true
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
 		},
 		"@emotion/unitless": {
 			"version": "0.7.5",
 			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-			"dev": true
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
 		},
 		"@emotion/utils": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-			"dev": true
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
 		},
 		"@emotion/weak-memoize": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-			"dev": true
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
@@ -1304,8 +1285,7 @@
 		"@icons/material": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-			"dev": true
+			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
 		},
 		"@jest/console": {
 			"version": "24.9.0",
@@ -3314,7 +3294,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.1.tgz",
 			"integrity": "sha512-Ov1j1J+pSgXliJHFL7XWhjyREwc6GxeWfgBTa5MMH5eRmYtHbPhaovba4xKo7aTVCg8fxkt2yDMNSpvwfUP+pA==",
-			"dev": true,
 			"requires": {
 				"create-react-context": "0.3.0",
 				"invariant": "^2.2.3",
@@ -3760,6 +3739,14 @@
 				}
 			}
 		},
+		"@storybook/csf": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
+			"integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"@storybook/html": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@storybook/html/-/html-5.2.1.tgz",
@@ -4006,8 +3993,12 @@
 		"@types/history": {
 			"version": "4.7.5",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
-			"integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==",
-			"dev": true
+			"integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
+		},
+		"@types/is-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
+			"integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w=="
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
@@ -4061,14 +4052,17 @@
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+		},
+		"@types/prismjs": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.16.0.tgz",
+			"integrity": "sha512-mEyuziLrfDCQ4juQP1k706BUU/c8OGn/ZFl69AXXY6dStHClKX4P+N8+rhqpul1vRDA2VOygzMRSJJZHyDEOfw=="
 		},
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-			"dev": true
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/q": {
 			"version": "1.5.2",
@@ -4080,7 +4074,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.0.tgz",
 			"integrity": "sha512-0aL79bFPJzJOJOOMZm2301ErQVaveBdpW88uuavXymUlcYIAOCmI1ujJ2XLH6Mzn76O94eQCHIl1FDzNNKJCYA==",
-			"dev": true,
 			"requires": {
 				"@types/history": "*",
 				"@types/react": "*"
@@ -4090,10 +4083,17 @@
 			"version": "16.9.21",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.21.tgz",
 			"integrity": "sha512-xpmenCMeBwJRct8vmIfczlgdOXWIWASoOM857kxKfHlVQvDltRh7IFRVfGws79iO2jkNPXOeWREyKoClzhBaQA==",
-			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
+			}
+		},
+		"@types/react-color": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.1.tgz",
+			"integrity": "sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==",
+			"requires": {
+				"@types/react": "*"
 			}
 		},
 		"@types/react-syntax-highlighter": {
@@ -4101,6 +4101,14 @@
 			"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz",
 			"integrity": "sha512-dF49hC4FZp1dIKyzacOrHvqMUe8U2IXyQCQXOcT1e6n64gLBp+xM6qGtPsThIT9XjiIHSg2W5Jc2V5IqekBfnA==",
 			"dev": true,
+			"requires": {
+				"@types/react": "*"
+			}
+		},
+		"@types/react-textarea-autosize": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
+			"integrity": "sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -4119,6 +4127,11 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
 			"dev": true
+		},
+		"@types/webpack-env": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.1.tgz",
+			"integrity": "sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA=="
 		},
 		"@types/yargs": {
 			"version": "13.0.8",
@@ -4458,7 +4471,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -4467,7 +4479,6 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
 			"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
-			"dev": true,
 			"requires": {
 				"humanize-ms": "^1.2.1"
 			}
@@ -4605,8 +4616,7 @@
 		"ansi-escapes": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-			"dev": true
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
 		},
 		"ansi-html": {
 			"version": "0.0.7",
@@ -4624,7 +4634,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -4680,8 +4689,7 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"arch": {
 			"version": "2.1.1",
@@ -5031,6 +5039,22 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
+		},
+		"axios": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"requires": {
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				}
+			}
 		},
 		"axobject-query": {
 			"version": "2.1.2",
@@ -5602,7 +5626,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.27.tgz",
 			"integrity": "sha512-SUNYcT4FqhOqvwv0z1oeYhqgheU8qrceLojuHyX17ngo7WtWqN5I9l3IGHzf21Xraj465CVzF4IvOlAF+3ed0A==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@emotion/hash": "0.7.4",
@@ -5641,7 +5664,6 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
 			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
@@ -5787,8 +5809,7 @@
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -6541,8 +6562,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -6644,6 +6664,11 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
+		"binaryextensions": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.2.0.tgz",
+			"integrity": "sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw=="
+		},
 		"bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -6652,6 +6677,15 @@
 			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"bl": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"requires": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"block-stream": {
@@ -6666,8 +6700,7 @@
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"dev": true
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"bmp-js": {
 			"version": "0.1.0",
@@ -6788,7 +6821,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -6999,17 +7031,35 @@
 				"isarray": "^1.0.0"
 			}
 		},
+		"buffer-alloc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"requires": {
+				"buffer-alloc-unsafe": "^1.1.0",
+				"buffer-fill": "^1.0.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+		},
 		"buffer-equal": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
 			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
 			"dev": true
 		},
+		"buffer-fill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -7032,8 +7082,7 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-			"dev": true
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
 		},
 		"byline": {
 			"version": "5.0.0",
@@ -7167,8 +7216,7 @@
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 		},
 		"camel-case": {
 			"version": "4.1.1",
@@ -7208,8 +7256,7 @@
 		"can-use-dom": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-			"integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=",
-			"dev": true
+			"integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001028",
@@ -7225,6 +7272,11 @@
 			"requires": {
 				"rsvp": "^4.8.4"
 			}
+		},
+		"capture-stack-trace": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
 		},
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.3.0",
@@ -7256,7 +7308,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -7266,26 +7317,22 @@
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-			"dev": true
+			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
 		},
 		"character-entities-legacy": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-			"dev": true
+			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
 		},
 		"character-reference-invalid": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-			"dev": true
+			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
 		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -7316,8 +7363,7 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"dev": true
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"chrome-remote-interface": {
 			"version": "0.25.7",
@@ -7411,8 +7457,7 @@
 		"classnames": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-			"dev": true
+			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clean-css": {
 			"version": "4.2.3",
@@ -7447,10 +7492,14 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
+		},
+		"cli-spinners": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
 		},
 		"cli-table3": {
 			"version": "0.5.1",
@@ -7499,14 +7548,12 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-			"dev": true
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"clipboard": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
 			"integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"good-listener": "^1.2.2",
@@ -7666,6 +7713,69 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true
 		},
+		"codesandbox": {
+			"version": "2.1.12",
+			"resolved": "https://registry.npmjs.org/codesandbox/-/codesandbox-2.1.12.tgz",
+			"integrity": "sha512-DDveHGGR3dGDgLwAbK0Z75pgA+5Mm2OwigYwrNgEc0m4anzTXWnk0CrWAIRJzDm1QCk97w17/DYl1R3LCYi3Tw==",
+			"requires": {
+				"axios": "^0.18.1",
+				"chalk": "^2.4.1",
+				"codesandbox-import-util-types": "^2.1.9",
+				"codesandbox-import-utils": "^2.1.12",
+				"commander": "^2.9.0",
+				"datauri": "^1.1.0",
+				"filesize": "^3.6.1",
+				"fs-extra": "^3.0.1",
+				"git-branch": "^1.0.0",
+				"git-repo-name": "^0.6.0",
+				"git-username": "^0.5.0",
+				"humps": "^2.0.1",
+				"inquirer": "^6.2.2",
+				"lodash": "^4.17.5",
+				"lz-string": "^1.4.4",
+				"ms": "^2.0.0",
+				"open": "^6.3.0",
+				"ora": "^1.3.0",
+				"pacote": "^2.7.36",
+				"shortid": "^2.2.8",
+				"update-notifier": "^2.2.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^3.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"jsonfile": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				}
+			}
+		},
+		"codesandbox-import-util-types": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/codesandbox-import-util-types/-/codesandbox-import-util-types-2.1.9.tgz",
+			"integrity": "sha512-Vc4qh+neVfHtS3RG+7wvaErMoEKdNTnLFnyj4Dcbn3NV7v9nlPj/z6MGhHp9S+vAjegWorFzxg9lKB1WGHTt5Q=="
+		},
+		"codesandbox-import-utils": {
+			"version": "2.1.12",
+			"resolved": "https://registry.npmjs.org/codesandbox-import-utils/-/codesandbox-import-utils-2.1.12.tgz",
+			"integrity": "sha512-eTP3TboAlFEZDblCf3uwnV0S3tZCKnoubDONibAE9rI2pdximDGFQdHUpHPU4509bQ6UF2w+DVExlhkxmLFenA==",
+			"requires": {
+				"codesandbox-import-util-types": "^2.1.9",
+				"istextorbinary": "^2.2.1",
+				"lz-string": "^1.4.4"
+			}
+		},
 		"coffeescript": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
@@ -7696,7 +7806,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -7704,8 +7813,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "1.5.3",
@@ -7762,14 +7870,12 @@
 		"comma-separated-tokens": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-			"dev": true
+			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
 		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"common-tags": {
 			"version": "1.8.0",
@@ -7813,14 +7919,12 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -7836,6 +7940,34 @@
 			"requires": {
 				"ini": "^1.3.4",
 				"proto-list": "~1.2.1"
+			}
+		},
+		"configstore": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+			"requires": {
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"make-dir": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"console-browserify": {
@@ -8164,7 +8296,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -8185,7 +8316,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -8205,7 +8335,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.1.tgz",
 			"integrity": "sha512-btru1Q6RD9wbonIvEU5EfnhIRGHLo//BGXQ1hNAD2avIs/nBZlpbOeKtv3mhoUByN4DB9Cb6/vXBymj1S43KmA==",
-			"dev": true,
 			"requires": {
 				"toggle-selection": "^1.0.6"
 			}
@@ -8243,8 +8372,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"corejs-upgrade-webpack-plugin": {
 			"version": "2.2.0",
@@ -8260,7 +8388,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
 			"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.1.0",
@@ -8283,6 +8410,14 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
+			}
+		},
+		"create-error-class": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"requires": {
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"create-hash": {
@@ -8316,7 +8451,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
 			"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-			"dev": true,
 			"requires": {
 				"gud": "^1.0.0",
 				"warning": "^4.0.3"
@@ -8350,7 +8484,6 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -8381,6 +8514,11 @@
 			"resolved": "https://registry.npmjs.org/crypto-md5/-/crypto-md5-1.0.0.tgz",
 			"integrity": "sha1-zMjadQx1PH7curxUKWdHKjhOhrs=",
 			"dev": true
+		},
+		"crypto-random-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 		},
 		"css": {
 			"version": "2.2.3",
@@ -8528,8 +8666,7 @@
 		"csstype": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
-			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
-			"dev": true
+			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
 		},
 		"cuint": {
 			"version": "0.2.2",
@@ -8546,11 +8683,18 @@
 				"array-find-index": "^1.0.1"
 			}
 		},
+		"cwd": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
+			"integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
+			"requires": {
+				"find-pkg": "^0.1.0"
+			}
+		},
 		"cyclist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
-			"dev": true
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.6",
@@ -8598,6 +8742,16 @@
 						"webidl-conversions": "^4.0.2"
 					}
 				}
+			}
+		},
+		"datauri": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/datauri/-/datauri-1.1.0.tgz",
+			"integrity": "sha512-0q+cTTKx7q8eDteZRIQLTFJuiIsVing17UbWTPssY4JLSMaYsk/VKpNulBDo9NSgQWcvlPrkEHW8kUO67T/7mQ==",
+			"requires": {
+				"image-size": "^0.6.2",
+				"mimer": "^0.3.2",
+				"semver": "^5.5.0"
 			}
 		},
 		"dateformat": {
@@ -8670,7 +8824,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
 			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-			"dev": true,
 			"requires": {
 				"is-arguments": "^1.0.4",
 				"is-date-object": "^1.0.1",
@@ -8679,6 +8832,11 @@
 				"object-keys": "^1.1.1",
 				"regexp.prototype.flags": "^1.2.0"
 			}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -8689,8 +8847,7 @@
 		"deep-object-diff": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
-			"dev": true
+			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
 		},
 		"defaults": {
 			"version": "1.0.3",
@@ -8705,7 +8862,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -8810,7 +8966,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
 			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-			"dev": true,
 			"optional": true
 		},
 		"delegates": {
@@ -8867,6 +9022,11 @@
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 			"dev": true
+		},
+		"detect-node": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
 		},
 		"detect-port": {
 			"version": "1.3.0",
@@ -8988,7 +9148,6 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
 			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2"
 			}
@@ -9020,8 +9179,7 @@
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-			"dev": true
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
 		},
 		"domain-browser": {
 			"version": "1.2.0",
@@ -9077,7 +9235,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -9180,11 +9337,15 @@
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
+		"duplexer3": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
 			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -9200,6 +9361,22 @@
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
+			}
+		},
+		"editions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
+			"integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
+			"requires": {
+				"errlop": "^2.0.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"ee-first": {
@@ -9272,7 +9449,6 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
 			"integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/weak-memoize": "0.2.5",
@@ -9298,7 +9474,6 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -9307,7 +9482,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -9389,8 +9563,12 @@
 		"err-code": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-			"dev": true
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+		},
+		"errlop": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/errlop/-/errlop-2.0.0.tgz",
+			"integrity": "sha512-z00WIrQhtOMUnjdTG0O4f6hMG64EVccVDBy2WwgjcF8S4UB1exGYuc2OFwmdQmsJwLQVEIHWHPCz/omXXgAZHw=="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -9405,7 +9583,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -9423,7 +9600,6 @@
 			"version": "1.17.4",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
 			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
@@ -9471,7 +9647,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -9487,14 +9662,12 @@
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-			"dev": true
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -9518,14 +9691,12 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-			"dev": true
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.14.1",
@@ -10122,8 +10293,7 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -10160,8 +10330,7 @@
 		"eventemitter3": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
-			"dev": true
+			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
 		},
 		"events": {
 			"version": "3.1.0",
@@ -10198,7 +10367,6 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -10269,6 +10437,14 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
 				}
+			}
+		},
+		"expand-tilde": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"requires": {
+				"os-homedir": "^1.0.1"
 			}
 		},
 		"expect": {
@@ -10386,7 +10562,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -10467,8 +10642,7 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-			"dev": true
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
 		"fast-glob": {
 			"version": "2.2.7",
@@ -10515,7 +10689,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
 			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-			"dev": true,
 			"requires": {
 				"format": "^0.2.0"
 			}
@@ -10548,7 +10721,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -10572,6 +10744,11 @@
 				"loader-utils": "^1.0.2",
 				"schema-utils": "^1.0.0"
 			}
+		},
+		"file-name": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
+			"integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc="
 		},
 		"file-system-cache": {
 			"version": "1.0.5",
@@ -10615,8 +10792,7 @@
 		"filesize": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
-			"dev": true
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -10744,11 +10920,27 @@
 				}
 			}
 		},
+		"find-file-up": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
+			"integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+			"requires": {
+				"fs-exists-sync": "^0.1.0",
+				"resolve-dir": "^0.1.0"
+			}
+		},
+		"find-pkg": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
+			"integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+			"requires": {
+				"find-file-up": "^0.1.2"
+			}
+		},
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-			"dev": true
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
 		},
 		"find-up": {
 			"version": "3.0.0",
@@ -10786,7 +10978,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
 			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.3.6"
@@ -10795,8 +10986,30 @@
 		"focus-lock": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
-			"integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==",
-			"dev": true
+			"integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw=="
+		},
+		"follow-redirects": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"requires": {
+				"debug": "=3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -10840,8 +11053,7 @@
 		"format": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
-			"dev": true
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -10874,11 +11086,20 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
 			}
+		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
+		"fs-exists-sync": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
 		},
 		"fs-extra": {
 			"version": "8.1.0",
@@ -10915,7 +11136,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -10926,8 +11146,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "1.2.11",
@@ -11502,8 +11721,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.name": {
 			"version": "1.0.12",
@@ -11790,8 +12008,7 @@
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -11806,6 +12023,31 @@
 			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
+			}
+		},
+		"git-branch": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/git-branch/-/git-branch-1.0.0.tgz",
+			"integrity": "sha512-ZTzuqw5Df8fyLXQWrX6hK+4FpNCdKzMcERlxENEGO5aKcLmG7MAszhrMhluUKNKmOS/JAGijDMQDXDCDw1mE/A=="
+		},
+		"git-config-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"fs-exists-sync": "^0.1.0",
+				"homedir-polyfill": "^1.0.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"git-raw-commits": {
@@ -11909,6 +12151,17 @@
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				}
+			}
+		},
+		"git-repo-name": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+			"integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
+			"requires": {
+				"cwd": "^0.9.1",
+				"file-name": "^0.1.0",
+				"lazy-cache": "^1.0.4",
+				"remote-origin-url": "^0.5.1"
 			}
 		},
 		"git-semver-tags": {
@@ -12018,6 +12271,32 @@
 				"git-up": "^4.0.0"
 			}
 		},
+		"git-username": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/git-username/-/git-username-0.5.1.tgz",
+			"integrity": "sha512-xjUjrj3i4kup2A3a/ZVZB1Nt0PUX7SU7KeVqIbXPdslT7NbNfyO04JMxBv4gar77JePdS+A6f05jG1Viy6+U1w==",
+			"requires": {
+				"remote-origin-url": "^0.4.0"
+			},
+			"dependencies": {
+				"parse-git-config": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.2.0.tgz",
+					"integrity": "sha1-Jygz/dFf6hRvt10zbSNrljtv9wY=",
+					"requires": {
+						"ini": "^1.3.3"
+					}
+				},
+				"remote-origin-url": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.4.0.tgz",
+					"integrity": "sha1-TT4pAvNOLTfRwmPYdxC3frQIajA=",
+					"requires": {
+						"parse-git-config": "^0.2.0"
+					}
+				}
+			}
+		},
 		"gitconfiglocal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
@@ -12031,7 +12310,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -12072,10 +12350,17 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
 			"integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-			"dev": true,
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "^0.11.10"
+			}
+		},
+		"global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"requires": {
+				"ini": "^1.3.4"
 			}
 		},
 		"global-modules": {
@@ -12151,17 +12436,33 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"delegate": "^3.1.2"
 			}
 		},
+		"got": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"requires": {
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-			"dev": true
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"graphlib": {
 			"version": "2.1.8",
@@ -12181,8 +12482,7 @@
 		"gud": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-			"dev": true
+			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
 		},
 		"gzip-size": {
 			"version": "5.1.1",
@@ -12234,7 +12534,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -12251,14 +12550,12 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -12321,14 +12618,12 @@
 		"hast-util-parse-selector": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
-			"integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q==",
-			"dev": true
+			"integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q=="
 		},
 		"hastscript": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.1.tgz",
 			"integrity": "sha512-xHo1Hkcqd0LlWNuDL3/BxwhgAGp3d7uEvCMgCTrBY+zsOooPPH+8KAvW8PCgl+GB8H3H44nfSaF0A4BQ+4xlYg==",
-			"dev": true,
 			"requires": {
 				"comma-separated-tokens": "^1.0.0",
 				"hast-util-parse-selector": "^2.0.0",
@@ -12382,7 +12677,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"dev": true,
 			"requires": {
 				"react-is": "^16.7.0"
 			}
@@ -12397,11 +12691,18 @@
 				"os-tmpdir": "^1.0.1"
 			}
 		},
+		"homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"requires": {
+				"parse-passwd": "^1.0.0"
+			}
+		},
 		"hosted-git-info": {
 			"version": "2.8.5",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
-			"dev": true
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -12561,8 +12862,7 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-			"dev": true
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
 		},
 		"http-errors": {
 			"version": "1.7.2",
@@ -12595,7 +12895,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-			"dev": true,
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
@@ -12605,7 +12904,6 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -12613,8 +12911,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -12639,7 +12936,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
 			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -12649,7 +12945,6 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -12666,16 +12961,19 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
+		},
+		"humps": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -12704,8 +13002,7 @@
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-			"dev": true
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -12721,6 +13018,11 @@
 			"requires": {
 				"minimatch": "^3.0.4"
 			}
+		},
+		"image-size": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
+			"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
 		},
 		"immer": {
 			"version": "1.10.0",
@@ -12741,7 +13043,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
 			"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -12750,8 +13051,7 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				}
 			}
 		},
@@ -12791,8 +13091,7 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-			"dev": true
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -12822,7 +13121,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -12831,14 +13129,12 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"init-package-json": {
 			"version": "1.10.3",
@@ -12860,7 +13156,6 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
 			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
@@ -12880,20 +13175,17 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -12903,7 +13195,6 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -12914,7 +13205,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					},
@@ -12922,8 +13212,7 @@
 						"ansi-regex": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 						}
 					}
 				}
@@ -12950,7 +13239,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -12964,8 +13252,7 @@
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -12996,14 +13283,12 @@
 		"is-alphabetical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-			"dev": true
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
 		},
 		"is-alphanumerical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
 			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -13012,14 +13297,12 @@
 		"is-arguments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-			"dev": true
+			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -13039,8 +13322,7 @@
 		"is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-			"dev": true
+			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -13074,14 +13356,12 @@
 		"is-date-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-decimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-			"dev": true
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -13133,8 +13413,7 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -13160,8 +13439,7 @@
 		"is-function": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-			"dev": true
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -13181,8 +13459,16 @@
 		"is-hexadecimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-			"dev": true
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+		},
+		"is-installed-globally": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"requires": {
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
+			}
 		},
 		"is-jquery-obj": {
 			"version": "0.1.1",
@@ -13201,6 +13487,11 @@
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
 			"dev": true
+		},
+		"is-npm": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -13225,8 +13516,7 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-			"dev": true
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-object": {
 			"version": "1.0.1",
@@ -13253,7 +13543,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -13268,7 +13557,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 			"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-			"dev": true,
 			"requires": {
 				"isobject": "^4.0.0"
 			},
@@ -13276,16 +13564,19 @@
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
 				}
 			}
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-			"dev": true
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-redirect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
 		},
 		"is-reference": {
 			"version": "1.1.4",
@@ -13300,7 +13591,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
 			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -13310,6 +13600,11 @@
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
 			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-root": {
 			"version": "2.1.0",
@@ -13341,8 +13636,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.5",
@@ -13354,7 +13648,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
@@ -13395,20 +13688,17 @@
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-			"dev": true
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -13501,6 +13791,16 @@
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0"
+			}
+		},
+		"istextorbinary": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+			"integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+			"requires": {
+				"binaryextensions": "^2.1.2",
+				"editions": "^2.2.0",
+				"textextensions": "^2.5.0"
 			}
 		},
 		"iterate-iterator": {
@@ -14042,8 +14342,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -14112,8 +14411,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -14221,6 +14519,19 @@
 				"colornames": "^1.1.1"
 			}
 		},
+		"latest-version": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"requires": {
+				"package-json": "^4.0.0"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+		},
 		"lazy-universal-dotenv": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.1.tgz",
@@ -14317,8 +14628,7 @@
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
 		},
 		"linux-platform-info": {
 			"version": "0.0.3",
@@ -14429,8 +14739,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -14447,8 +14756,7 @@
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -14465,8 +14773,7 @@
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
 		},
 		"lodash.set": {
 			"version": "4.3.2",
@@ -14502,8 +14809,7 @@
 		"lodash.throttle": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-			"dev": true
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
 		},
 		"lodash.toarray": {
 			"version": "4.4.0",
@@ -14522,6 +14828,14 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"requires": {
+				"chalk": "^2.0.1"
+			}
 		},
 		"log-update-async-hook": {
 			"version": "2.0.2",
@@ -14557,7 +14871,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -14581,6 +14894,11 @@
 				"tslib": "^1.10.0"
 			}
 		},
+		"lowercase-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+		},
 		"lowlight": {
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
@@ -14595,11 +14913,15 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
 			}
+		},
+		"lz-string": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
 		},
 		"macos-release": {
 			"version": "2.3.0",
@@ -14692,8 +15014,7 @@
 		"map-or-similar": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-			"integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
-			"dev": true
+			"integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
 		},
 		"map-reverse": {
 			"version": "1.0.1",
@@ -14730,7 +15051,6 @@
 			"version": "6.11.0",
 			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.0.tgz",
 			"integrity": "sha512-RH7LCJQ4RFmPqVeZEesKaO1biRzB/k4utoofmTCp3Eiw6D7qfvK8fzZq/2bjEJAtVkfPrM5SMt5APGf2rnaKMg==",
-			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -14754,8 +15074,7 @@
 		"material-colors": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-			"integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-			"dev": true
+			"integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -14783,14 +15102,12 @@
 		"memoize-one": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
-			"dev": true
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
 		},
 		"memoizerific": {
 			"version": "1.11.3",
 			"resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
 			"integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
-			"dev": true,
 			"requires": {
 				"map-or-similar": "^1.5.0"
 			}
@@ -14974,17 +15291,20 @@
 				"mime-db": "1.43.0"
 			}
 		},
+		"mimer": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/mimer/-/mimer-0.3.2.tgz",
+			"integrity": "sha512-N6NcgDQAevhP/02DQ/epK6daLy4NKrIHyTlJcO6qBiYn98q+Y4a/knNsAATCe1xLS2F0nEmJp+QYli2s8vKwyQ=="
+		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-			"dev": true
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"min-document": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-			"dev": true,
 			"requires": {
 				"dom-walk": "^0.1.0"
 			}
@@ -15005,7 +15325,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -15013,8 +15332,7 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-			"dev": true
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -15105,7 +15423,6 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -15113,8 +15430,7 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
 		},
@@ -15149,7 +15465,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -15162,8 +15477,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"multimatch": {
 			"version": "3.0.0",
@@ -15192,8 +15506,7 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"mv": {
 			"version": "2.1.1",
@@ -15331,7 +15644,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
 			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
-			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"json-parse-better-errors": "^1.0.0",
@@ -15740,7 +16052,6 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"resolve": "^1.10.0",
@@ -15843,7 +16154,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -15896,8 +16206,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -15933,20 +16242,17 @@
 		"object-inspect": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-			"dev": true
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 		},
 		"object-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-			"dev": true
+			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -15961,7 +16267,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -16049,7 +16354,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -16058,7 +16362,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -16067,7 +16370,6 @@
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
 			"integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
@@ -16104,6 +16406,17 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
+		"ora": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
+			"integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+			"requires": {
+				"chalk": "^2.1.0",
+				"cli-cursor": "^2.1.0",
+				"cli-spinners": "^1.0.1",
+				"log-symbols": "^2.1.0"
+			}
+		},
 		"original": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -16128,8 +16441,7 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"dev": true
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -16153,14 +16465,12 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -16184,8 +16494,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "2.2.2",
@@ -16264,6 +16573,243 @@
 				"p-reduce": "^1.0.0"
 			}
 		},
+		"package-json": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"requires": {
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
+			}
+		},
+		"pacote": {
+			"version": "2.7.38",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
+			"integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
+			"requires": {
+				"bluebird": "^3.5.0",
+				"cacache": "^9.2.9",
+				"glob": "^7.1.2",
+				"lru-cache": "^4.1.1",
+				"make-fetch-happen": "^2.4.13",
+				"minimatch": "^3.0.4",
+				"mississippi": "^1.2.0",
+				"normalize-package-data": "^2.4.0",
+				"npm-package-arg": "^5.1.2",
+				"npm-pick-manifest": "^1.0.4",
+				"osenv": "^0.1.4",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^1.1.1",
+				"protoduck": "^4.0.0",
+				"safe-buffer": "^5.1.1",
+				"semver": "^5.3.0",
+				"ssri": "^4.1.6",
+				"tar-fs": "^1.15.3",
+				"tar-stream": "^1.5.4",
+				"unique-filename": "^1.1.0",
+				"which": "^1.2.12"
+			},
+			"dependencies": {
+				"cacache": {
+					"version": "9.3.0",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
+					"integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+					"requires": {
+						"bluebird": "^3.5.0",
+						"chownr": "^1.0.1",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^1.3.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.1",
+						"ssri": "^4.1.6",
+						"unique-filename": "^1.1.0",
+						"y18n": "^3.2.1"
+					}
+				},
+				"genfun": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+					"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
+				},
+				"make-fetch-happen": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
+					"integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
+					"requires": {
+						"agentkeepalive": "^3.3.0",
+						"cacache": "^10.0.0",
+						"http-cache-semantics": "^3.8.0",
+						"http-proxy-agent": "^2.0.0",
+						"https-proxy-agent": "^2.1.0",
+						"lru-cache": "^4.1.1",
+						"mississippi": "^1.2.0",
+						"node-fetch-npm": "^2.0.2",
+						"promise-retry": "^1.1.1",
+						"socks-proxy-agent": "^3.0.1",
+						"ssri": "^5.0.0"
+					},
+					"dependencies": {
+						"cacache": {
+							"version": "10.0.4",
+							"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+							"requires": {
+								"bluebird": "^3.5.1",
+								"chownr": "^1.0.1",
+								"glob": "^7.1.2",
+								"graceful-fs": "^4.1.11",
+								"lru-cache": "^4.1.1",
+								"mississippi": "^2.0.0",
+								"mkdirp": "^0.5.1",
+								"move-concurrently": "^1.0.1",
+								"promise-inflight": "^1.0.1",
+								"rimraf": "^2.6.2",
+								"ssri": "^5.2.4",
+								"unique-filename": "^1.1.0",
+								"y18n": "^4.0.0"
+							},
+							"dependencies": {
+								"mississippi": {
+									"version": "2.0.0",
+									"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+									"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+									"requires": {
+										"concat-stream": "^1.5.0",
+										"duplexify": "^3.4.2",
+										"end-of-stream": "^1.1.0",
+										"flush-write-stream": "^1.0.0",
+										"from2": "^2.1.0",
+										"parallel-transform": "^1.1.0",
+										"pump": "^2.0.1",
+										"pumpify": "^1.3.3",
+										"stream-each": "^1.1.0",
+										"through2": "^2.0.0"
+									}
+								}
+							}
+						},
+						"pump": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+							"requires": {
+								"end-of-stream": "^1.1.0",
+								"once": "^1.3.1"
+							}
+						},
+						"ssri": {
+							"version": "5.3.0",
+							"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+							"requires": {
+								"safe-buffer": "^5.1.1"
+							}
+						},
+						"y18n": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+						}
+					}
+				},
+				"mississippi": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+					"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^1.0.0",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"npm-package-arg": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+					"integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
+					"requires": {
+						"hosted-git-info": "^2.4.2",
+						"osenv": "^0.1.4",
+						"semver": "^5.1.0",
+						"validate-npm-package-name": "^3.0.0"
+					}
+				},
+				"npm-pick-manifest": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
+					"integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
+					"requires": {
+						"npm-package-arg": "^5.1.2",
+						"semver": "^5.3.0"
+					}
+				},
+				"protoduck": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+					"integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
+					"requires": {
+						"genfun": "^4.0.1"
+					}
+				},
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"smart-buffer": {
+					"version": "1.1.15",
+					"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+					"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+				},
+				"socks": {
+					"version": "1.1.10",
+					"resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+					"integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+					"requires": {
+						"ip": "^1.1.4",
+						"smart-buffer": "^1.0.13"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+					"integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+					"requires": {
+						"agent-base": "^4.1.0",
+						"socks": "^1.1.10"
+					}
+				},
+				"ssri": {
+					"version": "4.1.6",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+					"integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+					"requires": {
+						"safe-buffer": "^5.1.0"
+					}
+				},
+				"y18n": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+				}
+			}
+		},
 		"pako": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -16274,7 +16820,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
 			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
-			"dev": true,
 			"requires": {
 				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
@@ -16295,7 +16840,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			}
@@ -16340,7 +16884,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
 			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
@@ -16348,6 +16891,27 @@
 				"is-alphanumerical": "^1.0.0",
 				"is-decimal": "^1.0.0",
 				"is-hexadecimal": "^1.0.0"
+			}
+		},
+		"parse-git-config": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+			"integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"fs-exists-sync": "^0.1.0",
+				"git-config-path": "^1.0.1",
+				"ini": "^1.3.4"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
 			}
 		},
 		"parse-github-repo-url": {
@@ -16366,13 +16930,17 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
 			"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
 				"json-parse-better-errors": "^1.0.1",
 				"lines-and-columns": "^1.1.6"
 			}
+		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
 		"parse-path": {
 			"version": "4.0.1",
@@ -16445,26 +17013,22 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-			"dev": true
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -16475,8 +17039,7 @@
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
 		"pathval": {
 			"version": "1.1.0",
@@ -16657,7 +17220,6 @@
 			"version": "3.4.4",
 			"resolved": "https://registry.npmjs.org/polished/-/polished-3.4.4.tgz",
 			"integrity": "sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.3"
 			}
@@ -16665,8 +17227,7 @@
 		"popper.js": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-			"dev": true
+			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -16846,6 +17407,11 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
+		"prepend-http": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+		},
 		"prettier": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
@@ -16898,7 +17464,6 @@
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
 			"integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
-			"dev": true,
 			"requires": {
 				"clipboard": "^2.0.0"
 			}
@@ -16912,14 +17477,12 @@
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-			"dev": true
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -16930,14 +17493,12 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-			"dev": true
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
 		},
 		"promise-retry": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
-			"dev": true,
 			"requires": {
 				"err-code": "^1.0.0",
 				"retry": "^0.10.0"
@@ -16999,7 +17560,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -17010,7 +17570,6 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
 			"integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
-			"dev": true,
 			"requires": {
 				"xtend": "^4.0.0"
 			}
@@ -17064,8 +17623,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
 			"version": "1.7.0",
@@ -17101,7 +17659,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -17112,7 +17669,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -17141,8 +17697,7 @@
 		"qs": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
-			"dev": true
+			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -17221,11 +17776,21 @@
 				"schema-utils": "^1.0.0"
 			}
 		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			}
+		},
 		"react": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
 			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -17236,7 +17801,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
 			"integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0"
 			}
@@ -17245,7 +17809,6 @@
 			"version": "2.18.0",
 			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.0.tgz",
 			"integrity": "sha512-FyVeU1kQiSokWc8NPz22azl1ezLpJdUyTbWL0LPUpcuuYDrZ/Y1veOk9rRK5B3pMlyDGvTk4f4KJhlkIQNRjEA==",
-			"dev": true,
 			"requires": {
 				"@icons/material": "^0.2.4",
 				"lodash": "^4.17.11",
@@ -17449,7 +18012,6 @@
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
 			"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -17476,8 +18038,7 @@
 		"react-fast-compare": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-			"integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
-			"dev": true
+			"integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
 		},
 		"react-focus-lock": {
 			"version": "1.19.1",
@@ -17495,7 +18056,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.4.tgz",
 			"integrity": "sha512-KTGHE9sz8N7+fCkZ2a3vzXH9eIkiTNhL2NhKR7XzzQl3WsGlCHh76arauJUIiGdfhjeMp7DY7PkASAmYFXeJYg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.3.4",
 				"invariant": "^2.2.4",
@@ -17517,7 +18077,6 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
 			"integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
-			"dev": true,
 			"requires": {
 				"prop-types": "^15.5.8"
 			}
@@ -17536,20 +18095,17 @@
 		"react-is": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-			"dev": true
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-			"dev": true
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-popper": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
 			"integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"create-react-context": "^0.3.0",
@@ -17564,7 +18120,6 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-2.10.1.tgz",
 			"integrity": "sha512-cib8bKiyYcrIlHo9zXx81G0XvARfL8Jt+xum709MFCgQa3HTqTi4au3iJ9tm7vi7WU7ngnqbpWkMinBOtwo+IQ==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.4",
 				"react-popper": "^1.3.6"
@@ -17574,7 +18129,6 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/react-select/-/react-select-3.0.8.tgz",
 			"integrity": "sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@emotion/cache": "^10.0.9",
@@ -17611,11 +18165,19 @@
 				"refractor": "^2.4.1"
 			}
 		},
+		"react-tabs": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.1.0.tgz",
+			"integrity": "sha512-9RKc77HCPsjQDVPyZEw37g3JPtg26oSQ9o4mtaVXjJuLedDX5+TQcE+MRNKR+4aO3GMAY4YslCePGG1//MQ3Jg==",
+			"requires": {
+				"classnames": "^2.2.0",
+				"prop-types": "^15.5.0"
+			}
+		},
 		"react-textarea-autosize": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
 			"integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"prop-types": "^15.6.0"
@@ -17625,7 +18187,6 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
 			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-			"dev": true,
 			"requires": {
 				"dom-helpers": "^3.4.0",
 				"loose-envify": "^1.4.0",
@@ -17637,7 +18198,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
 			"integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-			"dev": true,
 			"requires": {
 				"lodash": "^4.0.1"
 			}
@@ -17735,7 +18295,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -17830,7 +18389,6 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
 			"integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-			"dev": true,
 			"requires": {
 				"hastscript": "^5.0.0",
 				"parse-entities": "^1.1.2",
@@ -17841,7 +18399,6 @@
 					"version": "1.17.1",
 					"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
 					"integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-					"dev": true,
 					"requires": {
 						"clipboard": "^2.0.0"
 					}
@@ -17866,8 +18423,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-			"dev": true
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.1",
@@ -17892,7 +18448,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
 			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1"
@@ -17916,6 +18471,23 @@
 				"regjsparser": "^0.6.0",
 				"unicode-match-property-ecmascript": "^1.0.4",
 				"unicode-match-property-value-ecmascript": "^1.1.0"
+			}
+		},
+		"registry-auth-token": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+			"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+			"requires": {
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"registry-url": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"requires": {
+				"rc": "^1.0.1"
 			}
 		},
 		"regjsgen": {
@@ -17946,6 +18518,14 @@
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
+		},
+		"remote-origin-url": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz",
+			"integrity": "sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==",
+			"requires": {
+				"parse-git-config": "^1.1.1"
+			}
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
@@ -18115,14 +18695,12 @@
 		"resize-observer-polyfill": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-			"dev": true
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
 			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -18144,11 +18722,46 @@
 				}
 			}
 		},
+		"resolve-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+			"requires": {
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
+			},
+			"dependencies": {
+				"global-modules": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+					"requires": {
+						"global-prefix": "^0.1.4",
+						"is-windows": "^0.2.0"
+					}
+				},
+				"global-prefix": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+					"requires": {
+						"homedir-polyfill": "^1.0.0",
+						"ini": "^1.3.4",
+						"is-windows": "^0.2.0",
+						"which": "^1.2.12"
+					}
+				},
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+				}
+			}
+		},
 		"resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -18160,7 +18773,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -18175,8 +18787,7 @@
 		"retry": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-			"dev": true
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -18188,7 +18799,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -18339,7 +18949,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -18354,7 +18963,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -18378,7 +18986,6 @@
 			"version": "6.5.4",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
 			"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -18386,8 +18993,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -18401,8 +19007,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -18692,7 +19297,6 @@
 			"version": "0.18.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
 			"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -18734,14 +19338,20 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
 			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-			"dev": true,
 			"optional": true
 		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"semver-diff": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"requires": {
+				"semver": "^5.0.3"
+			}
 		},
 		"send": {
 			"version": "0.17.1",
@@ -18906,20 +19516,17 @@
 		"shallow-equal": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-			"integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-			"dev": true
+			"integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
 		},
 		"shallowequal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-			"dev": true
+			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -18927,8 +19534,7 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"shell-quote": {
 			"version": "1.7.2",
@@ -18953,6 +19559,21 @@
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
 		},
+		"shortid": {
+			"version": "2.2.15",
+			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+			"integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+			"requires": {
+				"nanoid": "^2.1.0"
+			},
+			"dependencies": {
+				"nanoid": {
+					"version": "2.1.11",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+					"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+				}
+			}
+		},
 		"side-channel": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
@@ -18966,8 +19587,7 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-			"dev": true
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -18990,7 +19610,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
 			"integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
-			"dev": true,
 			"requires": {
 				"can-use-dom": "^0.1.0",
 				"core-js": "^3.0.1",
@@ -19003,8 +19622,7 @@
 				"core-js": {
 					"version": "3.6.4",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-					"dev": true
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
 				}
 			}
 		},
@@ -19012,7 +19630,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
 			"integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
-			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.1",
 				"simplebar": "^4.2.3"
@@ -19255,8 +19872,7 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -19304,14 +19920,12 @@
 		"space-separated-tokens": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-			"dev": true
+			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19320,14 +19934,12 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-			"dev": true
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19336,8 +19948,7 @@
 		"spdx-license-ids": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-			"dev": true
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
 		"split": {
 			"version": "1.0.1",
@@ -19401,8 +20012,7 @@
 		"stable": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-			"dev": true
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
 		},
 		"stack-utils": {
 			"version": "1.0.2",
@@ -19461,8 +20071,287 @@
 		"store2": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/store2/-/store2-2.10.0.tgz",
-			"integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg==",
-			"dev": true
+			"integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg=="
+		},
+		"storybook-addon-preview": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.0.0.tgz",
+			"integrity": "sha512-u+LAZAa4TMxnK9e3sRpkUd1gZEplS9drHtO36nGbNiY/k0xcuwAuKROKNt2H2FAXHhX0xvqNl0k5+T2URTKKUw==",
+			"requires": {
+				"@storybook/addon-knobs": "^5.2.6",
+				"@types/prismjs": "^1.16.0",
+				"codesandbox": "^2.1.10",
+				"prismjs": "^1.17.1",
+				"react-tabs": "^3.0.0"
+			},
+			"dependencies": {
+				"@storybook/addon-knobs": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.3.14.tgz",
+					"integrity": "sha512-pBpFOdeCR8n8w6QHK1adABt6YKf+Q4itfX0+AtZRGLvbGum9O+paihvP9EVYPlKiG+0T7Zv2vFCl6q6qFjF/Mw==",
+					"requires": {
+						"@storybook/addons": "5.3.14",
+						"@storybook/api": "5.3.14",
+						"@storybook/client-api": "5.3.14",
+						"@storybook/components": "5.3.14",
+						"@storybook/core-events": "5.3.14",
+						"@storybook/theming": "5.3.14",
+						"@types/react-color": "^3.0.1",
+						"copy-to-clipboard": "^3.0.8",
+						"core-js": "^3.0.1",
+						"escape-html": "^1.0.3",
+						"fast-deep-equal": "^2.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"prop-types": "^15.7.2",
+						"qs": "^6.6.0",
+						"react-color": "^2.17.0",
+						"react-lifecycles-compat": "^3.0.4",
+						"react-select": "^3.0.8"
+					}
+				},
+				"@storybook/addons": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.14.tgz",
+					"integrity": "sha512-zoN1MYlArdThp93i+Ogil/pihyx8n7nkrdSO0j9HUh6jUsGeFFEluPQZdRFte9NIoY6ZWSWwuEMDgrv2Pw9r2Q==",
+					"requires": {
+						"@storybook/api": "5.3.14",
+						"@storybook/channels": "5.3.14",
+						"@storybook/client-logger": "5.3.14",
+						"@storybook/core-events": "5.3.14",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/api": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.14.tgz",
+					"integrity": "sha512-ANWRMTLEoAfu0IsXqbxmbTpxS8xTByZgLj20tH96bxgH1rJo9KAZnJ8A9kGYr+zklU8QnYvVIgmV3HESXII9zg==",
+					"requires": {
+						"@reach/router": "^1.2.1",
+						"@storybook/channels": "5.3.14",
+						"@storybook/client-logger": "5.3.14",
+						"@storybook/core-events": "5.3.14",
+						"@storybook/csf": "0.0.1",
+						"@storybook/router": "5.3.14",
+						"@storybook/theming": "5.3.14",
+						"@types/reach__router": "^1.2.3",
+						"core-js": "^3.0.1",
+						"fast-deep-equal": "^2.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3",
+						"prop-types": "^15.6.2",
+						"react": "^16.8.3",
+						"semver": "^6.0.0",
+						"shallow-equal": "^1.1.0",
+						"store2": "^2.7.1",
+						"telejson": "^3.2.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/channel-postmessage": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.14.tgz",
+					"integrity": "sha512-XKHxMSwW3movfTDOashuYlVCX3Hp7+X+amXc/xhDDzbiYjy3/CVm3LlkkM6v451IVEdK6pue4ewqZQWJAYAAEQ==",
+					"requires": {
+						"@storybook/channels": "5.3.14",
+						"@storybook/client-logger": "5.3.14",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"telejson": "^3.2.0"
+					}
+				},
+				"@storybook/channels": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.14.tgz",
+					"integrity": "sha512-k9QBf9Kwe+iGmdEK/kW5xprqem2SPfBVwET6LWvJkWOl9UQ9VoMuCHgV55p0tzjcugaqWWKoF9+FRMWxWRfsQg==",
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/client-api": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.14.tgz",
+					"integrity": "sha512-1qx1NIwto5F9N24Fb6VzKyDzeaZHtWTZ7afPrg56e1tUu7jbog7rELdRezk8+YAujveyMDJu4MxnOSP01sv7YQ==",
+					"requires": {
+						"@storybook/addons": "5.3.14",
+						"@storybook/channel-postmessage": "5.3.14",
+						"@storybook/channels": "5.3.14",
+						"@storybook/client-logger": "5.3.14",
+						"@storybook/core-events": "5.3.14",
+						"@storybook/csf": "0.0.1",
+						"@types/webpack-env": "^1.15.0",
+						"core-js": "^3.0.1",
+						"eventemitter3": "^4.0.0",
+						"global": "^4.3.2",
+						"is-plain-object": "^3.0.0",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0",
+						"stable": "^0.1.8",
+						"ts-dedent": "^1.1.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/client-logger": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.14.tgz",
+					"integrity": "sha512-YCHEsOvo6zPb4udlyAwqr5W0Kv9mAEQmcX73w9IDvAxbjR00T7empW7qmbjvviftKB/5MEgDdiYbj64ccs3aqg==",
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/components": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.14.tgz",
+					"integrity": "sha512-AsjkIFBrrqcBDLxGdmUHiauZo5gOL65eXx8WA7/yJDF8s45VVZX5Z0buOnjFyEhGVus02gwTov8da2irjL862A==",
+					"requires": {
+						"@storybook/client-logger": "5.3.14",
+						"@storybook/theming": "5.3.14",
+						"@types/react-syntax-highlighter": "11.0.2",
+						"@types/react-textarea-autosize": "^4.3.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"markdown-to-jsx": "^6.9.1",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.3.1",
+						"popper.js": "^1.14.7",
+						"prop-types": "^15.7.2",
+						"react": "^16.8.3",
+						"react-dom": "^16.8.3",
+						"react-focus-lock": "^2.1.0",
+						"react-helmet-async": "^1.0.2",
+						"react-popper-tooltip": "^2.8.3",
+						"react-syntax-highlighter": "^11.0.2",
+						"react-textarea-autosize": "^7.1.0",
+						"simplebar-react": "^1.0.0-alpha.6",
+						"ts-dedent": "^1.1.0"
+					}
+				},
+				"@storybook/core-events": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.14.tgz",
+					"integrity": "sha512-VCPLKqRugsOSx/smMJiJOvRgAzTrMpsbRuFw48kBGkQMP9TEV82Qe/341dv+f4GllPyBZyANG0p0m5+w7ZCURQ==",
+					"requires": {
+						"core-js": "^3.0.1"
+					}
+				},
+				"@storybook/router": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.14.tgz",
+					"integrity": "sha512-O0KwQFncdBeq+O2Aq8UAFBVWjWmP5rtqoacUOFSGkXgObOnyniEraLiPH7rPtq2dAlSpgYI9+srQAZfo52Hz2A==",
+					"requires": {
+						"@reach/router": "^1.2.1",
+						"@storybook/csf": "0.0.1",
+						"@types/reach__router": "^1.2.3",
+						"core-js": "^3.0.1",
+						"global": "^4.3.2",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3",
+						"qs": "^6.6.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"@storybook/theming": {
+					"version": "5.3.14",
+					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.14.tgz",
+					"integrity": "sha512-raqXC3yJycEt1CrCAfnBYUA6pyJI80E9M26EeQl3UfytJOL6euprOi+D17QvxqBn7jmmf9ZDw5XRkvJhQ17Y7Q==",
+					"requires": {
+						"@emotion/core": "^10.0.20",
+						"@emotion/styled": "^10.0.17",
+						"@storybook/client-logger": "5.3.14",
+						"core-js": "^3.0.1",
+						"deep-object-diff": "^1.1.0",
+						"emotion-theming": "^10.0.19",
+						"global": "^4.3.2",
+						"memoizerific": "^1.11.3",
+						"polished": "^3.3.1",
+						"prop-types": "^15.7.2",
+						"resolve-from": "^5.0.0",
+						"ts-dedent": "^1.1.0"
+					}
+				},
+				"@types/react-syntax-highlighter": {
+					"version": "11.0.2",
+					"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
+					"integrity": "sha512-iMNcixH8330f2dq0RY+VOXCP8JFehgmOhLOtnO85Ty+qu0fHXJNEqWx5VuFv8v0aEq0U/N9d/k1yvA+c6PEmPw==",
+					"requires": {
+						"@types/react": "*"
+					}
+				},
+				"core-js": {
+					"version": "3.6.4",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+				},
+				"highlight.js": {
+					"version": "9.13.1",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+					"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+				},
+				"isobject": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+				},
+				"lowlight": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
+					"integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+					"requires": {
+						"fault": "^1.0.2",
+						"highlight.js": "~9.13.0"
+					}
+				},
+				"react-focus-lock": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
+					"integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
+					"requires": {
+						"@babel/runtime": "^7.0.0",
+						"focus-lock": "^0.6.6",
+						"prop-types": "^15.6.2",
+						"react-clientside-effect": "^1.2.2",
+						"use-callback-ref": "^1.2.1",
+						"use-sidecar": "^1.0.1"
+					}
+				},
+				"react-syntax-highlighter": {
+					"version": "11.0.2",
+					"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
+					"integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
+					"requires": {
+						"@babel/runtime": "^7.3.1",
+						"highlight.js": "~9.13.0",
+						"lowlight": "~1.11.0",
+						"prismjs": "^1.8.4",
+						"refractor": "^2.4.1"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"telejson": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
+					"integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
+					"requires": {
+						"@types/is-function": "^1.0.0",
+						"global": "^4.4.0",
+						"is-function": "^1.0.1",
+						"is-regex": "^1.0.4",
+						"is-symbol": "^1.0.3",
+						"isobject": "^4.0.0",
+						"lodash": "^4.17.15",
+						"memoizerific": "^1.11.3"
+					}
+				}
+			}
 		},
 		"storybook-readme": {
 			"version": "5.0.6",
@@ -19514,7 +20403,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -19536,8 +20424,7 @@
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-			"dev": true
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"string-length": {
 			"version": "2.0.0",
@@ -19621,7 +20508,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
 			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
@@ -19631,7 +20517,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
 			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
@@ -19641,7 +20526,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -19664,8 +20548,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
@@ -19682,8 +20565,7 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -19710,7 +20592,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -19888,6 +20769,42 @@
 				}
 			}
 		},
+		"tar-fs": {
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+			"requires": {
+				"chownr": "^1.0.1",
+				"mkdirp": "^0.5.1",
+				"pump": "^1.0.0",
+				"tar-stream": "^1.1.2"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
+			}
+		},
+		"tar-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"requires": {
+				"bl": "^1.0.0",
+				"buffer-alloc": "^1.2.0",
+				"end-of-stream": "^1.0.0",
+				"fs-constants": "^1.0.0",
+				"readable-stream": "^2.3.0",
+				"to-buffer": "^1.1.1",
+				"xtend": "^4.0.0"
+			}
+		},
 		"telejson": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/telejson/-/telejson-2.2.2.tgz",
@@ -19964,7 +20881,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-			"dev": true,
 			"requires": {
 				"execa": "^0.7.0"
 			}
@@ -20898,6 +21814,11 @@
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true
 		},
+		"textextensions": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
+			"integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ=="
+		},
 		"thenify": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
@@ -20931,14 +21852,12 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-			"dev": true,
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
@@ -20949,6 +21868,11 @@
 			"resolved": "https://registry.npmjs.org/time-limit-promise/-/time-limit-promise-1.0.4.tgz",
 			"integrity": "sha512-FLHDDsIDducw7MBcRWlFtW2Tm50DoKOSFf0Nzx17qwXj8REXCte0eUkHrJl9QU3Bl9arG3XNYX0PcHpZ9xyuLw==",
 			"dev": true
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"timers-browserify": {
 			"version": "2.0.11",
@@ -20969,20 +21893,17 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-			"dev": true,
 			"optional": true
 		},
 		"tinycolor2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
-			"dev": true
+			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -21020,11 +21941,15 @@
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
 			"dev": true
 		},
+		"to-buffer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -21080,8 +22005,7 @@
 		"toggle-selection": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
-			"dev": true
+			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -21150,6 +22074,11 @@
 				"utf8-byte-length": "^1.0.1"
 			}
 		},
+		"ts-dedent": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
+			"integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg=="
+		},
 		"ts-pnp": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
@@ -21159,8 +22088,7 @@
 		"tslib": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
-			"dev": true
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -21217,14 +22145,12 @@
 		"typed-styles": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-			"dev": true
+			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-			"dev": true
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
 			"version": "3.8.2",
@@ -21339,7 +22265,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -21348,9 +22273,16 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
 			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
+			}
+		},
+		"unique-string": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"requires": {
+				"crypto-random-string": "^1.0.0"
 			}
 		},
 		"universal-user-agent": {
@@ -21365,8 +22297,7 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -21377,8 +22308,7 @@
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-			"dev": true
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -21420,11 +22350,112 @@
 				}
 			}
 		},
+		"unzip-response": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+		},
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
+		},
+		"update-notifier": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+			"requires": {
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-ci": "^1.0.10",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-align": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+					"requires": {
+						"string-width": "^2.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"boxen": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+					"requires": {
+						"ansi-align": "^2.0.0",
+						"camelcase": "^4.0.0",
+						"chalk": "^2.0.1",
+						"cli-boxes": "^1.0.0",
+						"string-width": "^2.0.0",
+						"term-size": "^1.2.0",
+						"widest-line": "^2.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+				},
+				"ci-info": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+				},
+				"cli-boxes": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+				},
+				"import-lazy": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"requires": {
+						"ci-info": "^1.5.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
 		},
 		"upper-case": {
 			"version": "1.1.3",
@@ -21504,11 +22535,33 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"url-parse-lax": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"requires": {
+				"prepend-http": "^1.0.1"
+			}
+		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
+		},
+		"use-callback-ref": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
+			"integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w=="
+		},
+		"use-sidecar": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
+			"integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
+			"requires": {
+				"detect-node": "^2.0.4",
+				"tslib": "^1.9.3"
+			}
 		},
 		"utf8-byte-length": {
 			"version": "1.0.4",
@@ -21545,8 +22598,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util-promisify": {
 			"version": "2.1.0",
@@ -21589,7 +22641,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -21599,7 +22650,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
 			}
@@ -21655,7 +22705,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
 			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -21831,7 +22880,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -21889,7 +22937,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
 			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
 			},
@@ -21897,20 +22944,17 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -21920,7 +22964,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -22053,8 +23096,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",
@@ -22069,7 +23111,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
 			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -22153,6 +23194,11 @@
 				"async-limiter": "~1.0.0"
 			}
 		},
+		"xdg-basedir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+		},
 		"xhr": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
@@ -22214,8 +23260,7 @@
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",
@@ -22226,14 +23271,12 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-			"dev": true
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yaml": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
 			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.3"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20400,9 +20400,9 @@
 			"dev": true
 		},
 		"storybook-addon-preview": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.0.3.tgz",
-			"integrity": "sha512-SUpGMKPVsosrkebN++CPUbxb2gK8+5qvM7ig8PzDptypM0KxPTQ+CsGq4+otm2mygGBfR14uLb+SgNIcxQ+OvA==",
+			"version": "1.1.0-beta8",
+			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.1.0-beta8.tgz",
+			"integrity": "sha512-VHRkBpPQaNY4Ly1X41IRQrVBQo2WQCW66zXHx5nlhG1hhCoxPdX+e7MKvZIaB68QTjsUe7mZuPhA3aVrauV76g==",
 			"dev": true,
 			"requires": {
 				"@storybook/addon-knobs": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20400,9 +20400,9 @@
 			"dev": true
 		},
 		"storybook-addon-preview": {
-			"version": "1.1.0-beta8",
-			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.1.0-beta8.tgz",
-			"integrity": "sha512-VHRkBpPQaNY4Ly1X41IRQrVBQo2WQCW66zXHx5nlhG1hhCoxPdX+e7MKvZIaB68QTjsUe7mZuPhA3aVrauV76g==",
+			"version": "1.1.0-beta11",
+			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.1.0-beta11.tgz",
+			"integrity": "sha512-L+TFn0A8WZhrHrIPa9fSlNB1k0k5cu9mueU+gE1E0On72yaaqkYVMxnq6+xilojz0xdj5vH0ruw1j7+7UH0Xfw==",
 			"dev": true,
 			"requires": {
 				"@storybook/addon-knobs": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.8.3"
 			}
@@ -208,6 +209,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
 			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -321,6 +323,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -956,6 +959,7 @@
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
 			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -992,6 +996,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
 			"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -1012,6 +1017,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.27.tgz",
 			"integrity": "sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==",
+			"dev": true,
 			"requires": {
 				"@emotion/sheet": "0.9.4",
 				"@emotion/stylis": "0.8.5",
@@ -1023,6 +1029,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.27.tgz",
 			"integrity": "sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/cache": "^10.0.27",
@@ -1036,6 +1043,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
 			"integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+			"dev": true,
 			"requires": {
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3",
@@ -1045,12 +1053,14 @@
 		"@emotion/hash": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
-			"integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
+			"integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==",
+			"dev": true
 		},
 		"@emotion/is-prop-valid": {
 			"version": "0.8.6",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz",
 			"integrity": "sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==",
+			"dev": true,
 			"requires": {
 				"@emotion/memoize": "0.7.4"
 			}
@@ -1058,12 +1068,14 @@
 		"@emotion/memoize": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+			"dev": true
 		},
 		"@emotion/serialize": {
 			"version": "0.11.15",
 			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.15.tgz",
 			"integrity": "sha512-YE+qnrmGwyR+XB5j7Bi+0GT1JWsdcjM/d4POu+TXkcnrRs4RFCCsi3d/Ebf+wSStHqAlTT2+dfd+b9N9EO2KBg==",
+			"dev": true,
 			"requires": {
 				"@emotion/hash": "0.7.4",
 				"@emotion/memoize": "0.7.4",
@@ -1075,12 +1087,14 @@
 		"@emotion/sheet": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+			"dev": true
 		},
 		"@emotion/styled": {
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
 			"integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+			"dev": true,
 			"requires": {
 				"@emotion/styled-base": "^10.0.27",
 				"babel-plugin-emotion": "^10.0.27"
@@ -1090,6 +1104,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.27.tgz",
 			"integrity": "sha512-ufHM/HhE3nr309hJG9jxuFt71r6aHn7p+bwXduFxcwPFEfBIqvmZUMtZ9YxIsY61PVwK3bp4G1XhaCzy9smVvw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/is-prop-valid": "0.8.6",
@@ -1100,22 +1115,26 @@
 		"@emotion/stylis": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+			"dev": true
 		},
 		"@emotion/unitless": {
 			"version": "0.7.5",
 			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+			"dev": true
 		},
 		"@emotion/utils": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+			"dev": true
 		},
 		"@emotion/weak-memoize": {
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+			"dev": true
 		},
 		"@evocateur/libnpmaccess": {
 			"version": "3.1.2",
@@ -1285,7 +1304,8 @@
 		"@icons/material": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+			"dev": true
 		},
 		"@jest/console": {
 			"version": "24.9.0",
@@ -3294,6 +3314,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.1.tgz",
 			"integrity": "sha512-Ov1j1J+pSgXliJHFL7XWhjyREwc6GxeWfgBTa5MMH5eRmYtHbPhaovba4xKo7aTVCg8fxkt2yDMNSpvwfUP+pA==",
+			"dev": true,
 			"requires": {
 				"create-react-context": "0.3.0",
 				"invariant": "^2.2.3",
@@ -3743,6 +3764,7 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
 			"integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.15"
 			}
@@ -3993,12 +4015,14 @@
 		"@types/history": {
 			"version": "4.7.5",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
-			"integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
+			"integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==",
+			"dev": true
 		},
 		"@types/is-function": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
-			"integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w=="
+			"integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w==",
+			"dev": true
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
@@ -4052,17 +4076,20 @@
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+			"dev": true
 		},
 		"@types/prismjs": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.16.0.tgz",
-			"integrity": "sha512-mEyuziLrfDCQ4juQP1k706BUU/c8OGn/ZFl69AXXY6dStHClKX4P+N8+rhqpul1vRDA2VOygzMRSJJZHyDEOfw=="
+			"integrity": "sha512-mEyuziLrfDCQ4juQP1k706BUU/c8OGn/ZFl69AXXY6dStHClKX4P+N8+rhqpul1vRDA2VOygzMRSJJZHyDEOfw==",
+			"dev": true
 		},
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+			"dev": true
 		},
 		"@types/q": {
 			"version": "1.5.2",
@@ -4074,6 +4101,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.0.tgz",
 			"integrity": "sha512-0aL79bFPJzJOJOOMZm2301ErQVaveBdpW88uuavXymUlcYIAOCmI1ujJ2XLH6Mzn76O94eQCHIl1FDzNNKJCYA==",
+			"dev": true,
 			"requires": {
 				"@types/history": "*",
 				"@types/react": "*"
@@ -4083,6 +4111,7 @@
 			"version": "16.9.21",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.21.tgz",
 			"integrity": "sha512-xpmenCMeBwJRct8vmIfczlgdOXWIWASoOM857kxKfHlVQvDltRh7IFRVfGws79iO2jkNPXOeWREyKoClzhBaQA==",
+			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -4092,6 +4121,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.1.tgz",
 			"integrity": "sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==",
+			"dev": true,
 			"requires": {
 				"@types/react": "*"
 			}
@@ -4109,6 +4139,7 @@
 			"version": "4.3.5",
 			"resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
 			"integrity": "sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==",
+			"dev": true,
 			"requires": {
 				"@types/react": "*"
 			}
@@ -4131,7 +4162,8 @@
 		"@types/webpack-env": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.1.tgz",
-			"integrity": "sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA=="
+			"integrity": "sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA==",
+			"dev": true
 		},
 		"@types/yargs": {
 			"version": "13.0.8",
@@ -4471,6 +4503,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
 			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
@@ -4479,6 +4512,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
 			"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+			"dev": true,
 			"requires": {
 				"humanize-ms": "^1.2.1"
 			}
@@ -4616,7 +4650,8 @@
 		"ansi-escapes": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+			"dev": true
 		},
 		"ansi-html": {
 			"version": "0.0.7",
@@ -4634,6 +4669,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -4689,7 +4725,8 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"arch": {
 			"version": "2.1.1",
@@ -5044,6 +5081,7 @@
 			"version": "0.18.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
 			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"dev": true,
 			"requires": {
 				"follow-redirects": "1.5.10",
 				"is-buffer": "^2.0.2"
@@ -5052,7 +5090,8 @@
 				"is-buffer": {
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
 				}
 			}
 		},
@@ -5626,6 +5665,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.27.tgz",
 			"integrity": "sha512-SUNYcT4FqhOqvwv0z1oeYhqgheU8qrceLojuHyX17ngo7WtWqN5I9l3IGHzf21Xraj465CVzF4IvOlAF+3ed0A==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@emotion/hash": "0.7.4",
@@ -5664,6 +5704,7 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
 			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
@@ -5809,7 +5850,8 @@
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -6562,7 +6604,8 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"base": {
 			"version": "0.11.2",
@@ -6667,7 +6710,8 @@
 		"binaryextensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.2.0.tgz",
-			"integrity": "sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw=="
+			"integrity": "sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw==",
+			"dev": true
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -6683,6 +6727,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -6700,7 +6745,8 @@
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true
 		},
 		"bmp-js": {
 			"version": "0.1.0",
@@ -6821,6 +6867,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -7035,6 +7082,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"dev": true,
 			"requires": {
 				"buffer-alloc-unsafe": "^1.1.0",
 				"buffer-fill": "^1.0.0"
@@ -7043,7 +7091,8 @@
 		"buffer-alloc-unsafe": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+			"dev": true
 		},
 		"buffer-equal": {
 			"version": "0.0.1",
@@ -7054,12 +7103,14 @@
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -7082,7 +7133,8 @@
 		"builtins": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+			"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+			"dev": true
 		},
 		"byline": {
 			"version": "5.0.0",
@@ -7216,7 +7268,8 @@
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
 		},
 		"camel-case": {
 			"version": "4.1.1",
@@ -7256,7 +7309,8 @@
 		"can-use-dom": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-			"integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
+			"integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=",
+			"dev": true
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001028",
@@ -7276,7 +7330,8 @@
 		"capture-stack-trace": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+			"dev": true
 		},
 		"case-sensitive-paths-webpack-plugin": {
 			"version": "2.3.0",
@@ -7308,6 +7363,7 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -7317,22 +7373,26 @@
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+			"dev": true
 		},
 		"character-entities-legacy": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+			"dev": true
 		},
 		"character-reference-invalid": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+			"dev": true
 		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"dev": true
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -7363,7 +7423,8 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"chrome-remote-interface": {
 			"version": "0.25.7",
@@ -7457,7 +7518,8 @@
 		"classnames": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+			"dev": true
 		},
 		"clean-css": {
 			"version": "4.2.3",
@@ -7492,6 +7554,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
 			}
@@ -7499,7 +7562,8 @@
 		"cli-spinners": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg=="
+			"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+			"dev": true
 		},
 		"cli-table3": {
 			"version": "0.5.1",
@@ -7548,12 +7612,14 @@
 		"cli-width": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+			"dev": true
 		},
 		"clipboard": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
 			"integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"good-listener": "^1.2.2",
@@ -7717,6 +7783,7 @@
 			"version": "2.1.12",
 			"resolved": "https://registry.npmjs.org/codesandbox/-/codesandbox-2.1.12.tgz",
 			"integrity": "sha512-DDveHGGR3dGDgLwAbK0Z75pgA+5Mm2OwigYwrNgEc0m4anzTXWnk0CrWAIRJzDm1QCk97w17/DYl1R3LCYi3Tw==",
+			"dev": true,
 			"requires": {
 				"axios": "^0.18.1",
 				"chalk": "^2.4.1",
@@ -7745,6 +7812,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
 					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"jsonfile": "^3.0.0",
@@ -7755,6 +7823,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
 					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6"
 					}
@@ -7764,12 +7833,14 @@
 		"codesandbox-import-util-types": {
 			"version": "2.1.9",
 			"resolved": "https://registry.npmjs.org/codesandbox-import-util-types/-/codesandbox-import-util-types-2.1.9.tgz",
-			"integrity": "sha512-Vc4qh+neVfHtS3RG+7wvaErMoEKdNTnLFnyj4Dcbn3NV7v9nlPj/z6MGhHp9S+vAjegWorFzxg9lKB1WGHTt5Q=="
+			"integrity": "sha512-Vc4qh+neVfHtS3RG+7wvaErMoEKdNTnLFnyj4Dcbn3NV7v9nlPj/z6MGhHp9S+vAjegWorFzxg9lKB1WGHTt5Q==",
+			"dev": true
 		},
 		"codesandbox-import-utils": {
 			"version": "2.1.12",
 			"resolved": "https://registry.npmjs.org/codesandbox-import-utils/-/codesandbox-import-utils-2.1.12.tgz",
 			"integrity": "sha512-eTP3TboAlFEZDblCf3uwnV0S3tZCKnoubDONibAE9rI2pdximDGFQdHUpHPU4509bQ6UF2w+DVExlhkxmLFenA==",
+			"dev": true,
 			"requires": {
 				"codesandbox-import-util-types": "^2.1.9",
 				"istextorbinary": "^2.2.1",
@@ -7806,6 +7877,7 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -7813,7 +7885,8 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"color-string": {
 			"version": "1.5.3",
@@ -7870,12 +7943,14 @@
 		"comma-separated-tokens": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"common-tags": {
 			"version": "1.8.0",
@@ -7919,12 +7994,14 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -7946,6 +8023,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
 			"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"graceful-fs": "^4.1.2",
@@ -7959,6 +8037,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -7966,7 +8045,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -8296,6 +8376,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -8316,6 +8397,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"fs-write-stream-atomic": "^1.0.8",
@@ -8335,6 +8417,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.1.tgz",
 			"integrity": "sha512-btru1Q6RD9wbonIvEU5EfnhIRGHLo//BGXQ1hNAD2avIs/nBZlpbOeKtv3mhoUByN4DB9Cb6/vXBymj1S43KmA==",
+			"dev": true,
 			"requires": {
 				"toggle-selection": "^1.0.6"
 			}
@@ -8372,7 +8455,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"corejs-upgrade-webpack-plugin": {
 			"version": "2.2.0",
@@ -8388,6 +8472,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
 			"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.1.0",
@@ -8416,6 +8501,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+			"dev": true,
 			"requires": {
 				"capture-stack-trace": "^1.0.0"
 			}
@@ -8451,6 +8537,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
 			"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+			"dev": true,
 			"requires": {
 				"gud": "^1.0.0",
 				"warning": "^4.0.3"
@@ -8484,6 +8571,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -8518,7 +8606,8 @@
 		"crypto-random-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
 		},
 		"css": {
 			"version": "2.2.3",
@@ -8666,7 +8755,8 @@
 		"csstype": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
-			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
+			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
+			"dev": true
 		},
 		"cuint": {
 			"version": "0.2.2",
@@ -8687,6 +8777,7 @@
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/cwd/-/cwd-0.9.1.tgz",
 			"integrity": "sha1-QeEKfhq4M9xZwuyoOBTH3ne1pP0=",
+			"dev": true,
 			"requires": {
 				"find-pkg": "^0.1.0"
 			}
@@ -8694,7 +8785,8 @@
 		"cyclist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
-			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+			"dev": true
 		},
 		"damerau-levenshtein": {
 			"version": "1.0.6",
@@ -8748,6 +8840,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/datauri/-/datauri-1.1.0.tgz",
 			"integrity": "sha512-0q+cTTKx7q8eDteZRIQLTFJuiIsVing17UbWTPssY4JLSMaYsk/VKpNulBDo9NSgQWcvlPrkEHW8kUO67T/7mQ==",
+			"dev": true,
 			"requires": {
 				"image-size": "^0.6.2",
 				"mimer": "^0.3.2",
@@ -8824,6 +8917,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
 			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+			"dev": true,
 			"requires": {
 				"is-arguments": "^1.0.4",
 				"is-date-object": "^1.0.1",
@@ -8836,7 +8930,8 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -8847,7 +8942,8 @@
 		"deep-object-diff": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
+			"integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
+			"dev": true
 		},
 		"defaults": {
 			"version": "1.0.3",
@@ -8862,6 +8958,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -8966,6 +9063,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
 			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"dev": true,
 			"optional": true
 		},
 		"delegates": {
@@ -9026,7 +9124,8 @@
 		"detect-node": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+			"dev": true
 		},
 		"detect-port": {
 			"version": "1.3.0",
@@ -9148,6 +9247,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
 			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2"
 			}
@@ -9179,7 +9279,8 @@
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+			"dev": true
 		},
 		"domain-browser": {
 			"version": "1.2.0",
@@ -9235,6 +9336,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"
 			}
@@ -9340,12 +9442,14 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
 		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
 			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
 				"inherits": "^2.0.1",
@@ -9367,6 +9471,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
 			"integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
+			"dev": true,
 			"requires": {
 				"errlop": "^2.0.0",
 				"semver": "^6.3.0"
@@ -9375,7 +9480,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -9449,6 +9555,7 @@
 			"version": "10.0.27",
 			"resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
 			"integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"@emotion/weak-memoize": "0.2.5",
@@ -9474,6 +9581,7 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -9482,6 +9590,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -9563,12 +9672,14 @@
 		"err-code": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+			"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+			"dev": true
 		},
 		"errlop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/errlop/-/errlop-2.0.0.tgz",
-			"integrity": "sha512-z00WIrQhtOMUnjdTG0O4f6hMG64EVccVDBy2WwgjcF8S4UB1exGYuc2OFwmdQmsJwLQVEIHWHPCz/omXXgAZHw=="
+			"integrity": "sha512-z00WIrQhtOMUnjdTG0O4f6hMG64EVccVDBy2WwgjcF8S4UB1exGYuc2OFwmdQmsJwLQVEIHWHPCz/omXXgAZHw==",
+			"dev": true
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -9583,6 +9694,7 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -9600,6 +9712,7 @@
 			"version": "1.17.4",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
 			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
@@ -9647,6 +9760,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -9662,12 +9776,14 @@
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
 			}
@@ -9691,12 +9807,14 @@
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"escodegen": {
 			"version": "1.14.1",
@@ -10293,7 +10411,8 @@
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -10330,7 +10449,8 @@
 		"eventemitter3": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+			"dev": true
 		},
 		"events": {
 			"version": "3.1.0",
@@ -10367,6 +10487,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -10443,6 +10564,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
 			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.1"
 			}
@@ -10562,6 +10684,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -10642,7 +10765,8 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "2.2.7",
@@ -10689,6 +10813,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
 			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"dev": true,
 			"requires": {
 				"format": "^0.2.0"
 			}
@@ -10721,6 +10846,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -10748,7 +10874,8 @@
 		"file-name": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/file-name/-/file-name-0.1.0.tgz",
-			"integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc="
+			"integrity": "sha1-ErEi8SD5w028F2wauBpUis7W3vc=",
+			"dev": true
 		},
 		"file-system-cache": {
 			"version": "1.0.5",
@@ -10792,7 +10919,8 @@
 		"filesize": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"dev": true
 		},
 		"fill-range": {
 			"version": "4.0.0",
@@ -10924,6 +11052,7 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-0.1.3.tgz",
 			"integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
+			"dev": true,
 			"requires": {
 				"fs-exists-sync": "^0.1.0",
 				"resolve-dir": "^0.1.0"
@@ -10933,6 +11062,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-0.1.2.tgz",
 			"integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
+			"dev": true,
 			"requires": {
 				"find-file-up": "^0.1.2"
 			}
@@ -10940,7 +11070,8 @@
 		"find-root": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"dev": true
 		},
 		"find-up": {
 			"version": "3.0.0",
@@ -10978,6 +11109,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
 			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.3.6"
@@ -10986,12 +11118,14 @@
 		"focus-lock": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
-			"integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw=="
+			"integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==",
+			"dev": true
 		},
 		"follow-redirects": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
 			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"dev": true,
 			"requires": {
 				"debug": "=3.1.0"
 			},
@@ -11000,6 +11134,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11007,7 +11142,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -11053,7 +11189,8 @@
 		"format": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+			"dev": true
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -11086,6 +11223,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -11094,12 +11232,14 @@
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
 		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+			"dev": true
 		},
 		"fs-extra": {
 			"version": "8.1.0",
@@ -11136,6 +11276,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"iferr": "^0.1.5",
@@ -11146,7 +11287,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"fsevents": {
 			"version": "1.2.11",
@@ -11721,7 +11863,8 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"function.name": {
 			"version": "1.0.12",
@@ -12008,7 +12151,8 @@
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -12028,12 +12172,14 @@
 		"git-branch": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/git-branch/-/git-branch-1.0.0.tgz",
-			"integrity": "sha512-ZTzuqw5Df8fyLXQWrX6hK+4FpNCdKzMcERlxENEGO5aKcLmG7MAszhrMhluUKNKmOS/JAGijDMQDXDCDw1mE/A=="
+			"integrity": "sha512-ZTzuqw5Df8fyLXQWrX6hK+4FpNCdKzMcERlxENEGO5aKcLmG7MAszhrMhluUKNKmOS/JAGijDMQDXDCDw1mE/A==",
+			"dev": true
 		},
 		"git-config-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
 			"integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"fs-exists-sync": "^0.1.0",
@@ -12044,6 +12190,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -12157,6 +12304,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
 			"integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
+			"dev": true,
 			"requires": {
 				"cwd": "^0.9.1",
 				"file-name": "^0.1.0",
@@ -12275,6 +12423,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/git-username/-/git-username-0.5.1.tgz",
 			"integrity": "sha512-xjUjrj3i4kup2A3a/ZVZB1Nt0PUX7SU7KeVqIbXPdslT7NbNfyO04JMxBv4gar77JePdS+A6f05jG1Viy6+U1w==",
+			"dev": true,
 			"requires": {
 				"remote-origin-url": "^0.4.0"
 			},
@@ -12283,6 +12432,7 @@
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.2.0.tgz",
 					"integrity": "sha1-Jygz/dFf6hRvt10zbSNrljtv9wY=",
+					"dev": true,
 					"requires": {
 						"ini": "^1.3.3"
 					}
@@ -12291,6 +12441,7 @@
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.4.0.tgz",
 					"integrity": "sha1-TT4pAvNOLTfRwmPYdxC3frQIajA=",
+					"dev": true,
 					"requires": {
 						"parse-git-config": "^0.2.0"
 					}
@@ -12310,6 +12461,7 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -12350,6 +12502,7 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
 			"integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+			"dev": true,
 			"requires": {
 				"min-document": "^2.19.0",
 				"process": "^0.11.10"
@@ -12359,6 +12512,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true,
 			"requires": {
 				"ini": "^1.3.4"
 			}
@@ -12436,6 +12590,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"delegate": "^3.1.2"
@@ -12445,6 +12600,7 @@
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+			"dev": true,
 			"requires": {
 				"create-error-class": "^3.0.0",
 				"duplexer3": "^0.1.4",
@@ -12462,7 +12618,8 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"dev": true
 		},
 		"graphlib": {
 			"version": "2.1.8",
@@ -12482,7 +12639,8 @@
 		"gud": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+			"dev": true
 		},
 		"gzip-size": {
 			"version": "5.1.1",
@@ -12534,6 +12692,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -12550,12 +12709,14 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"dev": true
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -12618,12 +12779,14 @@
 		"hast-util-parse-selector": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
-			"integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q=="
+			"integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q==",
+			"dev": true
 		},
 		"hastscript": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.1.tgz",
 			"integrity": "sha512-xHo1Hkcqd0LlWNuDL3/BxwhgAGp3d7uEvCMgCTrBY+zsOooPPH+8KAvW8PCgl+GB8H3H44nfSaF0A4BQ+4xlYg==",
+			"dev": true,
 			"requires": {
 				"comma-separated-tokens": "^1.0.0",
 				"hast-util-parse-selector": "^2.0.0",
@@ -12677,6 +12840,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+			"dev": true,
 			"requires": {
 				"react-is": "^16.7.0"
 			}
@@ -12695,6 +12859,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
 			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
@@ -12702,7 +12867,8 @@
 		"hosted-git-info": {
 			"version": "2.8.5",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+			"dev": true
 		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
@@ -12862,7 +13028,8 @@
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+			"dev": true
 		},
 		"http-errors": {
 			"version": "1.7.2",
@@ -12895,6 +13062,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
 			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "4",
 				"debug": "3.1.0"
@@ -12904,6 +13072,7 @@
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -12911,7 +13080,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -12936,6 +13106,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
 			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
@@ -12945,6 +13116,7 @@
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -12961,6 +13133,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+			"dev": true,
 			"requires": {
 				"ms": "^2.0.0"
 			}
@@ -12968,12 +13141,14 @@
 		"humps": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
+			"integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
+			"dev": true
 		},
 		"iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -13002,7 +13177,8 @@
 		"iferr": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+			"dev": true
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -13022,7 +13198,8 @@
 		"image-size": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
-			"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
+			"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
+			"dev": true
 		},
 		"immer": {
 			"version": "1.10.0",
@@ -13043,6 +13220,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
 			"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -13051,7 +13229,8 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
 				}
 			}
 		},
@@ -13091,7 +13270,8 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"in-publish": {
 			"version": "2.0.0",
@@ -13121,6 +13301,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -13129,12 +13310,14 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"init-package-json": {
 			"version": "1.10.3",
@@ -13156,6 +13339,7 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
 			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
@@ -13175,17 +13359,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -13195,6 +13382,7 @@
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
 							}
@@ -13205,6 +13393,7 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					},
@@ -13212,7 +13401,8 @@
 						"ansi-regex": {
 							"version": "4.1.0",
 							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
 						}
 					}
 				}
@@ -13239,6 +13429,7 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -13252,7 +13443,8 @@
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -13283,12 +13475,14 @@
 		"is-alphabetical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+			"dev": true
 		},
 		"is-alphanumerical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
 			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -13297,12 +13491,14 @@
 		"is-arguments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -13322,7 +13518,8 @@
 		"is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"dev": true
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -13356,12 +13553,14 @@
 		"is-date-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+			"dev": true
 		},
 		"is-decimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -13413,7 +13612,8 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -13439,7 +13639,8 @@
 		"is-function": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+			"dev": true
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -13459,12 +13660,14 @@
 		"is-hexadecimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+			"dev": true
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"dev": true,
 			"requires": {
 				"global-dirs": "^0.1.0",
 				"is-path-inside": "^1.0.0"
@@ -13491,7 +13694,8 @@
 		"is-npm": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+			"dev": true
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -13516,7 +13720,8 @@
 		"is-obj": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+			"dev": true
 		},
 		"is-object": {
 			"version": "1.0.1",
@@ -13543,6 +13748,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.1"
 			}
@@ -13557,6 +13763,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 			"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+			"dev": true,
 			"requires": {
 				"isobject": "^4.0.0"
 			},
@@ -13564,19 +13771,22 @@
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
 				}
 			}
 		},
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-redirect": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+			"dev": true
 		},
 		"is-reference": {
 			"version": "1.1.4",
@@ -13591,6 +13801,7 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
 			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -13604,7 +13815,8 @@
 		"is-retry-allowed": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+			"dev": true
 		},
 		"is-root": {
 			"version": "2.1.0",
@@ -13636,7 +13848,8 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
 		},
 		"is-string": {
 			"version": "1.0.5",
@@ -13648,6 +13861,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
@@ -13688,17 +13902,20 @@
 		"is-wsl": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -13797,6 +14014,7 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
 			"integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+			"dev": true,
 			"requires": {
 				"binaryextensions": "^2.1.2",
 				"editions": "^2.2.0",
@@ -14342,7 +14560,8 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -14411,7 +14630,8 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -14523,6 +14743,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+			"dev": true,
 			"requires": {
 				"package-json": "^4.0.0"
 			}
@@ -14530,7 +14751,8 @@
 		"lazy-cache": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true
 		},
 		"lazy-universal-dotenv": {
 			"version": "3.0.1",
@@ -14628,7 +14850,8 @@
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
 		},
 		"linux-platform-info": {
 			"version": "0.0.3",
@@ -14739,7 +14962,8 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -14756,7 +14980,8 @@
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+			"dev": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -14773,7 +14998,8 @@
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"dev": true
 		},
 		"lodash.set": {
 			"version": "4.3.2",
@@ -14809,7 +15035,8 @@
 		"lodash.throttle": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+			"dev": true
 		},
 		"lodash.toarray": {
 			"version": "4.4.0",
@@ -14833,6 +15060,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
 			}
@@ -14871,6 +15099,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -14897,7 +15126,8 @@
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"dev": true
 		},
 		"lowlight": {
 			"version": "1.9.2",
@@ -14913,6 +15143,7 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -14921,7 +15152,8 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+			"dev": true
 		},
 		"macos-release": {
 			"version": "2.3.0",
@@ -15014,7 +15246,8 @@
 		"map-or-similar": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-			"integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
+			"integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
+			"dev": true
 		},
 		"map-reverse": {
 			"version": "1.0.1",
@@ -15051,6 +15284,7 @@
 			"version": "6.11.0",
 			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.0.tgz",
 			"integrity": "sha512-RH7LCJQ4RFmPqVeZEesKaO1biRzB/k4utoofmTCp3Eiw6D7qfvK8fzZq/2bjEJAtVkfPrM5SMt5APGf2rnaKMg==",
+			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.2",
 				"unquote": "^1.1.0"
@@ -15074,7 +15308,8 @@
 		"material-colors": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-			"integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
+			"integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+			"dev": true
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -15102,12 +15337,14 @@
 		"memoize-one": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
+			"dev": true
 		},
 		"memoizerific": {
 			"version": "1.11.3",
 			"resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
 			"integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
+			"dev": true,
 			"requires": {
 				"map-or-similar": "^1.5.0"
 			}
@@ -15294,17 +15531,20 @@
 		"mimer": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/mimer/-/mimer-0.3.2.tgz",
-			"integrity": "sha512-N6NcgDQAevhP/02DQ/epK6daLy4NKrIHyTlJcO6qBiYn98q+Y4a/knNsAATCe1xLS2F0nEmJp+QYli2s8vKwyQ=="
+			"integrity": "sha512-N6NcgDQAevhP/02DQ/epK6daLy4NKrIHyTlJcO6qBiYn98q+Y4a/knNsAATCe1xLS2F0nEmJp+QYli2s8vKwyQ==",
+			"dev": true
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
 		},
 		"min-document": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"dev": true,
 			"requires": {
 				"dom-walk": "^0.1.0"
 			}
@@ -15325,6 +15565,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -15332,7 +15573,8 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -15423,6 +15665,7 @@
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			},
@@ -15430,7 +15673,8 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
 				}
 			}
 		},
@@ -15465,6 +15709,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1",
 				"copy-concurrently": "^1.0.0",
@@ -15477,7 +15722,8 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"multimatch": {
 			"version": "3.0.0",
@@ -15506,7 +15752,8 @@
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"mv": {
 			"version": "2.1.1",
@@ -15644,6 +15891,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
 			"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
 				"json-parse-better-errors": "^1.0.0",
@@ -16052,6 +16300,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"resolve": "^1.10.0",
@@ -16154,6 +16403,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -16206,7 +16456,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -16242,17 +16493,20 @@
 		"object-inspect": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"dev": true
 		},
 		"object-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -16267,6 +16521,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -16354,6 +16609,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -16362,6 +16618,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^1.0.0"
 			}
@@ -16370,6 +16627,7 @@
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
 			"integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+			"dev": true,
 			"requires": {
 				"is-wsl": "^1.1.0"
 			}
@@ -16410,6 +16668,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
 			"integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.1.0",
 				"cli-cursor": "^2.1.0",
@@ -16441,7 +16700,8 @@
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
 		},
 		"os-locale": {
 			"version": "1.4.0",
@@ -16465,12 +16725,14 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0",
 				"os-tmpdir": "^1.0.0"
@@ -16494,7 +16756,8 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-limit": {
 			"version": "2.2.2",
@@ -16577,6 +16840,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+			"dev": true,
 			"requires": {
 				"got": "^6.7.1",
 				"registry-auth-token": "^3.0.1",
@@ -16588,6 +16852,7 @@
 			"version": "2.7.38",
 			"resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.38.tgz",
 			"integrity": "sha512-XxHUyHQB7QCVBxoXeVu0yKxT+2PvJucsc0+1E+6f95lMUxEAYERgSAc71ckYXrYr35Ew3xFU/LrhdIK21GQFFA==",
+			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.0",
 				"cacache": "^9.2.9",
@@ -16616,6 +16881,7 @@
 					"version": "9.3.0",
 					"resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
 					"integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.0",
 						"chownr": "^1.0.1",
@@ -16635,12 +16901,14 @@
 				"genfun": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
-					"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
+					"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
+					"dev": true
 				},
 				"make-fetch-happen": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
 					"integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
+					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.3.0",
 						"cacache": "^10.0.0",
@@ -16659,6 +16927,7 @@
 							"version": "10.0.4",
 							"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.1",
 								"chownr": "^1.0.1",
@@ -16679,6 +16948,7 @@
 									"version": "2.0.0",
 									"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
 									"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+									"dev": true,
 									"requires": {
 										"concat-stream": "^1.5.0",
 										"duplexify": "^3.4.2",
@@ -16698,6 +16968,7 @@
 							"version": "2.0.1",
 							"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
 								"once": "^1.3.1"
@@ -16707,6 +16978,7 @@
 							"version": "5.3.0",
 							"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
 							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1"
 							}
@@ -16714,7 +16986,8 @@
 						"y18n": {
 							"version": "4.0.0",
 							"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+							"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+							"dev": true
 						}
 					}
 				},
@@ -16722,6 +16995,7 @@
 					"version": "1.3.1",
 					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
 					"integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
 						"duplexify": "^3.4.2",
@@ -16739,6 +17013,7 @@
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
 					"integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
+					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.4.2",
 						"osenv": "^0.1.4",
@@ -16750,6 +17025,7 @@
 					"version": "1.0.4",
 					"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-1.0.4.tgz",
 					"integrity": "sha512-MKxNdeyOZysPRTTbHtW0M5Fw38Jo/3ARsoGw5qjCfS+XGjvNB/Gb4qtAZUFmKPM2mVum+eX559eHvKywU856BQ==",
+					"dev": true,
 					"requires": {
 						"npm-package-arg": "^5.1.2",
 						"semver": "^5.3.0"
@@ -16759,6 +17035,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
 					"integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
+					"dev": true,
 					"requires": {
 						"genfun": "^4.0.1"
 					}
@@ -16767,6 +17044,7 @@
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
 					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -16775,12 +17053,14 @@
 				"smart-buffer": {
 					"version": "1.1.15",
 					"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-					"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+					"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
+					"dev": true
 				},
 				"socks": {
 					"version": "1.1.10",
 					"resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
 					"integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+					"dev": true,
 					"requires": {
 						"ip": "^1.1.4",
 						"smart-buffer": "^1.0.13"
@@ -16790,6 +17070,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
 					"integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+					"dev": true,
 					"requires": {
 						"agent-base": "^4.1.0",
 						"socks": "^1.1.10"
@@ -16799,6 +17080,7 @@
 					"version": "4.1.6",
 					"resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
 					"integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.0"
 					}
@@ -16806,7 +17088,8 @@
 				"y18n": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"dev": true
 				}
 			}
 		},
@@ -16820,6 +17103,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
 			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+			"dev": true,
 			"requires": {
 				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
@@ -16840,6 +17124,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			}
@@ -16884,6 +17169,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
 			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
@@ -16897,6 +17183,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
 			"integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
+			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"fs-exists-sync": "^0.1.0",
@@ -16908,6 +17195,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -16930,6 +17218,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
 			"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"error-ex": "^1.3.1",
@@ -16940,7 +17229,8 @@
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"dev": true
 		},
 		"parse-path": {
 			"version": "4.0.1",
@@ -17013,22 +17303,26 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -17039,7 +17333,8 @@
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
 		},
 		"pathval": {
 			"version": "1.1.0",
@@ -17220,6 +17515,7 @@
 			"version": "3.4.4",
 			"resolved": "https://registry.npmjs.org/polished/-/polished-3.4.4.tgz",
 			"integrity": "sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.3"
 			}
@@ -17227,7 +17523,8 @@
 		"popper.js": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+			"dev": true
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
@@ -17410,7 +17707,8 @@
 		"prepend-http": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+			"dev": true
 		},
 		"prettier": {
 			"version": "1.17.0",
@@ -17464,6 +17762,7 @@
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
 			"integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
+			"dev": true,
 			"requires": {
 				"clipboard": "^2.0.0"
 			}
@@ -17477,12 +17776,14 @@
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
 		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -17493,12 +17794,14 @@
 		"promise-inflight": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
 		},
 		"promise-retry": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
 			"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+			"dev": true,
 			"requires": {
 				"err-code": "^1.0.0",
 				"retry": "^0.10.0"
@@ -17560,6 +17863,7 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -17570,6 +17874,7 @@
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
 			"integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
+			"dev": true,
 			"requires": {
 				"xtend": "^4.0.0"
 			}
@@ -17623,7 +17928,8 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.7.0",
@@ -17659,6 +17965,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+			"dev": true,
 			"requires": {
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
@@ -17669,6 +17976,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -17697,7 +18005,8 @@
 		"qs": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
+			"dev": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -17780,6 +18089,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -17791,6 +18101,7 @@
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
 			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -17801,6 +18112,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
 			"integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.0.0"
 			}
@@ -17809,6 +18121,7 @@
 			"version": "2.18.0",
 			"resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.0.tgz",
 			"integrity": "sha512-FyVeU1kQiSokWc8NPz22azl1ezLpJdUyTbWL0LPUpcuuYDrZ/Y1veOk9rRK5B3pMlyDGvTk4f4KJhlkIQNRjEA==",
+			"dev": true,
 			"requires": {
 				"@icons/material": "^0.2.4",
 				"lodash": "^4.17.11",
@@ -18012,6 +18325,7 @@
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
 			"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -18038,7 +18352,8 @@
 		"react-fast-compare": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-			"integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+			"integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
+			"dev": true
 		},
 		"react-focus-lock": {
 			"version": "1.19.1",
@@ -18056,6 +18371,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.4.tgz",
 			"integrity": "sha512-KTGHE9sz8N7+fCkZ2a3vzXH9eIkiTNhL2NhKR7XzzQl3WsGlCHh76arauJUIiGdfhjeMp7DY7PkASAmYFXeJYg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.3.4",
 				"invariant": "^2.2.4",
@@ -18077,6 +18393,7 @@
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
 			"integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+			"dev": true,
 			"requires": {
 				"prop-types": "^15.5.8"
 			}
@@ -18095,17 +18412,20 @@
 		"react-is": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+			"dev": true
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+			"dev": true
 		},
 		"react-popper": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
 			"integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"create-react-context": "^0.3.0",
@@ -18120,6 +18440,7 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-2.10.1.tgz",
 			"integrity": "sha512-cib8bKiyYcrIlHo9zXx81G0XvARfL8Jt+xum709MFCgQa3HTqTi4au3iJ9tm7vi7WU7ngnqbpWkMinBOtwo+IQ==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.4",
 				"react-popper": "^1.3.6"
@@ -18129,6 +18450,7 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/react-select/-/react-select-3.0.8.tgz",
 			"integrity": "sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@emotion/cache": "^10.0.9",
@@ -18169,6 +18491,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-3.1.0.tgz",
 			"integrity": "sha512-9RKc77HCPsjQDVPyZEw37g3JPtg26oSQ9o4mtaVXjJuLedDX5+TQcE+MRNKR+4aO3GMAY4YslCePGG1//MQ3Jg==",
+			"dev": true,
 			"requires": {
 				"classnames": "^2.2.0",
 				"prop-types": "^15.5.0"
@@ -18178,6 +18501,7 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
 			"integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"prop-types": "^15.6.0"
@@ -18187,6 +18511,7 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
 			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+			"dev": true,
 			"requires": {
 				"dom-helpers": "^3.4.0",
 				"loose-envify": "^1.4.0",
@@ -18198,6 +18523,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
 			"integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.0.1"
 			}
@@ -18295,6 +18621,7 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -18389,6 +18716,7 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
 			"integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+			"dev": true,
 			"requires": {
 				"hastscript": "^5.0.0",
 				"parse-entities": "^1.1.2",
@@ -18399,6 +18727,7 @@
 					"version": "1.17.1",
 					"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
 					"integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+					"dev": true,
 					"requires": {
 						"clipboard": "^2.0.0"
 					}
@@ -18423,7 +18752,8 @@
 		"regenerator-runtime": {
 			"version": "0.13.3",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+			"dev": true
 		},
 		"regenerator-transform": {
 			"version": "0.14.1",
@@ -18448,6 +18778,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
 			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1"
@@ -18477,6 +18808,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
 			"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
 				"safe-buffer": "^5.0.1"
@@ -18486,6 +18818,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+			"dev": true,
 			"requires": {
 				"rc": "^1.0.1"
 			}
@@ -18523,6 +18856,7 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/remote-origin-url/-/remote-origin-url-0.5.3.tgz",
 			"integrity": "sha512-crQ7Xk1m/F2IiwBx5oTqk/c0hjoumrEz+a36+ZoVupskQRE/q7pAwHKsTNeiZ31sbSTELvVlVv4h1W0Xo5szKg==",
+			"dev": true,
 			"requires": {
 				"parse-git-config": "^1.1.1"
 			}
@@ -18695,12 +19029,14 @@
 		"resize-observer-polyfill": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
 			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -18726,6 +19062,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
 			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+			"dev": true,
 			"requires": {
 				"expand-tilde": "^1.2.2",
 				"global-modules": "^0.2.3"
@@ -18735,6 +19072,7 @@
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
 					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+					"dev": true,
 					"requires": {
 						"global-prefix": "^0.1.4",
 						"is-windows": "^0.2.0"
@@ -18744,6 +19082,7 @@
 					"version": "0.1.5",
 					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
 					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+					"dev": true,
 					"requires": {
 						"homedir-polyfill": "^1.0.0",
 						"ini": "^1.3.4",
@@ -18754,14 +19093,16 @@
 				"is-windows": {
 					"version": "0.2.0",
 					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
 				}
 			}
 		},
 		"resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -18773,6 +19114,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"dev": true,
 			"requires": {
 				"onetime": "^2.0.0",
 				"signal-exit": "^3.0.2"
@@ -18787,7 +19129,8 @@
 		"retry": {
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"dev": true
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -18799,6 +19142,7 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
 			}
@@ -18949,6 +19293,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
@@ -18963,6 +19308,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.1.1"
 			}
@@ -18986,6 +19332,7 @@
 			"version": "6.5.4",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
 			"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -18993,7 +19340,8 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -19007,7 +19355,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -19297,6 +19646,7 @@
 			"version": "0.18.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
 			"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -19338,17 +19688,20 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
 			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+			"dev": true,
 			"optional": true
 		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
 		},
 		"semver-diff": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
 			"requires": {
 				"semver": "^5.0.3"
 			}
@@ -19516,17 +19869,20 @@
 		"shallow-equal": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-			"integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+			"integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+			"dev": true
 		},
 		"shallowequal": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+			"dev": true
 		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -19534,7 +19890,8 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"shell-quote": {
 			"version": "1.7.2",
@@ -19563,6 +19920,7 @@
 			"version": "2.2.15",
 			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
 			"integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
+			"dev": true,
 			"requires": {
 				"nanoid": "^2.1.0"
 			},
@@ -19570,7 +19928,8 @@
 				"nanoid": {
 					"version": "2.1.11",
 					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-					"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+					"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
+					"dev": true
 				}
 			}
 		},
@@ -19587,7 +19946,8 @@
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -19610,6 +19970,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
 			"integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+			"dev": true,
 			"requires": {
 				"can-use-dom": "^0.1.0",
 				"core-js": "^3.0.1",
@@ -19622,7 +19983,8 @@
 				"core-js": {
 					"version": "3.6.4",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+					"dev": true
 				}
 			}
 		},
@@ -19630,6 +19992,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
 			"integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.1",
 				"simplebar": "^4.2.3"
@@ -19872,7 +20235,8 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -19920,12 +20284,14 @@
 		"space-separated-tokens": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19934,12 +20300,14 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -19948,7 +20316,8 @@
 		"spdx-license-ids": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"dev": true
 		},
 		"split": {
 			"version": "1.0.1",
@@ -20012,7 +20381,8 @@
 		"stable": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"dev": true
 		},
 		"stack-utils": {
 			"version": "1.0.2",
@@ -20071,12 +20441,14 @@
 		"store2": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/store2/-/store2-2.10.0.tgz",
-			"integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg=="
+			"integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg==",
+			"dev": true
 		},
 		"storybook-addon-preview": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.0.0.tgz",
-			"integrity": "sha512-u+LAZAa4TMxnK9e3sRpkUd1gZEplS9drHtO36nGbNiY/k0xcuwAuKROKNt2H2FAXHhX0xvqNl0k5+T2URTKKUw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.0.1.tgz",
+			"integrity": "sha512-5IeKC7axfab8rhxdCPwWfM8aO7ccEihxlmSmykQVNavQSewJhj5C2TvaDpqLJinWv7UloBkwdOS3R9dk7v4mRQ==",
+			"dev": true,
 			"requires": {
 				"@storybook/addon-knobs": "^5.2.6",
 				"@types/prismjs": "^1.16.0",
@@ -20089,6 +20461,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.3.14.tgz",
 					"integrity": "sha512-pBpFOdeCR8n8w6QHK1adABt6YKf+Q4itfX0+AtZRGLvbGum9O+paihvP9EVYPlKiG+0T7Zv2vFCl6q6qFjF/Mw==",
+					"dev": true,
 					"requires": {
 						"@storybook/addons": "5.3.14",
 						"@storybook/api": "5.3.14",
@@ -20114,6 +20487,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.14.tgz",
 					"integrity": "sha512-zoN1MYlArdThp93i+Ogil/pihyx8n7nkrdSO0j9HUh6jUsGeFFEluPQZdRFte9NIoY6ZWSWwuEMDgrv2Pw9r2Q==",
+					"dev": true,
 					"requires": {
 						"@storybook/api": "5.3.14",
 						"@storybook/channels": "5.3.14",
@@ -20128,6 +20502,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.14.tgz",
 					"integrity": "sha512-ANWRMTLEoAfu0IsXqbxmbTpxS8xTByZgLj20tH96bxgH1rJo9KAZnJ8A9kGYr+zklU8QnYvVIgmV3HESXII9zg==",
+					"dev": true,
 					"requires": {
 						"@reach/router": "^1.2.1",
 						"@storybook/channels": "5.3.14",
@@ -20155,6 +20530,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.14.tgz",
 					"integrity": "sha512-XKHxMSwW3movfTDOashuYlVCX3Hp7+X+amXc/xhDDzbiYjy3/CVm3LlkkM6v451IVEdK6pue4ewqZQWJAYAAEQ==",
+					"dev": true,
 					"requires": {
 						"@storybook/channels": "5.3.14",
 						"@storybook/client-logger": "5.3.14",
@@ -20167,6 +20543,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.14.tgz",
 					"integrity": "sha512-k9QBf9Kwe+iGmdEK/kW5xprqem2SPfBVwET6LWvJkWOl9UQ9VoMuCHgV55p0tzjcugaqWWKoF9+FRMWxWRfsQg==",
+					"dev": true,
 					"requires": {
 						"core-js": "^3.0.1"
 					}
@@ -20175,6 +20552,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.14.tgz",
 					"integrity": "sha512-1qx1NIwto5F9N24Fb6VzKyDzeaZHtWTZ7afPrg56e1tUu7jbog7rELdRezk8+YAujveyMDJu4MxnOSP01sv7YQ==",
+					"dev": true,
 					"requires": {
 						"@storybook/addons": "5.3.14",
 						"@storybook/channel-postmessage": "5.3.14",
@@ -20199,6 +20577,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.14.tgz",
 					"integrity": "sha512-YCHEsOvo6zPb4udlyAwqr5W0Kv9mAEQmcX73w9IDvAxbjR00T7empW7qmbjvviftKB/5MEgDdiYbj64ccs3aqg==",
+					"dev": true,
 					"requires": {
 						"core-js": "^3.0.1"
 					}
@@ -20207,6 +20586,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.14.tgz",
 					"integrity": "sha512-AsjkIFBrrqcBDLxGdmUHiauZo5gOL65eXx8WA7/yJDF8s45VVZX5Z0buOnjFyEhGVus02gwTov8da2irjL862A==",
+					"dev": true,
 					"requires": {
 						"@storybook/client-logger": "5.3.14",
 						"@storybook/theming": "5.3.14",
@@ -20235,6 +20615,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.14.tgz",
 					"integrity": "sha512-VCPLKqRugsOSx/smMJiJOvRgAzTrMpsbRuFw48kBGkQMP9TEV82Qe/341dv+f4GllPyBZyANG0p0m5+w7ZCURQ==",
+					"dev": true,
 					"requires": {
 						"core-js": "^3.0.1"
 					}
@@ -20243,6 +20624,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.14.tgz",
 					"integrity": "sha512-O0KwQFncdBeq+O2Aq8UAFBVWjWmP5rtqoacUOFSGkXgObOnyniEraLiPH7rPtq2dAlSpgYI9+srQAZfo52Hz2A==",
+					"dev": true,
 					"requires": {
 						"@reach/router": "^1.2.1",
 						"@storybook/csf": "0.0.1",
@@ -20259,6 +20641,7 @@
 					"version": "5.3.14",
 					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.14.tgz",
 					"integrity": "sha512-raqXC3yJycEt1CrCAfnBYUA6pyJI80E9M26EeQl3UfytJOL6euprOi+D17QvxqBn7jmmf9ZDw5XRkvJhQ17Y7Q==",
+					"dev": true,
 					"requires": {
 						"@emotion/core": "^10.0.20",
 						"@emotion/styled": "^10.0.17",
@@ -20278,6 +20661,7 @@
 					"version": "11.0.2",
 					"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
 					"integrity": "sha512-iMNcixH8330f2dq0RY+VOXCP8JFehgmOhLOtnO85Ty+qu0fHXJNEqWx5VuFv8v0aEq0U/N9d/k1yvA+c6PEmPw==",
+					"dev": true,
 					"requires": {
 						"@types/react": "*"
 					}
@@ -20285,22 +20669,26 @@
 				"core-js": {
 					"version": "3.6.4",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+					"dev": true
 				},
 				"highlight.js": {
 					"version": "9.13.1",
 					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-					"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+					"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+					"dev": true
 				},
 				"isobject": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+					"dev": true
 				},
 				"lowlight": {
 					"version": "1.11.0",
 					"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
 					"integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+					"dev": true,
 					"requires": {
 						"fault": "^1.0.2",
 						"highlight.js": "~9.13.0"
@@ -20310,6 +20698,7 @@
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
 					"integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.0.0",
 						"focus-lock": "^0.6.6",
@@ -20323,6 +20712,7 @@
 					"version": "11.0.2",
 					"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
 					"integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
+					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"highlight.js": "~9.13.0",
@@ -20334,12 +20724,14 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				},
 				"telejson": {
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
 					"integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
+					"dev": true,
 					"requires": {
 						"@types/is-function": "^1.0.0",
 						"global": "^4.4.0",
@@ -20403,6 +20795,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
@@ -20424,7 +20817,8 @@
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+			"dev": true
 		},
 		"string-length": {
 			"version": "2.0.0",
@@ -20508,6 +20902,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
 			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
@@ -20517,6 +20912,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
 			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
@@ -20526,6 +20922,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -20548,7 +20945,8 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
@@ -20565,7 +20963,8 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
@@ -20592,6 +20991,7 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -20773,6 +21173,7 @@
 			"version": "1.16.3",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
 			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+			"dev": true,
 			"requires": {
 				"chownr": "^1.0.1",
 				"mkdirp": "^0.5.1",
@@ -20784,6 +21185,7 @@
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
 					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -20795,6 +21197,7 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
 			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"dev": true,
 			"requires": {
 				"bl": "^1.0.0",
 				"buffer-alloc": "^1.2.0",
@@ -20881,6 +21284,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
 			"requires": {
 				"execa": "^0.7.0"
 			}
@@ -21817,7 +22221,8 @@
 		"textextensions": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
-			"integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ=="
+			"integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==",
+			"dev": true
 		},
 		"thenify": {
 			"version": "3.3.0",
@@ -21852,12 +22257,14 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
@@ -21872,7 +22279,8 @@
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+			"dev": true
 		},
 		"timers-browserify": {
 			"version": "2.0.11",
@@ -21893,17 +22301,20 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+			"dev": true,
 			"optional": true
 		},
 		"tinycolor2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+			"dev": true
 		},
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -21944,12 +22355,14 @@
 		"to-buffer": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -22005,7 +22418,8 @@
 		"toggle-selection": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+			"integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
+			"dev": true
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -22077,7 +22491,8 @@
 		"ts-dedent": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
-			"integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg=="
+			"integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==",
+			"dev": true
 		},
 		"ts-pnp": {
 			"version": "1.1.6",
@@ -22088,7 +22503,8 @@
 		"tslib": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+			"dev": true
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -22145,12 +22561,14 @@
 		"typed-styles": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
+			"dev": true
 		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
 		},
 		"typescript": {
 			"version": "3.8.2",
@@ -22265,6 +22683,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+			"dev": true,
 			"requires": {
 				"unique-slug": "^2.0.0"
 			}
@@ -22273,6 +22692,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
 			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -22281,6 +22701,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
 			"requires": {
 				"crypto-random-string": "^1.0.0"
 			}
@@ -22297,7 +22718,8 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -22308,7 +22730,8 @@
 		"unquote": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -22353,7 +22776,8 @@
 		"unzip-response": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+			"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+			"dev": true
 		},
 		"upath": {
 			"version": "1.2.0",
@@ -22365,6 +22789,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
 			"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+			"dev": true,
 			"requires": {
 				"boxen": "^1.2.1",
 				"chalk": "^2.0.1",
@@ -22382,6 +22807,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
 					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0"
 					}
@@ -22389,12 +22815,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"boxen": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
 					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+					"dev": true,
 					"requires": {
 						"ansi-align": "^2.0.0",
 						"camelcase": "^4.0.0",
@@ -22408,27 +22836,32 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				},
 				"ci-info": {
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+					"dev": true
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+					"dev": true
 				},
 				"import-lazy": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+					"dev": true
 				},
 				"is-ci": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
 					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"dev": true,
 					"requires": {
 						"ci-info": "^1.5.0"
 					}
@@ -22436,12 +22869,14 @@
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -22451,6 +22886,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -22539,6 +22975,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+			"dev": true,
 			"requires": {
 				"prepend-http": "^1.0.1"
 			}
@@ -22552,12 +22989,14 @@
 		"use-callback-ref": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
-			"integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w=="
+			"integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==",
+			"dev": true
 		},
 		"use-sidecar": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
 			"integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
+			"dev": true,
 			"requires": {
 				"detect-node": "^2.0.4",
 				"tslib": "^1.9.3"
@@ -22598,7 +23037,8 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
 		},
 		"util-promisify": {
 			"version": "2.1.0",
@@ -22641,6 +23081,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -22650,6 +23091,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 			"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+			"dev": true,
 			"requires": {
 				"builtins": "^1.0.3"
 			}
@@ -22705,6 +23147,7 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
 			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -22880,6 +23323,7 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -22937,6 +23381,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
 			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
 			},
@@ -22944,17 +23389,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -22964,6 +23412,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -23096,7 +23545,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "0.2.1",
@@ -23111,6 +23561,7 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
 			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"imurmurhash": "^0.1.4",
@@ -23197,7 +23648,8 @@
 		"xdg-basedir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
 		},
 		"xhr": {
 			"version": "2.5.0",
@@ -23260,7 +23712,8 @@
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true
 		},
 		"y18n": {
 			"version": "4.0.0",
@@ -23271,12 +23724,14 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yaml": {
 			"version": "1.7.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
 			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.3"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3760,15 +3760,6 @@
 				}
 			}
 		},
-		"@storybook/csf": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
-			"integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.15"
-			}
-		},
 		"@storybook/html": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@storybook/html/-/html-5.2.1.tgz",
@@ -4018,12 +4009,6 @@
 			"integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==",
 			"dev": true
 		},
-		"@types/is-function": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
-			"integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w==",
-			"dev": true
-		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -4117,28 +4102,10 @@
 				"csstype": "^2.2.0"
 			}
 		},
-		"@types/react-color": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.1.tgz",
-			"integrity": "sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*"
-			}
-		},
 		"@types/react-syntax-highlighter": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz",
 			"integrity": "sha512-dF49hC4FZp1dIKyzacOrHvqMUe8U2IXyQCQXOcT1e6n64gLBp+xM6qGtPsThIT9XjiIHSg2W5Jc2V5IqekBfnA==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*"
-			}
-		},
-		"@types/react-textarea-autosize": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
-			"integrity": "sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==",
 			"dev": true,
 			"requires": {
 				"@types/react": "*"
@@ -4157,12 +4124,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
 			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-			"dev": true
-		},
-		"@types/webpack-env": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.1.tgz",
-			"integrity": "sha512-eWN5ElDTeBc5lRDh95SqA8x18D0ll2pWudU3uWiyfsRmIZcmUXpEsxPU+7+BsdCrO2vfLRC629u/MmjbmF+2tA==",
 			"dev": true
 		},
 		"@types/yargs": {
@@ -9119,12 +9080,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
 			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-			"dev": true
-		},
-		"detect-node": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-			"integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
 			"dev": true
 		},
 		"detect-port": {
@@ -20445,304 +20400,16 @@
 			"dev": true
 		},
 		"storybook-addon-preview": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.0.1.tgz",
-			"integrity": "sha512-5IeKC7axfab8rhxdCPwWfM8aO7ccEihxlmSmykQVNavQSewJhj5C2TvaDpqLJinWv7UloBkwdOS3R9dk7v4mRQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/storybook-addon-preview/-/storybook-addon-preview-1.0.3.tgz",
+			"integrity": "sha512-SUpGMKPVsosrkebN++CPUbxb2gK8+5qvM7ig8PzDptypM0KxPTQ+CsGq4+otm2mygGBfR14uLb+SgNIcxQ+OvA==",
 			"dev": true,
 			"requires": {
-				"@storybook/addon-knobs": "^5.2.6",
+				"@storybook/addon-knobs": "^5.2.0",
 				"@types/prismjs": "^1.16.0",
 				"codesandbox": "^2.1.10",
 				"prismjs": "^1.17.1",
 				"react-tabs": "^3.0.0"
-			},
-			"dependencies": {
-				"@storybook/addon-knobs": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.3.14.tgz",
-					"integrity": "sha512-pBpFOdeCR8n8w6QHK1adABt6YKf+Q4itfX0+AtZRGLvbGum9O+paihvP9EVYPlKiG+0T7Zv2vFCl6q6qFjF/Mw==",
-					"dev": true,
-					"requires": {
-						"@storybook/addons": "5.3.14",
-						"@storybook/api": "5.3.14",
-						"@storybook/client-api": "5.3.14",
-						"@storybook/components": "5.3.14",
-						"@storybook/core-events": "5.3.14",
-						"@storybook/theming": "5.3.14",
-						"@types/react-color": "^3.0.1",
-						"copy-to-clipboard": "^3.0.8",
-						"core-js": "^3.0.1",
-						"escape-html": "^1.0.3",
-						"fast-deep-equal": "^2.0.1",
-						"global": "^4.3.2",
-						"lodash": "^4.17.15",
-						"prop-types": "^15.7.2",
-						"qs": "^6.6.0",
-						"react-color": "^2.17.0",
-						"react-lifecycles-compat": "^3.0.4",
-						"react-select": "^3.0.8"
-					}
-				},
-				"@storybook/addons": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.14.tgz",
-					"integrity": "sha512-zoN1MYlArdThp93i+Ogil/pihyx8n7nkrdSO0j9HUh6jUsGeFFEluPQZdRFte9NIoY6ZWSWwuEMDgrv2Pw9r2Q==",
-					"dev": true,
-					"requires": {
-						"@storybook/api": "5.3.14",
-						"@storybook/channels": "5.3.14",
-						"@storybook/client-logger": "5.3.14",
-						"@storybook/core-events": "5.3.14",
-						"core-js": "^3.0.1",
-						"global": "^4.3.2",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/api": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.14.tgz",
-					"integrity": "sha512-ANWRMTLEoAfu0IsXqbxmbTpxS8xTByZgLj20tH96bxgH1rJo9KAZnJ8A9kGYr+zklU8QnYvVIgmV3HESXII9zg==",
-					"dev": true,
-					"requires": {
-						"@reach/router": "^1.2.1",
-						"@storybook/channels": "5.3.14",
-						"@storybook/client-logger": "5.3.14",
-						"@storybook/core-events": "5.3.14",
-						"@storybook/csf": "0.0.1",
-						"@storybook/router": "5.3.14",
-						"@storybook/theming": "5.3.14",
-						"@types/reach__router": "^1.2.3",
-						"core-js": "^3.0.1",
-						"fast-deep-equal": "^2.0.1",
-						"global": "^4.3.2",
-						"lodash": "^4.17.15",
-						"memoizerific": "^1.11.3",
-						"prop-types": "^15.6.2",
-						"react": "^16.8.3",
-						"semver": "^6.0.0",
-						"shallow-equal": "^1.1.0",
-						"store2": "^2.7.1",
-						"telejson": "^3.2.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/channel-postmessage": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.14.tgz",
-					"integrity": "sha512-XKHxMSwW3movfTDOashuYlVCX3Hp7+X+amXc/xhDDzbiYjy3/CVm3LlkkM6v451IVEdK6pue4ewqZQWJAYAAEQ==",
-					"dev": true,
-					"requires": {
-						"@storybook/channels": "5.3.14",
-						"@storybook/client-logger": "5.3.14",
-						"core-js": "^3.0.1",
-						"global": "^4.3.2",
-						"telejson": "^3.2.0"
-					}
-				},
-				"@storybook/channels": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.14.tgz",
-					"integrity": "sha512-k9QBf9Kwe+iGmdEK/kW5xprqem2SPfBVwET6LWvJkWOl9UQ9VoMuCHgV55p0tzjcugaqWWKoF9+FRMWxWRfsQg==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.0.1"
-					}
-				},
-				"@storybook/client-api": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.14.tgz",
-					"integrity": "sha512-1qx1NIwto5F9N24Fb6VzKyDzeaZHtWTZ7afPrg56e1tUu7jbog7rELdRezk8+YAujveyMDJu4MxnOSP01sv7YQ==",
-					"dev": true,
-					"requires": {
-						"@storybook/addons": "5.3.14",
-						"@storybook/channel-postmessage": "5.3.14",
-						"@storybook/channels": "5.3.14",
-						"@storybook/client-logger": "5.3.14",
-						"@storybook/core-events": "5.3.14",
-						"@storybook/csf": "0.0.1",
-						"@types/webpack-env": "^1.15.0",
-						"core-js": "^3.0.1",
-						"eventemitter3": "^4.0.0",
-						"global": "^4.3.2",
-						"is-plain-object": "^3.0.0",
-						"lodash": "^4.17.15",
-						"memoizerific": "^1.11.3",
-						"qs": "^6.6.0",
-						"stable": "^0.1.8",
-						"ts-dedent": "^1.1.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/client-logger": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.14.tgz",
-					"integrity": "sha512-YCHEsOvo6zPb4udlyAwqr5W0Kv9mAEQmcX73w9IDvAxbjR00T7empW7qmbjvviftKB/5MEgDdiYbj64ccs3aqg==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.0.1"
-					}
-				},
-				"@storybook/components": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.14.tgz",
-					"integrity": "sha512-AsjkIFBrrqcBDLxGdmUHiauZo5gOL65eXx8WA7/yJDF8s45VVZX5Z0buOnjFyEhGVus02gwTov8da2irjL862A==",
-					"dev": true,
-					"requires": {
-						"@storybook/client-logger": "5.3.14",
-						"@storybook/theming": "5.3.14",
-						"@types/react-syntax-highlighter": "11.0.2",
-						"@types/react-textarea-autosize": "^4.3.3",
-						"core-js": "^3.0.1",
-						"global": "^4.3.2",
-						"lodash": "^4.17.15",
-						"markdown-to-jsx": "^6.9.1",
-						"memoizerific": "^1.11.3",
-						"polished": "^3.3.1",
-						"popper.js": "^1.14.7",
-						"prop-types": "^15.7.2",
-						"react": "^16.8.3",
-						"react-dom": "^16.8.3",
-						"react-focus-lock": "^2.1.0",
-						"react-helmet-async": "^1.0.2",
-						"react-popper-tooltip": "^2.8.3",
-						"react-syntax-highlighter": "^11.0.2",
-						"react-textarea-autosize": "^7.1.0",
-						"simplebar-react": "^1.0.0-alpha.6",
-						"ts-dedent": "^1.1.0"
-					}
-				},
-				"@storybook/core-events": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.14.tgz",
-					"integrity": "sha512-VCPLKqRugsOSx/smMJiJOvRgAzTrMpsbRuFw48kBGkQMP9TEV82Qe/341dv+f4GllPyBZyANG0p0m5+w7ZCURQ==",
-					"dev": true,
-					"requires": {
-						"core-js": "^3.0.1"
-					}
-				},
-				"@storybook/router": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.14.tgz",
-					"integrity": "sha512-O0KwQFncdBeq+O2Aq8UAFBVWjWmP5rtqoacUOFSGkXgObOnyniEraLiPH7rPtq2dAlSpgYI9+srQAZfo52Hz2A==",
-					"dev": true,
-					"requires": {
-						"@reach/router": "^1.2.1",
-						"@storybook/csf": "0.0.1",
-						"@types/reach__router": "^1.2.3",
-						"core-js": "^3.0.1",
-						"global": "^4.3.2",
-						"lodash": "^4.17.15",
-						"memoizerific": "^1.11.3",
-						"qs": "^6.6.0",
-						"util-deprecate": "^1.0.2"
-					}
-				},
-				"@storybook/theming": {
-					"version": "5.3.14",
-					"resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.14.tgz",
-					"integrity": "sha512-raqXC3yJycEt1CrCAfnBYUA6pyJI80E9M26EeQl3UfytJOL6euprOi+D17QvxqBn7jmmf9ZDw5XRkvJhQ17Y7Q==",
-					"dev": true,
-					"requires": {
-						"@emotion/core": "^10.0.20",
-						"@emotion/styled": "^10.0.17",
-						"@storybook/client-logger": "5.3.14",
-						"core-js": "^3.0.1",
-						"deep-object-diff": "^1.1.0",
-						"emotion-theming": "^10.0.19",
-						"global": "^4.3.2",
-						"memoizerific": "^1.11.3",
-						"polished": "^3.3.1",
-						"prop-types": "^15.7.2",
-						"resolve-from": "^5.0.0",
-						"ts-dedent": "^1.1.0"
-					}
-				},
-				"@types/react-syntax-highlighter": {
-					"version": "11.0.2",
-					"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
-					"integrity": "sha512-iMNcixH8330f2dq0RY+VOXCP8JFehgmOhLOtnO85Ty+qu0fHXJNEqWx5VuFv8v0aEq0U/N9d/k1yvA+c6PEmPw==",
-					"dev": true,
-					"requires": {
-						"@types/react": "*"
-					}
-				},
-				"core-js": {
-					"version": "3.6.4",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-					"integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
-					"dev": true
-				},
-				"highlight.js": {
-					"version": "9.13.1",
-					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-					"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-					"dev": true
-				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
-				},
-				"lowlight": {
-					"version": "1.11.0",
-					"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-					"integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
-					"dev": true,
-					"requires": {
-						"fault": "^1.0.2",
-						"highlight.js": "~9.13.0"
-					}
-				},
-				"react-focus-lock": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.2.1.tgz",
-					"integrity": "sha512-47g0xYcCTZccdzKRGufepY8oZ3W1Qg+2hn6u9SHZ0zUB6uz/4K4xJe7yYFNZ1qT6m+2JDm82F6QgKeBTbjW4PQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.0.0",
-						"focus-lock": "^0.6.6",
-						"prop-types": "^15.6.2",
-						"react-clientside-effect": "^1.2.2",
-						"use-callback-ref": "^1.2.1",
-						"use-sidecar": "^1.0.1"
-					}
-				},
-				"react-syntax-highlighter": {
-					"version": "11.0.2",
-					"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
-					"integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.3.1",
-						"highlight.js": "~9.13.0",
-						"lowlight": "~1.11.0",
-						"prismjs": "^1.8.4",
-						"refractor": "^2.4.1"
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				},
-				"telejson": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-					"integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-					"dev": true,
-					"requires": {
-						"@types/is-function": "^1.0.0",
-						"global": "^4.4.0",
-						"is-function": "^1.0.1",
-						"is-regex": "^1.0.4",
-						"is-symbol": "^1.0.3",
-						"isobject": "^4.0.0",
-						"lodash": "^4.17.15",
-						"memoizerific": "^1.11.3"
-					}
-				}
 			}
 		},
 		"storybook-readme": {
@@ -22488,12 +22155,6 @@
 				"utf8-byte-length": "^1.0.1"
 			}
 		},
-		"ts-dedent": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
-			"integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==",
-			"dev": true
-		},
 		"ts-pnp": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
@@ -22985,22 +22646,6 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
-		},
-		"use-callback-ref": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.1.tgz",
-			"integrity": "sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==",
-			"dev": true
-		},
-		"use-sidecar": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
-			"integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
-			"dev": true,
-			"requires": {
-				"detect-node": "^2.0.4",
-				"tslib": "^1.9.3"
-			}
 		},
 		"utf8-byte-length": {
 			"version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@skatejs/val": "^0.4.0",
     "@webcomponents/webcomponentsjs": "2.2.10",
     "lit-element": "^2.2.0",
-    "lit-html": "^1.1.0"
+    "lit-html": "^1.1.0",
+    "storybook-addon-preview": "^1.0.0"
   },
   "devDependencies": {
     "@axa-ch/patterns-library-polyfill": "^1.4.12",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "@skatejs/val": "^0.4.0",
     "@webcomponents/webcomponentsjs": "2.2.10",
     "lit-element": "^2.2.0",
-    "lit-html": "^1.1.0",
-    "storybook-addon-preview": "^1.0.0"
+    "lit-html": "^1.1.0"
   },
   "devDependencies": {
     "@axa-ch/patterns-library-polyfill": "^1.4.12",
@@ -90,6 +89,7 @@
     "rollup-plugin-sass": "^1.1.0",
     "rollup-plugin-uglify": "^6.0.4",
     "sass-loader": "^7.1.0",
+    "storybook-addon-preview": "^1.0.1",
     "storybook-readme": "5.0.6",
     "svgo": "^1.2.0",
     "testcafe": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "rollup-plugin-sass": "^1.1.0",
     "rollup-plugin-uglify": "^6.0.4",
     "sass-loader": "^7.1.0",
-    "storybook-addon-preview": "^1.1.0-beta8",
+    "storybook-addon-preview": "1.1.0-beta11",
     "storybook-readme": "5.0.6",
     "svgo": "^1.2.0",
     "testcafe": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "rollup-plugin-sass": "^1.1.0",
     "rollup-plugin-uglify": "^6.0.4",
     "sass-loader": "^7.1.0",
-    "storybook-addon-preview": "1.0.3",
+    "storybook-addon-preview": "^1.1.0-beta8",
     "storybook-readme": "5.0.6",
     "svgo": "^1.2.0",
     "testcafe": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "rollup-plugin-sass": "^1.1.0",
     "rollup-plugin-uglify": "^6.0.4",
     "sass-loader": "^7.1.0",
-    "storybook-addon-preview": "^1.0.1",
+    "storybook-addon-preview": "1.0.3",
     "storybook-readme": "5.0.6",
     "svgo": "^1.2.0",
     "testcafe": "1.8.2",

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -13,8 +13,13 @@ import { iconList } from '../icon/icon-list';
 import Readme from './README.md';
 import Changelog from './CHANGELOG.md';
 
+// eslint-disable-next-line import/first
+import { withPreview, previewTemplate, DEFAULT_VANILLA_CODESANDBOX } from "storybook-addon-preview";
+
+
 const storyButton = storiesOf('Components|Atoms/Button', module);
 storyButton.addDecorator(withKnobs);
+storyButton.addDecorator(withPreview);
 storyButton.addParameters({
   readme: {
     sidebar: Readme,
@@ -84,4 +89,18 @@ storyButton.add('Button', () => {
   `;
   render(template, wrapper);
   return wrapper;
+}, {
+  preview: [
+    {
+      tab: "Vanilla",
+      template: previewTemplate`
+const inst = new Instance({
+    opt1: ${"text"},
+    num1:,
+});
+            `,
+      language: "js",
+      copy: true,
+    },
+  ]
 });

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -14,8 +14,7 @@ import Readme from './README.md';
 import Changelog from './CHANGELOG.md';
 
 // eslint-disable-next-line import/first
-import { withPreview, previewTemplate } from "storybook-addon-preview";
-
+import { withPreview, previewTemplate } from 'storybook-addon-preview';
 
 const storyButton = storiesOf('Components|Atoms/Button', module);
 storyButton.addDecorator(withKnobs);
@@ -60,58 +59,51 @@ export const invertedBgs = {
   'inverted-blue-teal': '#027180',
 };
 
-storyButton.add('Button', () => {
-  const buttonText = text('text', 'Calculate Premium');
-  const variants = radios('variant', variantOptions, '');
-  const sizes = radios('size', sizeOptions, '');
-  const icons = select('icon', iconList, '');
-  const motionOff = boolean('motionOff', false);
-  const disabled = boolean('disabled', false);
-  const types = radios('types', typesOptions, 'button');
+storyButton.add(
+  'Button',
+  () => {
+    const buttonText = text('text', 'Calculate Premium');
+    const variants = radios('variant', variantOptions, '');
+    const sizes = radios('size', sizeOptions, '');
+    const icons = select('icon', iconList, '');
+    const motionOff = boolean('motionOff', false);
+    const disabled = boolean('disabled', false);
+    const types = radios('types', typesOptions, 'button');
 
-  const wrapper = document.createElement('div');
-  const template = html`
-    <div
-      style="${variants.includes('inverted')
-        ? `background-color: ${invertedBgs[variants]}; padding: 10px;`
-        : ''}"
-    >
-      <axa-button
-        type="${types}"
-        variant="${variants}"
-        size="${sizes}"
-        icon="${icons}"
-        ?disabled="${disabled}"
-        ?motionoff="${motionOff}"
-        >${buttonText}
-      </axa-button>
-    </div>
-  `;
-  render(template, wrapper);
-  return wrapper;
-}, {
-  preview: [
-    {
-      tab: "with previewTemplate",
-      template: previewTemplate`
-const inst = new Instance({
-    opt1: ${"text"},
-    num1:,
-});
-            `,
-      language: "js",
-      copy: true,
-    },
-    {
-      tab: "without",
-      template: `
-const inst = new Instance({
-    opt1: ${"text"},
-    num1:,
-});
-            `,
-      language: "js",
-      copy: true,
-    },
-  ]
-});
+    const wrapper = document.createElement('div');
+    const template = html`
+      <div
+        style="${variants.includes('inverted')
+          ? `background-color: ${invertedBgs[variants]}; padding: 10px;`
+          : ''}"
+      >
+        <axa-button
+          type="${types}"
+          variant="${variants}"
+          size="${sizes}"
+          icon="${icons}"
+          ?disabled="${disabled}"
+          ?motionoff="${motionOff}"
+          >${buttonText}
+        </axa-button>
+      </div>
+    `;
+    render(template, wrapper);
+    return wrapper;
+  },
+  {
+    preview: [
+      {
+        tab: 'HTML',
+        template: previewTemplate`
+<axa-button
+    variant=${'variant'}>
+${'text'}
+</axa-button>
+         `,
+        language: 'js',
+        copy: true,
+      },
+    ],
+  }
+);

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -14,7 +14,7 @@ import Readme from './README.md';
 import Changelog from './CHANGELOG.md';
 
 // eslint-disable-next-line import/first
-import { withPreview, previewTemplate } from 'storybook-addon-preview';
+import { withPreview, previewTemplate, raw } from 'storybook-addon-preview';
 
 const storyButton = storiesOf('Components|Atoms/Button', module);
 storyButton.addDecorator(withKnobs);
@@ -118,7 +118,7 @@ export default AXAButtonReact;
 
 <AXAButtonReact 
     variant=${'variant'}>
-        ${'text'}
+        ${raw('text')}
 </AxaButtonReact>
          `,
         language: 'js',

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -94,12 +94,32 @@ storyButton.add(
   {
     preview: [
       {
-        tab: 'HTML',
+        tab: 'Vanilla',
         template: previewTemplate`
+import '@axa-ch/button';
+
 <axa-button
     variant=${'variant'}>
 ${'text'}
 </axa-button>
+         `,
+        language: 'js',
+        copy: true,
+      },
+      {
+        tab: 'React',
+        template: previewTemplate`
+import { createElement } from 'react';
+import createAXAButtonReact from '@axa-ch/button/lib/index.react';
+
+const AXAButtonReact = createAXAButtonReact(createElement);
+
+export default AXAButtonReact;
+
+<AXAButtonReact 
+    variant=${'variant'}>
+        ${'text'}
+</AxaButtonReact>
          `,
         language: 'js',
         copy: true,

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -92,8 +92,19 @@ storyButton.add('Button', () => {
 }, {
   preview: [
     {
-      tab: "Vanilla",
+      tab: "with previewTemplate",
       template: previewTemplate`
+const inst = new Instance({
+    opt1: ${"text"},
+    num1:,
+});
+            `,
+      language: "js",
+      copy: true,
+    },
+    {
+      tab: "without",
+      template: `
 const inst = new Instance({
     opt1: ${"text"},
     num1:,

--- a/src/components/10-atoms/button/story.js
+++ b/src/components/10-atoms/button/story.js
@@ -14,7 +14,7 @@ import Readme from './README.md';
 import Changelog from './CHANGELOG.md';
 
 // eslint-disable-next-line import/first
-import { withPreview, previewTemplate, DEFAULT_VANILLA_CODESANDBOX } from "storybook-addon-preview";
+import { withPreview, previewTemplate } from "storybook-addon-preview";
 
 
 const storyButton = storiesOf('Components|Atoms/Button', module);


### PR DESCRIPTION
We have codepreview right now:
![image](https://user-images.githubusercontent.com/7448004/76327803-bebabd80-62ea-11ea-948a-cd70d33f8902.png)

What do you think about this solution?
https://axa-ch.github.io/plib-feature/1656_codepreview_3rdpartymodule/?path=/story/components-atoms-button--button (only preview for Button is integrated)
![image](https://user-images.githubusercontent.com/7448004/76388723-0b91a900-636a-11ea-8fb2-883502b294b4.png)
