### PR TITLE
remove browser default margins for axa-heading

### DIFF
--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -37,9 +37,14 @@ class AXAHeading extends LitElement {
       this.variant === 'secondary' ? 'a-heading--secondary' : '';
 
     const template = `
-      <h${this.rank} class="a-heading ${secondaryVariant}">
-        <slot></slot>
-      </h${this.rank}>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <h${this.rank} class="a-heading ${secondaryVariant}">
+      <slot></slot>
+    </h${this.rank}>
     `;
 
     return html`

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,5 +1,6 @@
 .a-heading {
   // reset browser styles
+  margin: 0;
   margin-block-start: 0;
   margin-block-end: 0;
   margin-inline-start: 0;
@@ -7,6 +8,8 @@
 }
 
 h1.a-heading {
+  margin: 20px 0;
+
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -31,6 +34,8 @@ h1.a-heading {
 }
 
 h2.a-heading {
+  margin: 18px 0;
+
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -55,6 +60,8 @@ h2.a-heading {
 }
 
 h3.a-heading {
+  margin: 16px 0;
+
   @include typo-title(large);
 
   @include breakpoint($mediaquery-md) {
@@ -79,6 +86,8 @@ h3.a-heading {
 }
 
 h4.a-heading {
+  margin: 14px 0;
+
   @include typo-title(large);
 
   @include breakpoint($mediaquery-md) {
@@ -103,6 +112,8 @@ h4.a-heading {
 }
 
 h5.a-heading {
+  margin: 12px 0;
+
   @include typo-title(medium-1);
 
   @include breakpoint($mediaquery-md) {
@@ -127,6 +138,8 @@ h5.a-heading {
 }
 
 h6.a-heading {
+  margin: 10px 0;
+
   @include typo-title(medium);
 
   @include breakpoint($mediaquery-md) {

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,3 +1,11 @@
+.a-heading {
+  // reset browser styles
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+}
+
 h1.a-heading {
   @include typo-title(large-1);
 

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -19,17 +19,28 @@ storyAXAHeading.add('Heading', () => {
   const wrapper = document.createElement('div');
   const template = html`
     <axa-heading rank="1">H1 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="2">H2 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="3">H3 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="4">H4 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="5">H5 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="6">H6 Primary Heading</axa-heading>
+    <br />
 
     <axa-heading variant="secondary" rank="1">H1 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="2">H2 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="3">H3 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="4">H4 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="5">H5 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="6">H6 Secondary Heading</axa-heading>
   `;
 

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -1,10 +1,11 @@
 /* global document */
 import { storiesOf } from '@storybook/html';
-// if your need more boolean, select, radios
-import { withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+
+const loremIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
 const storyAXAHeading = storiesOf('Components|Atoms/Heading', module);
 storyAXAHeading.addDecorator(withKnobs);
@@ -12,38 +13,24 @@ storyAXAHeading.addParameters({
   readme: {
     sidebar: Readme,
   },
-  knobs: { disabled: true },
 });
 
 storyAXAHeading.add('Heading', () => {
+  const rank = select('Rank', ['1', '2', '3', '4', '5', '6'], '1');
+  const secondary = boolean('Secondary (variant)', false);
+
   const wrapper = document.createElement('div');
-  const template = html`
-    <axa-heading rank="1">H1 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="2">H2 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="3">H3 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="4">H4 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="5">H5 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="6">H6 Primary Heading</axa-heading>
-    <br />
-
-    <axa-heading variant="secondary" rank="1">H1 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="2">H2 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="3">H3 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="4">H4 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="5">H5 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="6">H6 Secondary Heading</axa-heading>
-  `;
-
+  const template = secondary
+    ? html`
+        <axa-heading rank="${rank}" variant="secondary"
+          >H1 Primary Heading</axa-heading
+        >
+        <axa-text>${loremIpsum}</axa-text>
+      `
+    : html`
+        <axa-heading rank="${rank}">H1 Primary Heading</axa-heading>
+        <axa-text>${loremIpsum}</axa-text>
+      `;
   render(template, wrapper);
   return wrapper;
 });


### PR DESCRIPTION
Fixes #1693

 OPTION 1! Read here about the in my opinion better option: #1703 

This is a very controversial PR. I would like to receive many opinions on it.

The need was to get resettable margins (and optionally customizable margins).

The way I went with that:
1. I use the CSS-Selector `:host` to make the `axa-heading` element displayed as a block element. `:host` is still in draft state, but my change is tested in Chrome, Safari and IE. Still, we once decided to not use a feature because it was in draft state.
2. We use predefined margins for the heading (as expected). But for the user to counter this margin, he needs to apply a negative margin to the root-element, which does not sound that nice, but makes the component extremely flexible.
3. I could have gone one step further and apply ALL margins directly on the root element, which would make negative margins (issues by the user) obsolete. But this would rely heavily on the host-property. This is my most liked approach and I will open a separate PR for this option, since we get the best compromise with this one.
4.  Not using the `:host` feature means a huge effort or the denial to our users to be able to manipulate the margins on their own.

Difference between Option 1 and 2:
```
Option 1:

<axa-heading rank="1">I am a heading</axa-heading>

<style>
  axa-heading[rank="1"] {
    margin-bottom: -15px;
    /* The margin-bottom is now 5px, because the default margin is 20px for H1, the user needs to know that and rely on it for the future. */
  }

Option 2:

<axa-heading rank="1">I am a heading</axa-heading>

<style>
  axa-heading[rank="1"] {
    margin-bottom: 5px;
    /* The margin-bottom is now 5px. */
  }

</style>
```

What do you think? In my opinion, we should allow the host property, just because it already works everywhere (it seems) and if, for whatever reason, support would get cancelled, we will probably note that ourselves or get failing tests. The IE support will never drop, for chrome we can write tests, only Safari and Firefox could go unseen, if nobody tracks this information.

# Done is when (DoD):
- [ ] Modifications within components are reflected by tests.
- [ ] A self-review of the code has been performed.
- [ ] The modified component properties have been added to the typescript typings.
- [ ] Potential design changes have been reviewed by a designer.
- [ ] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [ ] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
- [ ] The modifications still work in IE.
- [ ] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
