### PR TITLE
Feature/remove heading margins v2

### DIFF
--- a/src/components/10-atoms/heading/CHANGELOG.md
+++ b/src/components/10-atoms/heading/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## 2.0.0
 
-- The default browser margins were reset to 0.
-- The margins of the axa-heading can now be changed by the user, by applying the margins directly to the root element.
+- The default browser margins were reset to 0. [#1693](https://github.com/axa-ch/patterns-library/issues/1693)
+- The margins of the axa-heading can now be changed by the user, by applying the margins directly to the root element. [#1693](https://github.com/axa-ch/patterns-library/issues/1693)

--- a/src/components/10-atoms/heading/CHANGELOG.md
+++ b/src/components/10-atoms/heading/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2.0.0
+
+- The default browser margins were reset to 0.
+- The margins of the axa-heading can now be changed by the user, by applying the margins directly to the root element.

--- a/src/components/10-atoms/heading/README.md
+++ b/src/components/10-atoms/heading/README.md
@@ -59,3 +59,22 @@ Import the heading-defining script and use a heading like this:
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `variant="secondary"` | Secondary variant will use publico as font. Default: "primary"                                                                 |
 | `rank="1"`            | Rank holds a number from one to six, which represents the underlying html heading tag. `rank="1"` will lead to a `h1` element. |
+
+## Custom Margins
+
+The custom element tag has the style property `display: block` applied to it, which means, that you can overwrite the predefined margins. Please only do this if this is abolutely necessary, since the default margins are aligned with the styleguide.
+
+Example:
+
+```html
+<axa-heading rank="1">I'm a h1 title</axa-heading>
+
+<style>
+  axa-heading {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+</style>
+```

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -30,6 +30,15 @@ class AXAHeading extends LitElement {
     // this functions applies default values per type and verifies if
     // the HTML attribute has been set before defining the custom element
     applyDefaults(this);
+
+    this.topBottomMarginsByRank = {
+      1: '20px',
+      2: '18px',
+      3: '16px',
+      4: '14px',
+      5: '12px',
+      6: '10px',
+    };
   }
 
   render() {
@@ -40,6 +49,7 @@ class AXAHeading extends LitElement {
     <style>
       :host {
         display: block;
+        margin: ${this.topBottomMarginsByRank[this.rank]} 0;
       }
     </style>
     <h${this.rank} class="a-heading ${secondaryVariant}">

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -37,9 +37,14 @@ class AXAHeading extends LitElement {
       this.variant === 'secondary' ? 'a-heading--secondary' : '';
 
     const template = `
-      <h${this.rank} class="a-heading ${secondaryVariant}">
-        <slot></slot>
-      </h${this.rank}>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <h${this.rank} class="a-heading ${secondaryVariant}">
+      <slot></slot>
+    </h${this.rank}>
     `;
 
     return html`

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -45,13 +45,10 @@ class AXAHeading extends LitElement {
     const secondaryVariant =
       this.variant === 'secondary' ? 'a-heading--secondary' : '';
 
+    this.style.marginTop = TOP_BOTTOM_MARGINS_BY_RANK[this.rank];
+    this.style.marginBottom = TOP_BOTTOM_MARGINS_BY_RANK[this.rank];
+
     const template = `
-    <style>
-      :host {
-        display: block;
-        margin: ${TOP_BOTTOM_MARGINS_BY_RANK[this.rank]} 0;
-      }
-    </style>
     <h${this.rank} class="a-heading ${secondaryVariant}">
       <slot></slot>
     </h${this.rank}>

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -6,6 +6,15 @@ import defineOnce from '../../../utils/define-once';
 import { applyDefaults } from '../../../utils/with-react';
 import styles from './index.scss';
 
+const TOP_BOTTOM_MARGINS_BY_RANK = {
+  1: '20px',
+  2: '18px',
+  3: '16px',
+  4: '14px',
+  5: '12px',
+  6: '10px',
+};
+
 class AXAHeading extends LitElement {
   static get tagName() {
     return 'axa-heading';
@@ -30,15 +39,6 @@ class AXAHeading extends LitElement {
     // this functions applies default values per type and verifies if
     // the HTML attribute has been set before defining the custom element
     applyDefaults(this);
-
-    this.topBottomMarginsByRank = {
-      1: '20px',
-      2: '18px',
-      3: '16px',
-      4: '14px',
-      5: '12px',
-      6: '10px',
-    };
   }
 
   render() {
@@ -49,7 +49,7 @@ class AXAHeading extends LitElement {
     <style>
       :host {
         display: block;
-        margin: ${this.topBottomMarginsByRank[this.rank]} 0;
+        margin: ${TOP_BOTTOM_MARGINS_BY_RANK[this.rank]} 0;
       }
     </style>
     <h${this.rank} class="a-heading ${secondaryVariant}">

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,5 +1,6 @@
 .a-heading {
   // reset browser styles
+  margin: 0;
   margin-block-start: 0;
   margin-block-end: 0;
   margin-inline-start: 0;
@@ -7,6 +8,8 @@
 }
 
 h1.a-heading {
+  margin: 20px 0;
+
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -31,6 +34,8 @@ h1.a-heading {
 }
 
 h2.a-heading {
+  margin: 18px 0;
+
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -55,6 +60,8 @@ h2.a-heading {
 }
 
 h3.a-heading {
+  margin: 16px 0;
+
   @include typo-title(large);
 
   @include breakpoint($mediaquery-md) {
@@ -79,6 +86,8 @@ h3.a-heading {
 }
 
 h4.a-heading {
+  margin: 14px 0;
+
   @include typo-title(large);
 
   @include breakpoint($mediaquery-md) {
@@ -103,6 +112,8 @@ h4.a-heading {
 }
 
 h5.a-heading {
+  margin: 12px 0;
+
   @include typo-title(medium-1);
 
   @include breakpoint($mediaquery-md) {
@@ -127,6 +138,8 @@ h5.a-heading {
 }
 
 h6.a-heading {
+  margin: 10px 0;
+
   @include typo-title(medium);
 
   @include breakpoint($mediaquery-md) {

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,3 +1,11 @@
+.a-heading {
+  // reset browser styles
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+}
+
 h1.a-heading {
   @include typo-title(large-1);
 

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,3 +1,4 @@
+// We set the display property to 'block', so that a user of this element can overwrite the margins.
 :host {
   display: block;
 }

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -8,8 +8,6 @@
 }
 
 h1.a-heading {
-  margin: 20px 0;
-
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -34,8 +32,6 @@ h1.a-heading {
 }
 
 h2.a-heading {
-  margin: 18px 0;
-
   @include typo-title(large-1);
 
   @include breakpoint($mediaquery-md) {
@@ -60,8 +56,6 @@ h2.a-heading {
 }
 
 h3.a-heading {
-  margin: 16px 0;
-
   @include typo-title(large);
 
   @include breakpoint($mediaquery-md) {
@@ -86,8 +80,6 @@ h3.a-heading {
 }
 
 h4.a-heading {
-  margin: 14px 0;
-
   @include typo-title(large);
 
   @include breakpoint($mediaquery-md) {
@@ -112,8 +104,6 @@ h4.a-heading {
 }
 
 h5.a-heading {
-  margin: 12px 0;
-
   @include typo-title(medium-1);
 
   @include breakpoint($mediaquery-md) {
@@ -138,8 +128,6 @@ h5.a-heading {
 }
 
 h6.a-heading {
-  margin: 10px 0;
-
   @include typo-title(medium);
 
   @include breakpoint($mediaquery-md) {

--- a/src/components/10-atoms/heading/index.scss
+++ b/src/components/10-atoms/heading/index.scss
@@ -1,3 +1,7 @@
+:host {
+  display: block;
+}
+
 .a-heading {
   // reset browser styles
   margin: 0;

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -19,17 +19,28 @@ storyAXAHeading.add('Heading', () => {
   const wrapper = document.createElement('div');
   const template = html`
     <axa-heading rank="1">H1 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="2">H2 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="3">H3 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="4">H4 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="5">H5 Primary Heading</axa-heading>
+    <br />
     <axa-heading rank="6">H6 Primary Heading</axa-heading>
+    <br />
 
     <axa-heading variant="secondary" rank="1">H1 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="2">H2 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="3">H3 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="4">H4 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="5">H5 Secondary Heading</axa-heading>
+    <br />
     <axa-heading variant="secondary" rank="6">H6 Secondary Heading</axa-heading>
   `;
 

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -18,8 +18,8 @@ storyAXAHeading.addParameters({
 storyAXAHeading.add('Heading', () => {
   const rank = select('Rank', ['1', '2', '3', '4', '5', '6'], '1');
   const secondary = boolean('Secondary (variant)', false);
-
   const wrapper = document.createElement('div');
+
   const template = secondary
     ? html`
         <axa-heading rank="${rank}" variant="secondary"
@@ -31,6 +31,7 @@ storyAXAHeading.add('Heading', () => {
         <axa-heading rank="${rank}">H1 Primary Heading</axa-heading>
         <axa-text>${loremIpsum}</axa-text>
       `;
+
   render(template, wrapper);
   return wrapper;
 });

--- a/src/components/10-atoms/heading/story.js
+++ b/src/components/10-atoms/heading/story.js
@@ -1,10 +1,11 @@
 /* global document */
 import { storiesOf } from '@storybook/html';
-// if your need more boolean, select, radios
-import { withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit-html';
 import './index';
 import Readme from './README.md';
+
+const loremIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
 const storyAXAHeading = storiesOf('Components|Atoms/Heading', module);
 storyAXAHeading.addDecorator(withKnobs);
@@ -12,38 +13,24 @@ storyAXAHeading.addParameters({
   readme: {
     sidebar: Readme,
   },
-  knobs: { disabled: true },
 });
 
 storyAXAHeading.add('Heading', () => {
+  const rank = select('Rank', ['1', '2', '3', '4', '5', '6'], '1');
+  const secondary = boolean('Secondary (variant)', false);
+
   const wrapper = document.createElement('div');
-  const template = html`
-    <axa-heading rank="1">H1 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="2">H2 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="3">H3 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="4">H4 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="5">H5 Primary Heading</axa-heading>
-    <br />
-    <axa-heading rank="6">H6 Primary Heading</axa-heading>
-    <br />
-
-    <axa-heading variant="secondary" rank="1">H1 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="2">H2 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="3">H3 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="4">H4 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="5">H5 Secondary Heading</axa-heading>
-    <br />
-    <axa-heading variant="secondary" rank="6">H6 Secondary Heading</axa-heading>
-  `;
-
+  const template = secondary
+    ? html`
+        <axa-heading rank="${rank}" variant="secondary"
+          >H1 Primary Heading</axa-heading
+        >
+        <axa-text>${loremIpsum}</axa-text>
+      `
+    : html`
+        <axa-heading rank="${rank}">H1 Primary Heading</axa-heading>
+        <axa-text>${loremIpsum}</axa-text>
+      `;
   render(template, wrapper);
   return wrapper;
 });

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -3,7 +3,7 @@ import { Selector } from 'testcafe';
 const host = process.env.TEST_HOST_STORYBOOK_URL;
 
 fixture('Heading - Correct CSS attributes')
-  .page(`${host}/iframe.html?id=components-atoms-heading--heading`)
+  .page(`${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=1`)
   .afterEach(async t => {
     await t.maximizeWindow();
   });
@@ -21,9 +21,7 @@ async function _getHeadingElement(t, rank, variant) {
     () =>
       document
         .querySelector(
-          `axa-heading[rank='${rank}']${
-            variant ? `[variant="${variant}"]` : ''
-          }`
+          `axa-heading[rank='${rank}']${variant ? `[variant="secondary"]` : ''}`
         )
         .shadowRoot.querySelector('.a-heading'),
     { dependencies: { rank, variant } }
@@ -50,193 +48,6 @@ test('should render h1 primary correctly on desktop', async t => {
   await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
 });
 
-test('should render h2 primary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('48px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('54px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.48px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h3 primary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.36px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h4 primary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.28px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h5 primary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.24px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h6 primary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.2px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h1 secondary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('62px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('72px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.62px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h2 secondary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('48px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('54px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.48px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h3 secondary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.36px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h4 secondary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.28px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h5 secondary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.24px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
-test('should render h6 secondary correctly on desktop', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.2px');
-}).before(async t => {
-  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
-});
-
 test('should render h1 primary correctly on tablet', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
 
@@ -250,193 +61,6 @@ test('should render h1 primary correctly on tablet', async t => {
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.36px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h2 primary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.3px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h3 primary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.28px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h4 primary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('25px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.25px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h5 primary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.2px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h6 primary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Source Sans Pro", Arial, sans-serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.18px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h1 secondary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.36px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h2 secondary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.3px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h3 secondary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.28px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h4 secondary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('25px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.25px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h5 secondary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.2px');
-}).before(async t => {
-  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
-});
-
-test('should render h6 secondary correctly on tablet', async t => {
-  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
-
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('font-family'))
-    .eql('"Publico Headline", Georgia, serif');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
-  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
-  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
-  await t
-    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
-    .eql('-0.18px');
 }).before(async t => {
   await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
@@ -458,6 +82,46 @@ test('should render h1 primary correctly on mobile', async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });
 
+fixture('Heading - Correct CSS attributes')
+  .page(`${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=2`)
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h2 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('48px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('54px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.48px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h2 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.3px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
 test('should render h2 primary correctly on mobile', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
 
@@ -473,6 +137,46 @@ test('should render h2 primary correctly on mobile', async t => {
     .eql('-0.24px');
 }).before(async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+fixture('Heading - Correct CSS attributes')
+  .page(`${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=3`)
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h3 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h3 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h3 primary correctly on mobile', async t => {
@@ -492,6 +196,46 @@ test('should render h3 primary correctly on mobile', async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });
 
+fixture('Heading - Correct CSS attributes')
+  .page(`${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=4`)
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h4 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h4 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('25px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.25px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
 test('should render h4 primary correctly on mobile', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
 
@@ -507,6 +251,46 @@ test('should render h4 primary correctly on mobile', async t => {
     .eql('-0.2px');
 }).before(async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+fixture('Heading - Correct CSS attributes')
+  .page(`${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=5`)
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h5 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h5 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h5 primary correctly on mobile', async t => {
@@ -526,6 +310,46 @@ test('should render h5 primary correctly on mobile', async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });
 
+fixture('Heading - Correct CSS attributes')
+  .page(`${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=6`)
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h6 primary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h6 primary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Source Sans Pro", Arial, sans-serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.18px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
 test('should render h6 primary correctly on mobile', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
 
@@ -541,6 +365,48 @@ test('should render h6 primary correctly on mobile', async t => {
     .eql('-0.16px');
 }).before(async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+fixture('Heading - Correct CSS attributes')
+  .page(
+    `${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=1&knob-Secondary%20(variant)=true`
+  )
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h1 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('62px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('72px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.62px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h1 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h1 secondary correctly on mobile', async t => {
@@ -560,6 +426,48 @@ test('should render h1 secondary correctly on mobile', async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });
 
+fixture('Heading - Correct CSS attributes')
+  .page(
+    `${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=2&knob-Secondary%20(variant)=true`
+  )
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h2 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('48px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('54px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.48px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h2 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.3px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
 test('should render h2 secondary correctly on mobile', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
 
@@ -575,6 +483,48 @@ test('should render h2 secondary correctly on mobile', async t => {
     .eql('-0.24px');
 }).before(async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+fixture('Heading - Correct CSS attributes')
+  .page(
+    `${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=3&knob-Secondary%20(variant)=true`
+  )
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h3 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('36px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('42px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.36px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h3 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h3 secondary correctly on mobile', async t => {
@@ -594,6 +544,48 @@ test('should render h3 secondary correctly on mobile', async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });
 
+fixture('Heading - Correct CSS attributes')
+  .page(
+    `${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=4&knob-Secondary%20(variant)=true`
+  )
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h4 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('28px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('32px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.28px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h4 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('25px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.25px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
 test('should render h4 secondary correctly on mobile', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
 
@@ -611,6 +603,48 @@ test('should render h4 secondary correctly on mobile', async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
 });
 
+fixture('Heading - Correct CSS attributes')
+  .page(
+    `${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=5&knob-Secondary%20(variant)=true`
+  )
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h5 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('24px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('29px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.24px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h5 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
+});
+
 test('should render h5 secondary correctly on mobile', async t => {
   const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
 
@@ -626,6 +660,48 @@ test('should render h5 secondary correctly on mobile', async t => {
     .eql('-0.18px');
 }).before(async t => {
   await t.resizeWindow(mobileBreakpoint, mobileBreakpoint);
+});
+
+fixture('Heading - Correct CSS attributes')
+  .page(
+    `${host}/iframe.html?id=components-atoms-heading--heading&knob-Rank=6&knob-Secondary%20(variant)=true`
+  )
+  .afterEach(async t => {
+    await t.maximizeWindow();
+  });
+
+test('should render h6 secondary correctly on desktop', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('20px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('26px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.2px');
+}).before(async t => {
+  await t.resizeWindow(desktopBreakpoint, desktopBreakpoint);
+});
+
+test('should render h6 secondary correctly on tablet', async t => {
+  const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
+
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('font-family'))
+    .eql('"Publico Headline", Georgia, serif');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-weight')).eql('400');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
+  await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('18px');
+  await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('20px');
+  await t
+    .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
+    .eql('-0.18px');
+}).before(async t => {
+  await t.resizeWindow(tabletBreakpoint, tabletBreakpoint);
 });
 
 test('should render h6 secondary correctly on mobile', async t => {

--- a/src/components/10-atoms/heading/ui.test.js
+++ b/src/components/10-atoms/heading/ui.test.js
@@ -32,8 +32,11 @@ async function _getHeadingElement(t, rank, variant) {
 }
 
 test('should render h1 primary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('20px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('20px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -49,8 +52,11 @@ test('should render h1 primary correctly on desktop', async t => {
 });
 
 test('should render h1 primary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('20px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('20px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -66,8 +72,11 @@ test('should render h1 primary correctly on tablet', async t => {
 });
 
 test('should render h1 primary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '1', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('20px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('20px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -89,8 +98,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h2 primary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('18px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('18px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -106,8 +118,11 @@ test('should render h2 primary correctly on desktop', async t => {
 });
 
 test('should render h2 primary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('18px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('18px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -115,6 +130,7 @@ test('should render h2 primary correctly on tablet', async t => {
   await t.expect($axaElemShadowEl.getStyleProperty('font-style')).eql('normal');
   await t.expect($axaElemShadowEl.getStyleProperty('font-size')).eql('30px');
   await t.expect($axaElemShadowEl.getStyleProperty('line-height')).eql('34px');
+  await t;
   await t
     .expect($axaElemShadowEl.getStyleProperty('letter-spacing'))
     .eql('-0.3px');
@@ -123,8 +139,11 @@ test('should render h2 primary correctly on tablet', async t => {
 });
 
 test('should render h2 primary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '2', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('18px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('18px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -146,8 +165,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h3 primary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('16px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('16px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -163,8 +185,11 @@ test('should render h3 primary correctly on desktop', async t => {
 });
 
 test('should render h3 primary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('16px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('16px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -180,8 +205,11 @@ test('should render h3 primary correctly on tablet', async t => {
 });
 
 test('should render h3 primary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '3', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('16px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('16px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -203,8 +231,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h4 primary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('14px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('14px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -220,8 +251,11 @@ test('should render h4 primary correctly on desktop', async t => {
 });
 
 test('should render h4 primary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('14px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('14px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -237,8 +271,11 @@ test('should render h4 primary correctly on tablet', async t => {
 });
 
 test('should render h4 primary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '4', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('14px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('14px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -260,8 +297,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h5 primary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('12px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('12px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -277,8 +317,11 @@ test('should render h5 primary correctly on desktop', async t => {
 });
 
 test('should render h5 primary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('12px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('12px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -294,8 +337,11 @@ test('should render h5 primary correctly on tablet', async t => {
 });
 
 test('should render h5 primary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '5', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('12px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('12px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -317,8 +363,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h6 primary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('10px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('10px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -334,8 +383,11 @@ test('should render h6 primary correctly on desktop', async t => {
 });
 
 test('should render h6 primary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('10px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('10px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -351,8 +403,11 @@ test('should render h6 primary correctly on tablet', async t => {
 });
 
 test('should render h6 primary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '6', '');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('10px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('10px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Source Sans Pro", Arial, sans-serif');
@@ -376,8 +431,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h1 secondary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('20px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('20px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -393,8 +451,11 @@ test('should render h1 secondary correctly on desktop', async t => {
 });
 
 test('should render h1 secondary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('20px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('20px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -410,8 +471,11 @@ test('should render h1 secondary correctly on tablet', async t => {
 });
 
 test('should render h1 secondary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '1', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('20px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('20px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -435,8 +499,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h2 secondary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('18px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('18px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -452,8 +519,11 @@ test('should render h2 secondary correctly on desktop', async t => {
 });
 
 test('should render h2 secondary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('18px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('18px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -469,8 +539,11 @@ test('should render h2 secondary correctly on tablet', async t => {
 });
 
 test('should render h2 secondary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '2', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('18px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('18px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -494,8 +567,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h3 secondary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('16px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('16px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -511,8 +587,11 @@ test('should render h3 secondary correctly on desktop', async t => {
 });
 
 test('should render h3 secondary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('16px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('16px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -528,8 +607,11 @@ test('should render h3 secondary correctly on tablet', async t => {
 });
 
 test('should render h3 secondary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '3', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('16px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('16px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -553,8 +635,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h4 secondary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('14px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('14px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -570,8 +655,11 @@ test('should render h4 secondary correctly on desktop', async t => {
 });
 
 test('should render h4 secondary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('14px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('14px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -587,8 +675,11 @@ test('should render h4 secondary correctly on tablet', async t => {
 });
 
 test('should render h4 secondary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '4', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('14px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('14px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -612,8 +703,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h5 secondary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('12px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('12px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -629,8 +723,11 @@ test('should render h5 secondary correctly on desktop', async t => {
 });
 
 test('should render h5 secondary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('12px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('12px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -646,8 +743,11 @@ test('should render h5 secondary correctly on tablet', async t => {
 });
 
 test('should render h5 secondary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '5', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('12px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('12px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -671,8 +771,11 @@ fixture('Heading - Correct CSS attributes')
   });
 
 test('should render h6 secondary correctly on desktop', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('10px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('10px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -688,8 +791,11 @@ test('should render h6 secondary correctly on desktop', async t => {
 });
 
 test('should render h6 secondary correctly on tablet', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('10px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('10px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');
@@ -705,8 +811,11 @@ test('should render h6 secondary correctly on tablet', async t => {
 });
 
 test('should render h6 secondary correctly on mobile', async t => {
+  const $headingElement = await Selector(TAG);
   const $axaElemShadowEl = await _getHeadingElement(t, '6', 'secondary');
 
+  await t.expect($headingElement.getStyleProperty('margin-top')).eql('10px');
+  await t.expect($headingElement.getStyleProperty('margin-bottom')).eql('10px');
   await t
     .expect($axaElemShadowEl.getStyleProperty('font-family'))
     .eql('"Publico Headline", Georgia, serif');


### PR DESCRIPTION
Fixes #1693

OPTION 2! Read about Option 1: https://github.com/axa-ch/patterns-library/pull/1702

This is a very controversial PR. I would like to receive many opinions on it.

Tested on: Chrome, IE11, Brave, Firefox, Safari

The need was to get resettable margins (and optionally customizable margins).

The way I went with that:
1. I use the CSS-Selector `:host` to make the `axa-heading` element displayed as a block element. `:host` is still in draft state, but seems to work fine in all major browsers. Still, we once decided to not use a feature because it was in draft state (slotted).
2. The user does not need to apply a negative margin to the element, but he can overwrite the default margin by simply styling the root element.
3. Not using the `:host` feature means a huge effort or the denial to our users to be able to manipulate the margins on their own.

Difference between Option 1 and 2:
```
Option 1:

<axa-heading rank="1">I am a heading</axa-heading>

<style>
  axa-heading[rank="1"] {
    margin-bottom: -15px;
    /* The margin-bottom is now 5px, because the default margin is 20px for H1, the user needs to know that and rely on it for the future. */
  }

Option 2:

<axa-heading rank="1">I am a heading</axa-heading>

<style>
  axa-heading[rank="1"] {
    margin-bottom: 5px;
    /* The margin-bottom is now 5px. */
  }

</style>
```

What do you think? In my opinion, we should allow the host property, just because it already works everywhere (it seems) and if, for whatever reason, support would get cancelled, we will probably note that ourselves or get failing tests. The IE support will never drop, for chrome we can write tests, only Safari and Firefox could go unseen, if nobody tracks this information.

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
