### PR TITLE
Heading: update TS types to allow all HTMLHeadingElement's HTMLAttributes

### DIFF
--- a/src/components/10-atoms/heading/index.react.d.ts
+++ b/src/components/10-atoms/heading/index.react.d.ts
@@ -3,7 +3,7 @@ import React from 'react';
 export type Variant = 'primary' | 'secondary';
 export type Rank = 1 | 2 | 3 | 4 | 5 | 6;
 
-export interface AXAHeadingProps {
+export interface AXAHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   rank: Rank;
   variant?: Variant;
 }


### PR DESCRIPTION
Update Heading TS types to allow all HTMLHeadingElement's HTMLAttributes
(As all attributes are now passed down.)

This allows in React using props like `className` or `style` needed to adjust the margins.

Related to https://github.com/axa-ch/patterns-library/issues/1693

# Done is when (DoD):
- [ ] Modifications within components are reflected by tests.
- [ ] A self-review of the code has been performed.
- [ ] The modified component properties have been added to the typescript typings.
- [ ] Potential design changes have been reviewed by a designer.
- [ ] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [ ] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
- [ ] The modifications still work in IE.
- [ ] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
