### PR TITLE
remove datepicker specific stylings from axa dropdown

### DIFF
--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -384,7 +384,6 @@ class AXADatepicker extends NoShadowDOM {
                       maxheight="270"
                       items="${JSON.stringify(this.monthitems)}"
                       defaulttitle="${this.monthtitle}"
-                      usecase="datepicker"
                     >
                     </axa-dropdown>
 
@@ -394,7 +393,6 @@ class AXADatepicker extends NoShadowDOM {
                       maxheight="270"
                       items="${JSON.stringify(this.yearitems)}"
                       defaulttitle="${this.yeartitle}"
-                      usecase="datepicker"
                     >
                     </axa-dropdown>
                   </div>

--- a/src/components/20-molecules/dropdown/index.scss
+++ b/src/components/20-molecules/dropdown/index.scss
@@ -39,16 +39,6 @@ $dropdown-height: 40px;
 axa-dropdown {
   display: block;
 
-  &[usecase="datepicker"] {
-    .m-dropdown__select {
-      min-width: auto;
-      padding-right: 32px;
-    }
-    .m-dropdown__button {
-      padding-right: 32px;
-    }
-  }
-
   .m-dropdown__label {
     @include typo(primary, medium);
     display: block;
@@ -96,7 +86,6 @@ axa-dropdown {
   .m-dropdown__select {
     @include normalize-native-select-styles();
     @include typo(primary, small);
-    min-width: 100px;
     width: 100%;
     color: $dropdown-color;
     padding: 0 40px 0 20px;
@@ -180,7 +169,7 @@ axa-dropdown {
 
   .m-dropdown__option,
   .m-dropdown__button {
-    padding: 10px 40px 10px 10px;
+    padding: 10px;
     box-sizing: border-box;
     width: 100%;
     line-height: 20px;


### PR DESCRIPTION
Fixes #1720

This is discussed with the designers and ok for them.

@markus-walther I didn't understand, why there is a min-width on the dropdown. If there is a reason for that, which I guess there is, since I remember that there has been a discussion on the topic once, we could re-evaluate it. But your approval will be required before this PR gets live.

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
- [ ] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
