### PR TITLE
Change React-wrapper for Boolean props and fix checkbox as a result

### DIFF
--- a/src/components/10-atoms/checkbox/react/DemoCheckboxCallbackProps.jsx
+++ b/src/components/10-atoms/checkbox/react/DemoCheckboxCallbackProps.jsx
@@ -2,12 +2,19 @@ import React, { useState } from 'react';
 import AXACheckbox from './AXACheckboxReact';
 
 const DemoCheckboxCallbackProps = () => {
+  const [frozen, setFrozen] = useState(false);
   const [checked, setChecked] = useState(false);
   const [focus, setFocus] = useState(false);
   const [blur, setBlur] = useState(false);
 
+  const handleFreeze = e => {
+    setFrozen(!frozen);
+  };
+
   const handleCheckboxChange = () => {
-    setChecked(!checked);
+    if (!frozen) {
+      setChecked(!checked);
+    }
   };
 
   const handleCheckboxBlur = () => {
@@ -20,7 +27,10 @@ const DemoCheckboxCallbackProps = () => {
 
   return (
     <fieldset>
-      <legend>Checkbox Callback Props</legend>
+      <legend>
+        Checkbox Callback Props: frozen
+        <input type="checkbox" data-test-id="frozen" onChange={handleFreeze} />
+      </legend>
       <AXACheckbox
         label="I'm a checkbox that is controlled"
         checked={checked}

--- a/src/components/10-atoms/checkbox/ui.test.js
+++ b/src/components/10-atoms/checkbox/ui.test.js
@@ -86,14 +86,8 @@ test('should style checked error checkbox-icon inner box correctly', async t => 
   await t
     .wait(50)
     .expect(await getIconBackgroundColor())
-    .eql('rgb(0, 0, 143)'); // has to be blue when seleted, due to styleguide specification
+    .eql('rgb(0, 0, 143)'); // has to be blue when selected, due to styleguide specification
 });
-
-// test('should be clickable + change state', async t => {
-//   const $axaCheckbox = await Selector(TAG);
-//   await t.click($axaCheckbox);
-//   await t.expect($axaCheckbox.checked).ok();
-// });
 
 test('should set refId on label and input', async t => {
   const label = await Selector('.a-checkbox__wrapper');
@@ -277,4 +271,32 @@ test('should update checkbox when its children change', async t => {
   await t.click(buttonToRerenderCheckboxChildren);
   await t.expect(checkboxChildLabel.innerHTML).contains('Rerenders: 1');
   await t.expect(checkboxPropLabel.textContent).contains('Rerenders: 1');
+});
+
+fixture('Checkbox - controlled behaviour under React').page(
+  `${host}/iframe.html?id=components-atoms-checkbox-react-demo--checkbox-default-with-label`
+);
+
+test('should shows correct controlled behavior', async t => {
+  const frozenControl = await Selector('input[data-test-id="frozen"]');
+  const checkbox = await Selector('axa-checkbox');
+  const checkboxClickable = await Selector('axa-checkbox > label');
+  // clicking on checkbox changes checked state:
+  await t.expect(checkbox.exists).ok();
+  // from false before...
+  await t.expect(checkbox.checked).notOk();
+  // ... to true after click
+  await t.click(checkboxClickable);
+  await t.expect(checkbox.checked).ok();
+  // ... and back
+  await t.click(checkboxClickable);
+  await t.wait(50);
+  await t.expect(checkbox.checked).notOk();
+  // after freezing the last controlled state...
+  await t.click(frozenControl);
+  await t.wait(50);
+  // ... a click on the checkbox no longer changes state
+  await t.click(checkboxClickable);
+  await t.wait(50);
+  await t.expect(checkbox.checked).notOk();
 });

--- a/src/utils/with-react.js
+++ b/src/utils/with-react.js
@@ -109,7 +109,7 @@ const distributeProperties = (properties, componentClass) => {
   let map;
   // iterate over all properties
   Object.keys(properties).forEach(name => {
-    let value = properties[name];
+    const value = properties[name];
     // classify property by type to select correct map object
     // (note that unregistered properties are classified as attr(ibute)s via their undefined .type)
     let type;
@@ -132,11 +132,8 @@ const distributeProperties = (properties, componentClass) => {
       case Array:
       case Object:
       case Function:
-        map = props;
-        break;
       case Boolean:
-        map = attrs;
-        value = value ? '' : null; // ''/null: canonicalize Boolean values s.t. val(...) sets or removes the attribute
+        map = props;
         break;
       default:
         map = declaredType ? props : attrs;


### PR DESCRIPTION
Fixes #1761.
fixes #1772 

This needs thorough thinking and reviewing, since it changes the behaviour for **all** Boolean properties under React.