### PR TITLE
make footer link less vulnerable to external hover stylings

### DIFF
--- a/src/components/30-organisms/footer/child.scss
+++ b/src/components/30-organisms/footer/child.scss
@@ -55,6 +55,7 @@ axa-footer {
 
     &:hover {
       color: rgba($color-prim-white, 0.65);
+      text-decoration: none; // Needed because this style is easily overwritten for a:hover declarations
     }
   }
 }


### PR DESCRIPTION
Any `a:hover` would overwrite the text-decoration of footer before. This PR changes that. That was a problem on axa.ch.