### PR TITLE
make year dropdown a bit bigger

### DIFF
--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.7
+
+- The year drop down enlarged by 5px. (AEM-5445)
+
 ## 7.0.5
 
 - Fix wrong date formatting for locale `it-CH` (#1740)

--- a/src/components/20-molecules/datepicker/index.scss
+++ b/src/components/20-molecules/datepicker/index.scss
@@ -175,7 +175,7 @@ axa-datepicker {
   }
 
   &__dropdown-year {
-    width: 90px;
+    width: 95px; // width: 90px is too less for iPhone on axa.ch-AEM
     text-transform: uppercase;
   }
 


### PR DESCRIPTION

Fixes an issue at axa.ch core migration bug-board. (AEM-5445)

# Done is when (DoD):
- [ ] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [ ] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
