### PR TITLE
Fix dynamic child-text updating for submit/reset-type buttons

### DIFF
--- a/src/components/10-atoms/button/CHANGELOG.md
+++ b/src/components/10-atoms/button/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.2
+
+- Dynamic button-text updates for submit/reset-type buttons no longer break form submittability. (#1815)
+
 ## 5.0.0
 
 - Upgrade to versioned component.

--- a/src/components/10-atoms/button/react/DemoButtonForm.jsx
+++ b/src/components/10-atoms/button/react/DemoButtonForm.jsx
@@ -1,7 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import AXAButton from './AXAButton';
 
 const DemoButtonForm = () => {
+  const [buttonText, setButtonText] = useState(`0 times clicked`);
+
+  const handleSubmitAndChangeText = ev => {
+    ev.preventDefault();
+    const count = parseInt(buttonText, 10) || 0;
+    setButtonText(`${count + 1} times clicked`);
+  };
+
   const handleSubmit = ev => {
     ev.preventDefault();
   };
@@ -21,6 +29,16 @@ const DemoButtonForm = () => {
           for you for example you can validate me
         </p>
         <AXAButton type="submit">Click me I prevent submit</AXAButton>
+      </form>
+
+      <form onSubmit={handleSubmitAndChangeText}>
+        <p>
+          I&apos;m type submit Button in a form, on click I stop submit event
+          for you and change my child label text
+        </p>
+        <AXAButton type="submit" data-test-id="button-submit-text-change">
+          {buttonText}
+        </AXAButton>
       </form>
 
       <form>

--- a/src/components/10-atoms/button/ui.test.js
+++ b/src/components/10-atoms/button/ui.test.js
@@ -140,3 +140,27 @@ test('should submit only once', async t => {
   );
   await t.expect(await count()).eql('1');
 });
+
+fixture('Button - React form').page(
+  `${host}/iframe.html?id=components-atoms-button-react-demos--feature-button-in-a-form`
+);
+
+test('should submit before and after text child updates', async t => {
+  const $submitButton = await Selector(
+    '[data-test-id="button-submit-text-change"]'
+  );
+
+  await t.expect($submitButton.innerText).contains('0');
+
+  await t.click($submitButton());
+
+  await t.wait(50);
+
+  await t.expect($submitButton.innerText).contains('1');
+
+  await t.click($submitButton());
+
+  await t.wait(50);
+
+  await t.expect($submitButton.innerText).contains('2');
+});


### PR DESCRIPTION
Fixes #1815

This uses a variant of the approach in axa-text to detect child text changes with a MutationObserver, here 'repairing' the overwriting of children with new text by re-attaching the hidden fake submit button under the hood.

An alternative would have been to place the hidden fake submit button _outside_ the axa-button, i.e. as a sibling node. This was deemed too risky, however, because it rests on the goodwill of frameworks like React to tolerate direct DOM manipulation - it might or might not work under all circumstances and all framework versions.

# Done is when (DoD):
- [ x] Modifications within components are reflected by tests.
- [ x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
