### PR TITLE
Add parent tagname to be able to select the versionnumber even at dis…

### DIFF
--- a/src/components/30-organisms/footer/index.js
+++ b/src/components/30-organisms/footer/index.js
@@ -61,7 +61,7 @@ class AXAFooter extends InlineStyles {
     this.slotsNotPrepared = true;
 
     /* eslint-disable no-undef */
-    defineVersioned([AXAContainer], __VERSION_INFO__);
+    defineVersioned([AXAContainer], __VERSION_INFO__, this.tagName);
     /* eslint-enable no-undef */
   }
 

--- a/src/utils/component-versioning.js
+++ b/src/utils/component-versioning.js
@@ -58,7 +58,10 @@ const defineVersioned = (dependencies, versionInfo, parentElementName) => {
     const { tagName } = componentClass;
 
     // TODO: the versionInfo object is different on every different build (dist, storybook-dist, lib)
-    const externalVersion = versionInfo[tagName] || versionInfo[parentElementName][tagName] || 'truthy'; // any truthy value is working. on falsy we get an error on dist-js-usage.
+    const externalVersion =
+      versionInfo[tagName] ||
+      versionInfo[parentElementName][tagName] ||
+      'truthy'; // any truthy value is working. on falsy we get an error on dist-js-usage.
 
     // ordinary, non-POD versioning?
     if (!customVersion && externalVersion) {

--- a/src/utils/component-versioning.js
+++ b/src/utils/component-versioning.js
@@ -44,8 +44,9 @@ const rewrite = (someStrings, aTagName, aVersion) =>
 // examples: defineVersioned([AXADatepicker, AXADropdown, AXAButton], __ VERSION_INFO__);
 //           defineVersioned([AXADatepicker],  __ VERSION_INFO__);
 //           defineVersioned([AXADropdown],  __ VERSION_INFO__);
+//           defineVersioned([AXAContainer],  __ VERSION_INFO__, 'axa-footer');
 //           defineVersioned([AXACheckbox], 'rsv');
-const defineVersioned = (dependencies, versionInfo) => {
+const defineVersioned = (dependencies, versionInfo, parentElementName) => {
   // set up
   const customVersion = typeof versionInfo === 'string' && versionInfo;
   let versionedTagName = '';
@@ -55,7 +56,10 @@ const defineVersioned = (dependencies, versionInfo) => {
       dependency instanceof HTMLElement ? dependency.constructor : dependency;
     // extract each dependant component's version
     const { tagName } = componentClass;
-    const externalVersion = versionInfo[tagName];
+
+    // TODO: the versionInfo object is different on every different build (dist, storybook-dist, lib)
+    const externalVersion = versionInfo[tagName] || versionInfo[parentElementName][tagName] || 'truthy'; // any truthy value is working. on falsy we get an error on dist-js-usage.
+
     // ordinary, non-POD versioning?
     if (!customVersion && externalVersion) {
       // yes, first time versioning/registration of this component, but its class


### PR DESCRIPTION
…t build. (Caused by a different versionInfo object on lib/dist build)

Fixes #1832

# Done is when (DoD):
- [ ] Modifications within components are reflected by tests.
- [ ] A self-review of the code has been performed.
- [ ] The modified component properties have been added to the typescript typings.
- [ ] Potential design changes have been reviewed by a designer.
- [ ] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [ ] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [ ] The modifications are shortly added to CHANGELOG.md with the issue number.
- [ ] The modifications still work in IE.
- [ ] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
