### PR TITLE
axa-dropdown: rename onchange event object item "name" to "optionLabel" 

### DIFF
--- a/src/components/20-molecules/dropdown/CHANGELOG.md
+++ b/src/components/20-molecules/dropdown/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 8.4.1
+## 9.0.0
+
+- Breaking change 1: onChange/change event gives 'name' field new semantics, adds 'optionLabel' for old, cf. README. (#1910)
+- Breaking change 2: 'disabled' is no longer supported in dropdown items; use 'defaultTitle' instead, cf. README. (#1923)
+- to match native select, a closed but focussed dropdown can now be opened via up/down arrow keys. (#1923)
+
+## 8.3.2
 
 - Fix: prevent duplicate style attachment. (#1727)
 
-## 8.4.0
+## 8.3.1
 
 - New styled icon for the arrow of the dropdown. #1882
 

--- a/src/components/20-molecules/dropdown/README.md
+++ b/src/components/20-molecules/dropdown/README.md
@@ -35,16 +35,11 @@ export default AXADropdownReact;
 ```js
 <AXADropdownReact
   items={[
-    {
-      name: 'Please Select',
-      value: 'Please Select',
-      selected: true,
-      disabled: true,
-    },
     { name: 'Item 1', value: 'Item 1' },
     { name: 'Item 2', value: 'Item 2' },
     { name: 'Item 3', value: 'Item 3' },
   ]}
+  defaultTitle="Please Select"
   onChange={event => console.log(`value changed ${event.target.value}`)}
 />
 ```
@@ -59,8 +54,6 @@ The String-valued attribute `defaultTitle` sets the initial title of the closed 
 
 Its intended use is primarily for native-HTML situations where server-generated `items` describe the choices proper,
 and a separate title like `defaulttitle="Please select"` prompts the user to make a choice.
-
-See the above React example for an alternative parametrization strategy that relies on using `items` only.
 
 ### value
 
@@ -109,7 +102,6 @@ Is an array of objects to set the options of the dropdown. The objects must have
 | name     | The text that is displayed                                       |
 | value    | The value that is submitted via form submit                      |
 | selected | boolean: just set true to one of the options to preselect option |
-| disabled | boolean: disables the option                                     |
 
 ## Callback Properties
 

--- a/src/components/20-molecules/dropdown/README.md
+++ b/src/components/20-molecules/dropdown/README.md
@@ -1,5 +1,7 @@
 # AXA Dropdown
 
+This component represents a styled, enhanced replacement for native HTML &lt;select&gt;. The component is responsive, falling back to native look-and-feel under mobile viewports. Keyboard operation is supported.
+
 ## Usage
 
 **Important:** If this component needs to run in Internet Explorer 11, [you need to use our polyfill](https://github.com/axa-ch/patterns-library/tree/develop/src/components/05-utils/polyfill).
@@ -51,9 +53,9 @@ export default AXADropdownReact;
 
 ## Properties
 
-### defaulttitle
+### defaultTitle
 
-The String-valued attribute `defaulttitle` sets the initial title of the closed dropdown (default: first selected item).
+The String-valued attribute `defaultTitle` sets the initial title of the closed dropdown (default: first selected item).
 
 Its intended use is primarily for native-HTML situations where server-generated `items` describe the choices proper,
 and a separate title like `defaulttitle="Please select"` prompts the user to make a choice.
@@ -114,16 +116,16 @@ Is an array of objects to set the options of the dropdown. The objects must have
 ### onChange
 
 The function-valued attribute `onChange` can be used as a callback prop for React and other frameworks. The callback is invoked whenever
-the selected dropdown option changes. Its only parameter is an event-like object with `{target:{value,name,optionLabel,optionIndex}` structure.
+the selected dropdown option changes. Its only parameter is an event-like object with `{target:{value,name,optionLabel,index}` structure.
 
 | target      | Details                                             |
 | ----------- | --------------------------------------------------- |
 | value       | The currently selected value                        |
 | name        | The name of the element you set via property `name` |
 | optionLabel | Visible text corresponding to `value`               |
-| optionIndex | 0-based index of currently selected option          |
+| index       | 0-based index of currently selected option          |
 
-If a defaulttitle is set, the first element has index 1, because the title gets index 0.
+If a defaultTitle is set, the first element has index 1, because the title gets index 0.
 
 _Important_: This attribute can also be used natively. However, in this case the event parameter passed conforms to the **change** event described below.
 

--- a/src/components/20-molecules/dropdown/README.md
+++ b/src/components/20-molecules/dropdown/README.md
@@ -98,13 +98,32 @@ If you do not set this attribute, all the options will be displayed without any 
 
 This property is most useful in space-constrained scenarios or with many options, e.g. in a country selector.
 
+### items
+
+Is an array of objects to set the options of the dropdown. The objects must have a `name` and `value` set. See an example at the top of this Readme.
+
+| item     | Details                                                          |
+| -------- | ---------------------------------------------------------------- |
+| name     | The text that is displayed                                       |
+| value    | The value that is submitted via form submit                      |
+| selected | boolean: just set true to one of the options to preselect option |
+| disabled | boolean: disables the option                                     |
+
 ## Callback Properties
 
 ### onChange
 
 The function-valued attribute `onChange` can be used as a callback prop for React and other frameworks. The callback is invoked whenever
-the selected dropdown option changes. Its only parameter is an event-like object with `{target:{value,index,name}` structure, where `value` is
-the currently selected value, `index` is its 0-based index and `name` is the visible text corresponding to `value`. If a defaulttitle is set, the first element has index 1, because the title receives index 0 internally.
+the selected dropdown option changes. Its only parameter is an event-like object with `{target:{value,name,optionLabel,optionIndex}` structure.
+
+| target      | Details                                             |
+| ----------- | --------------------------------------------------- |
+| value       | The currently selected value                        |
+| name        | The name of the element you set via property `name` |
+| optionLabel | Visible text corresponding to `value`               |
+| optionIndex | 0-based index of currently selected option          |
+
+If a defaulttitle is set, the first element has index 1, because the title gets index 0.
 
 _Important_: This attribute can also be used natively. However, in this case the event parameter passed conforms to the **change** event described below.
 
@@ -120,6 +139,6 @@ If not in controlled-component mode, two custom events `axa-change` and `change`
 
 `axa-change`'s event `detail` is the currently selected value (a string).
 
-`change`'s event `detail` is an object `{value,index,name}`,where `value` is the currently selected value, `index` is its 0-based index and `name` is the visible text corresponding to `value`.
+`change`'s event `detail` is an object that is described above at `onChange`.
 
 Both events do _not_ bubble up through the DOM.

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -212,7 +212,10 @@ class AXADropdown extends NoShadowDOM {
     const defaultTitleOffset = defaultTitle ? 1 : 0;
 
     // don't get involved if preexisting focus outside enhanced-mode DOM
-    if (!/(?:BUTTON|LI)/.test(activeElement.tagName)) {
+    if (
+      !this.contains(activeElement) ||
+      !/(?:BUTTON|LI)/.test(activeElement.tagName)
+    ) {
       return;
     }
 

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -45,7 +45,7 @@ const forEach = (array, callback, scope) => {
   }
 };
 
-const nativeItemsMapper = ({ name, value, selected, disabled }, index) =>
+const nativeItemsMapper = ({ label, value, selected, disabled }, index) =>
   html`
     <option
       class="m-dropdown__option"
@@ -54,12 +54,12 @@ const nativeItemsMapper = ({ name, value, selected, disabled }, index) =>
       data-value="${value}"
       ?selected="${selected}"
       ?disabled="${disabled}"
-      >${name}</option
+      >${label}</option
     >
   `;
 
 const contentItemsMapper = (clickHandler, keyUpHandler, defaultTitle) => (
-  { name, value, selected, disabled },
+  { label, value, selected, disabled },
   index
 ) => {
   const classes = {
@@ -79,7 +79,7 @@ const contentItemsMapper = (clickHandler, keyUpHandler, defaultTitle) => (
             data-index="${index + (defaultTitle ? 1 : 0)}"
             data-value="${value}"
           >
-            ${name}
+            ${label}
           </button>
         </li>
       `;
@@ -87,7 +87,7 @@ const contentItemsMapper = (clickHandler, keyUpHandler, defaultTitle) => (
 
 const defaultTitleIfNeeded = (title, anotherSelection) =>
   title
-    ? [{ name: title, disabled: true, selected: !anotherSelection, value: '' }]
+    ? [{ label: title, disabled: true, selected: !anotherSelection, value: '' }]
     : [];
 
 // CE
@@ -255,7 +255,7 @@ class AXADropdown extends NoShadowDOM {
         : target;
 
     const { value, index } = realTarget.dataset;
-    const { onChange, selectedIndex } = this;
+    const { onChange, selectedIndex, name } = this;
 
     this.openDropdown(false);
 
@@ -271,15 +271,20 @@ class AXADropdown extends NoShadowDOM {
     }
 
     this.selectedIndex = integerIndex;
-    const [{ name }] = this.findByValue(value);
+    const [{ label }] = this.findByValue(value);
     // allow idiomatic event.target.value in onChange callback!
-    const syntheticEvent = { target: { value, index: integerIndex, name } };
+    const details = {
+      value,
+      name,
+      optionIndex: integerIndex,
+      optionLabel: label,
+    };
+    const syntheticEvent = { target: details };
     onChange(syntheticEvent);
     if (!this.isControlled) {
       // declare the following value update to be uncontrolled
       this.state.firstTime = false;
       this.value = value; // triggers re-render
-      const details = { value, index: integerIndex, name };
       fireCustomEvent('axa-change', value, this, { bubbles: false });
       fireCustomEvent('change', details, this, { bubbles: false });
     }
@@ -303,8 +308,8 @@ class AXADropdown extends NoShadowDOM {
     if (!item) {
       return;
     }
-    const { name } = item;
-    this.value = value || name || '';
+    const { label } = item;
+    this.value = value || label || '';
     // clone items array with updated selected property
     // (the fact that items are cloned ensures re-render!)
     this.items = this.items.map((_item, index) => {
@@ -352,7 +357,7 @@ class AXADropdown extends NoShadowDOM {
     } = this;
 
     const [selectedItem] = this.findByValue(null);
-    this.title = selectedItem ? selectedItem.name : defaultTitle;
+    this.title = selectedItem ? selectedItem.label : defaultTitle;
 
     return html`
       ${label &&

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -45,7 +45,7 @@ const forEach = (array, callback, scope) => {
   }
 };
 
-const nativeItemsMapper = ({ label, value, selected, disabled }, index) =>
+const nativeItemsMapper = ({ name, value, selected, disabled }, index) =>
   html`
     <option
       class="m-dropdown__option"
@@ -54,12 +54,12 @@ const nativeItemsMapper = ({ label, value, selected, disabled }, index) =>
       data-value="${value}"
       ?selected="${selected}"
       ?disabled="${disabled}"
-      >${label}</option
+      >${name}</option
     >
   `;
 
 const contentItemsMapper = (clickHandler, keyUpHandler, defaultTitle) => (
-  { label, value, selected, disabled },
+  { name, value, selected, disabled },
   index
 ) => {
   const classes = {
@@ -79,7 +79,7 @@ const contentItemsMapper = (clickHandler, keyUpHandler, defaultTitle) => (
             data-index="${index + (defaultTitle ? 1 : 0)}"
             data-value="${value}"
           >
-            ${label}
+            ${name}
           </button>
         </li>
       `;
@@ -87,7 +87,7 @@ const contentItemsMapper = (clickHandler, keyUpHandler, defaultTitle) => (
 
 const defaultTitleIfNeeded = (title, anotherSelection) =>
   title
-    ? [{ label: title, disabled: true, selected: !anotherSelection, value: '' }]
+    ? [{ name: title, disabled: true, selected: !anotherSelection, value: '' }]
     : [];
 
 // CE
@@ -271,13 +271,13 @@ class AXADropdown extends NoShadowDOM {
     }
 
     this.selectedIndex = integerIndex;
-    const [{ label }] = this.findByValue(value);
+    const [{ name: optionLabel }] = this.findByValue(value);
     // allow idiomatic event.target.value in onChange callback!
     const details = {
       value,
       name,
+      optionLabel,
       optionIndex: integerIndex,
-      optionLabel: label,
     };
     const syntheticEvent = { target: details };
     onChange(syntheticEvent);
@@ -308,8 +308,8 @@ class AXADropdown extends NoShadowDOM {
     if (!item) {
       return;
     }
-    const { label } = item;
-    this.value = value || label || '';
+    const { name } = item;
+    this.value = value || name || '';
     // clone items array with updated selected property
     // (the fact that items are cloned ensures re-render!)
     this.items = this.items.map((_item, index) => {
@@ -357,7 +357,7 @@ class AXADropdown extends NoShadowDOM {
     } = this;
 
     const [selectedItem] = this.findByValue(null);
-    this.title = selectedItem ? selectedItem.label : defaultTitle;
+    this.title = selectedItem ? selectedItem.name : defaultTitle;
 
     return html`
       ${label &&

--- a/src/components/20-molecules/dropdown/react/DemoDropdownReact.jsx
+++ b/src/components/20-molecules/dropdown/react/DemoDropdownReact.jsx
@@ -5,24 +5,18 @@ import findIndex from '../../../../utils/find-index';
 
 const DemoDropdown = () => {
   const items = [
-    {
-      name: 'Please Select',
-      value: 'Please Select',
-      selected: true,
-      disabled: true,
-    },
     { name: 'Item A', value: 'Item 1' },
     { name: 'Item B', value: 'Item 2' },
     { name: 'Item C', value: 'Item 3' },
   ];
 
-  const [value, setValue] = useState(items[0].value);
+  const [value, setValue] = useState('Please Select');
   const [frozen, setFrozen] = useState(false);
   const [error, setError] = useState('');
   const [native, setNative] = useState(false);
 
   const findName = val =>
-    items[findIndex(items, item => item.value === val)].name;
+    (items[findIndex(items, item => item.value === val)] || { name: '' }).name;
 
   const handleChange = event => {
     setValue(frozen ? value : event.target.value);
@@ -69,6 +63,7 @@ const DemoDropdown = () => {
         invalid={frozen}
         checkMark={!frozen}
         error={error}
+        defaultTitle="Please Select"
       />
       <br />
       <p>

--- a/src/components/20-molecules/dropdown/react/DemoDropdownVersionedReact.jsx
+++ b/src/components/20-molecules/dropdown/react/DemoDropdownVersionedReact.jsx
@@ -10,13 +10,9 @@ const DemoVersionedDropdown = () => {
     item2: 'item2',
     item3: 'item3',
     name: 'my-versioned-dropdown',
+    defaultTitle: 'Please Select',
   };
   const items = [
-    {
-      name: 'Please Select',
-      value: 'Please Select',
-      disabled: true,
-    },
     { name: props.item1, value: 'Item 1' },
     { name: props.item2, value: 'Item 2', selected: true },
     { name: props.item3, value: 'Item 3' },
@@ -25,7 +21,6 @@ const DemoVersionedDropdown = () => {
   return (
     <AXADropdownVersionedReact
       data-test-id="versioned-dropdown-react"
-      title="Please Select"
       items={items}
       label={props.label}
       defaultTitle={props.defaultTitle}

--- a/src/components/20-molecules/dropdown/react/DemoFocussableDropdownReact.jsx
+++ b/src/components/20-molecules/dropdown/react/DemoFocussableDropdownReact.jsx
@@ -6,11 +6,6 @@ const DemoFocussableDropdown = () => {
   let output;
 
   const items = [
-    {
-      name: 'Please Select',
-      value: 'Please Select',
-      disabled: true,
-    },
     { name: 'Item A', value: 'Item 1' },
     { name: 'Item B', value: 'Item 2', selected: true },
     { name: 'Item C', value: 'Item 3' },
@@ -25,7 +20,7 @@ const DemoFocussableDropdown = () => {
       />
       <AXADropdownReact
         data-test-id="focussable-dropdown-react"
-        title="Please Select"
+        defaultTitle="Please Select"
         items={items}
         onChange={value => {
           output.innerHTML += `${value.target.name},`;

--- a/src/components/20-molecules/dropdown/react/DemoUncontrolledDropdownReact.jsx
+++ b/src/components/20-molecules/dropdown/react/DemoUncontrolledDropdownReact.jsx
@@ -4,11 +4,6 @@ import AXADropdownReact from './AXADropdownReact';
 
 const DemoUncontrolledDropdown = props => {
   const items = [
-    {
-      name: 'Please Select',
-      value: 'Please Select',
-      disabled: true,
-    },
     { name: props.item1, value: 'Item 1' },
     { name: props.item2, value: 'Item 2', selected: true },
     { name: props.item3, value: 'Item 3' },
@@ -17,7 +12,6 @@ const DemoUncontrolledDropdown = props => {
   return (
     <AXADropdownReact
       data-test-id="uncontrolled-dropdown-react"
-      title="Please Select"
       items={items}
       label={props.label}
       defaultTitle={props.defaultTitle}

--- a/src/components/20-molecules/dropdown/react/story.jsx
+++ b/src/components/20-molecules/dropdown/react/story.jsx
@@ -24,7 +24,7 @@ storiesOf('Examples/Dropdown/React', module)
 
     const label = text('label', '');
     const value = text('value', '');
-    const defaultTitle = text('defaulttitle', '');
+    const defaultTitle = text('defaulttitle', 'Please Select');
     const name = text('name', '');
     const invalid = boolean('invalid', false);
     const error = text('error', 'Error Message');

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -47,7 +47,7 @@ storyDropdown.add('Dropdown', () => {
       ?native="${native}"
       items='[
         {"name": "< CHF 1,000", "value": "Item 1" },
-        {"name": "From CHF 1,000 to 10,0000", "value": "Item 2", "disabled": "true" },
+        {"name": "From CHF 1,000 to 10,0000", "value": "Item 2" },
         {"name": "> CHF 10,000", "value": "Item 3" }
      ]'
     ></axa-dropdown>

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -29,10 +29,15 @@ storyDropdown.add('Dropdown', () => {
   const dataTestId = text('data-test-id', '');
   const maxHeight = text('max-height', '');
 
+  const handleChange = e => {
+    const { target, detail } = e;
+    target.dataset.change = JSON.stringify(detail);
+  };
+
   const wrapper = document.createElement('div');
   const template = html`
     <axa-dropdown
-      onchange="console.log('onchange triggered: ', event.detail)"
+      @change="${handleChange}"
       defaulttitle="${defaultTitle}"
       value="${value}"
       label="${label}"

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -46,9 +46,9 @@ storyDropdown.add('Dropdown', () => {
       ?required="${required}"
       ?native="${native}"
       items='[
-        {"label": "< CHF 1,000", "value": "Item 1" },
-        {"label": "From CHF 1,000 to 10,0000", "value": "Item 2" },
-        {"label": "> CHF 10,000", "value": "Item 3" }
+        {"name": "< CHF 1,000", "value": "Item 1" },
+        {"name": "From CHF 1,000 to 10,0000", "value": "Item 2", "disabled": "true" },
+        {"name": "> CHF 10,000", "value": "Item 3" }
      ]'
     ></axa-dropdown>
   `;

--- a/src/components/20-molecules/dropdown/story.js
+++ b/src/components/20-molecules/dropdown/story.js
@@ -46,9 +46,9 @@ storyDropdown.add('Dropdown', () => {
       ?required="${required}"
       ?native="${native}"
       items='[
-        {"name": "< CHF 1,000", "value": "Item 1" },
-        {"name": "From CHF 1,000 to 10,0000", "value": "Item 2" },
-        {"name": "> CHF 10,000", "value": "Item 3" }
+        {"label": "< CHF 1,000", "value": "Item 1" },
+        {"label": "From CHF 1,000 to 10,0000", "value": "Item 2" },
+        {"label": "> CHF 10,000", "value": "Item 3" }
      ]'
     ></axa-dropdown>
   `;

--- a/src/components/20-molecules/dropdown/ui.test.js
+++ b/src/components/20-molecules/dropdown/ui.test.js
@@ -117,6 +117,46 @@ test('should select previous element with key if a element has focus', async t =
     .ok();
 });
 
+fixture('Dropdown named').page(
+  `${host}//iframe.html?id=components--dropdown&knob-defaulttitle=Select%20amount&knob-name=my-insurance`
+);
+
+test('should select entry and fire change event correctly', async t => {
+  const dropdown = Selector('axa-dropdown');
+
+  await t
+    .click(dropdown)
+    .pressKey('down')
+    .pressKey('down')
+    .pressKey('enter')
+    .expect(dropdown.getAttribute('data-change'))
+    .contains('"optionLabel":"From CHF 1,000 to 10,0000"');
+
+  await t
+    .expect(dropdown.getAttribute('data-change'))
+    .contains('"name":"my-insurance"');
+});
+
+test('should open via arrow keys alone', async t => {
+  const body = Selector('body');
+  const dropdown = Selector('axa-dropdown');
+
+  // focus dropdown
+  await t.click(body).pressKey('tab');
+
+  // open dropdown
+  await t.pressKey('up');
+
+  // binary attribute 'open' exists
+  await t.expect(dropdown.getAttribute('open')).eql('');
+
+  // select first entry
+  await t
+    .pressKey('enter')
+    .expect(dropdown.getAttribute('data-change'))
+    .contains('"optionLabel":"< CHF 1,000"');
+});
+
 fixture('Dropdown disabled').page(
   `${host}/iframe.html?id=components--dropdown&knob-label=&knob-value=&knob-defaulttitle=Please%20Select&knob-name=&knob-error=Error%20Message&knob-disabled=true&knob-data-test-id=&knob-max-height=`
 );


### PR DESCRIPTION
Fixes #1910.
Fixed #1923.

The idea is to merge this PR first, then adapt https://github.com/axa-ch/patterns-library/pull/1920 slightly to the improved keyboard navigation code introduced here, then merge the latter, too.

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
