### PR TITLE
Fix duplicate stylesheets

### DIFF
--- a/scripts/build/common.rollup.js
+++ b/scripts/build/common.rollup.js
@@ -22,7 +22,7 @@ module.exports.commonPlugins = [
     '__VERSION_INFO__': stringifiedVersionInfo
   }),
   sass({
-    insert: true,
+    insert: false, /* no automatic style insertion in <head>, style use under component control */
     include: '**/*.scss',
     options: {
       includePaths: [

--- a/src/components/10-atoms/button-link/CHANGELOG.md
+++ b/src/components/10-atoms/button-link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.4
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.2.3
 
 - Fix: Gap below the component. (#1878)

--- a/src/components/10-atoms/button/CHANGELOG.md
+++ b/src/components/10-atoms/button/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.4
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 5.2.3
 
 - Fix: Gap below the component. (#1878)

--- a/src/components/10-atoms/carousel/CHANGELOG.md
+++ b/src/components/10-atoms/carousel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.2.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/checkbox/CHANGELOG.md
+++ b/src/components/10-atoms/checkbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 5.1.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/fieldset/CHANGELOG.md
+++ b/src/components/10-atoms/fieldset/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.1.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/heading/CHANGELOG.md
+++ b/src/components/10-atoms/heading/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.1.0
 
 - Replaced old typography with new one. This changes have changed the components design. The font-weight is now 700. (#1796 and #1750)

--- a/src/components/10-atoms/icon/CHANGELOG.md
+++ b/src/components/10-atoms/icon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.4
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 5.0.3
 
 - Remove `plus` icon and replace it with `add` in Typescript typings.

--- a/src/components/10-atoms/input-file/CHANGELOG.md
+++ b/src/components/10-atoms/input-file/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.0.0
 
 - **BREAKING CHANGE**: You now have to use the property `text` to display text inside the component. (#1838)

--- a/src/components/10-atoms/input-text/CHANGELOG.md
+++ b/src/components/10-atoms/input-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.3.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/link/CHANGELOG.md
+++ b/src/components/10-atoms/link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.2.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/link/index.js
+++ b/src/components/10-atoms/link/index.js
@@ -11,10 +11,15 @@ import {
 import { applyDefaults } from '../../../utils/with-react';
 
 class AXALink extends LitElement {
-  static tagName = 'axa-link';
-  static styles = css`
-    ${unsafeCSS(linkCSS)}
-  `;
+  static get tagName() {
+    return 'axa-link';
+  }
+
+  static get styles() {
+    return css`
+      ${unsafeCSS(linkCSS)}
+    `;
+  }
 
   // N.B. onClick deliberately not declared here, since
   // its use inside render() is guarded appropriately

--- a/src/components/10-atoms/radio/CHANGELOG.md
+++ b/src/components/10-atoms/radio/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.1.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/text/CHANGELOG.md
+++ b/src/components/10-atoms/text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.3.0
 
 - Add new variant `semibold` with a font-weight of 600. #1895

--- a/src/components/10-atoms/textarea/CHANGELOG.md
+++ b/src/components/10-atoms/textarea/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.1.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/10-atoms/toggle-switch/CHANGELOG.md
+++ b/src/components/10-atoms/toggle-switch/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 1.0.0
 
 - First release of component.

--- a/src/components/20-molecules/cookie-disclaimer/CHANGELOG.md
+++ b/src/components/20-molecules/cookie-disclaimer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.3
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.2.2
 
 - Fixed optical bug at storybook (#1860)

--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 10.1.0
 
 - New calendar icon. #1882

--- a/src/components/20-molecules/dropdown/CHANGELOG.md
+++ b/src/components/20-molecules/dropdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.4.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 8.4.0
 
 - New styled icon for the arrow of the dropdown. #1882

--- a/src/components/20-molecules/file-upload/CHANGELOG.md
+++ b/src/components/20-molecules/file-upload/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.3.0
 
 - New icons. #1882

--- a/src/components/20-molecules/footer-small/CHANGELOG.md
+++ b/src/components/20-molecules/footer-small/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 5.1.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/20-molecules/footer-small/index.js
+++ b/src/components/20-molecules/footer-small/index.js
@@ -88,6 +88,7 @@ class AXAFooterSmall extends InlineStyles {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     // remove installed observer
     this._observer.disconnect();
   }

--- a/src/components/20-molecules/policy-features/CHANGELOG.md
+++ b/src/components/20-molecules/policy-features/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.2.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/20-molecules/popup/CHANGELOG.md
+++ b/src/components/20-molecules/popup/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.2.0
 
 - Updated all the icons. #1882

--- a/src/components/20-molecules/top-content-bar/CHANGELOG.md
+++ b/src/components/20-molecules/top-content-bar/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.2.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)

--- a/src/components/30-organisms/commercial-hero-banner/CHANGELOG.md
+++ b/src/components/30-organisms/commercial-hero-banner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.0.1
 
 - Fix button width, that was broken due to button changes. #1862

--- a/src/components/30-organisms/container/CHANGELOG.md
+++ b/src/components/30-organisms/container/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.0.1
 
 - Remove unnecessary ts type for `variant`.

--- a/src/components/30-organisms/footer/CHANGELOG.md
+++ b/src/components/30-organisms/footer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.3
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 4.1.2
 
 - Only render accordion on mobile when content is given. #1836

--- a/src/components/30-organisms/table-sortable/CHANGELOG.md
+++ b/src/components/30-organisms/table-sortable/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.1.0
 
 - You can now import ts types for `model` and props.

--- a/src/components/30-organisms/table/CHANGELOG.md
+++ b/src/components/30-organisms/table/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.0.0
 
 - Upgrade to versioned component.

--- a/src/components/30-organisms/testimonials/CHANGELOG.md
+++ b/src/components/30-organisms/testimonials/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Fix: prevent duplicate style attachment. (#1727)
+
 ## 3.2.0
 
 - Replaced old typography with new one. This changes could have changed the components design. (#1796 and #1750)


### PR DESCRIPTION
Fixes #1727.

**Replaces stale PR https://github.com/axa-ch/patterns-library/pull/1736**
**Supersedes reviewed PR with git accidents https://github.com/axa-ch/patterns-library/pull/1892**

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)

Steps left for thorough review, _reduced_ requirements compared to now-stale PR:

- [x] Is there a .css file in the export?
- [x]  review sass-loader code for side effects other than head insertion
- [x] sample testing of 6 most used components: React, lib export
- [x] sample testing of 6 most used components:  native, dist export

Informal proof that the fix is correct: https://gist.github.com/markus-walther/c50ec05d645eaa4e6c7b71ced20c56cf