### PR TITLE
Fix axa-footer delayed-children problem

### DIFF
--- a/src/components/30-organisms/footer/CHANGELOG.md
+++ b/src/components/30-organisms/footer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.7
+
+- Fix: change rendering to requestAnimationFrame timing, s.t. browsers have more time to attach children to DOM. (#1890)
+
 ## 4.1.3
 
 - Fix: prevent duplicate style attachment. (#1727)


### PR DESCRIPTION
Fixes #1890.

Tested by simple HTML page consisting of **inline script** with dist export, followed by axa-footer with lots of children.
It is hypothesized that an inline script is going to be loaded **and** evaluated much faster than a network-loaded (i.e. `src`) script, which is why the subtle bug mentioned in #1890 deterministically occurs in this scenario, and only if the script is first in textual order.

The bigger task of making the entire footer children dynamically updateable has to wait for another day, as the convoluted implementation makes a simple modification towards supporting this scenario difficult to implement for now.

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
