### PR TITLE
Bugfix/exclude dropdown error span when no error defined

### DIFF
--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -430,7 +430,7 @@ class AXADropdown extends NoShadowDOM {
             `
           : ''}
       </div>
-      ${invalid
+      ${invalid && error
         ? html`
             <span class="m-dropdown__error js-dropdown__error">${error}</span>
           `

--- a/src/components/20-molecules/dropdown/react/DemoUncontrolledDropdownReact.jsx
+++ b/src/components/20-molecules/dropdown/react/DemoUncontrolledDropdownReact.jsx
@@ -15,22 +15,32 @@ const DemoUncontrolledDropdown = props => {
   ];
 
   return (
-    <AXADropdownReact
-      data-test-id="uncontrolled-dropdown-react"
-      title="Please Select"
-      items={items}
-      label={props.label}
-      defaultTitle={props.defaultTitle}
-      name={props.name}
-      invalid={props.invalid}
-      error={props.error}
-      native={props.native}
-      required={props.required}
-      checkMark={props.checkMark}
-      disabled={props.disabled}
-      // eslint-disable-next-line no-console
-      onChange={value => console.log(JSON.stringify(value))}
-    />
+    <div
+      style={{
+        height: 80,
+        display: 'flex',
+        alignItems: 'center',
+        border: '2px solid blue',
+        padding: '0 20px',
+      }}
+    >
+      <AXADropdownReact
+        data-test-id="uncontrolled-dropdown-react"
+        title="Please Select"
+        items={items}
+        label={props.label}
+        defaultTitle={props.defaultTitle}
+        name={props.name}
+        invalid={props.invalid}
+        error={props.error}
+        native={props.native}
+        required={props.required}
+        checkMark={props.checkMark}
+        disabled={props.disabled}
+        // eslint-disable-next-line no-console
+        onChange={value => console.log(JSON.stringify(value))}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
#fixes #1918 

Hi, nice work. Dropdowns seem to create error `<span>`s when `invalid` is set, even when no error message is defined. This prohibits nice vertical centering in a flexbox row layout, for instance. Is this intended? My guess is no. This PR offers a remedy. Please see `DemoUncontrolledDropdownReact.jsx` changes that demonstrate the issue. Set the `invalid` knob and watch the default error message appear. Now remove the error message in the corresponding knob and see the dropdown staying misaligned due to the superfluous `<span>`. Hope the fix finds you well, regards.