### PR TITLE
Make date formatting/parsing in axa-datepicker locale-independent

### DIFF
--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.0
+
+- breaking change: inputfield formatting is always dd.mm.yyyy irrespective of locale. (#1845)
+
 ## 11.0.0
 
 - The datepicker is now wider than before.

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -251,7 +251,7 @@ class AXADatepicker extends NoShadowDOM {
   }
 
   formatDate(date) {
-    return parseLocalisedDateIfValid(this.locale, date);
+    return parseLocalisedDateIfValid(date);
   }
 
   constructor() {
@@ -614,8 +614,8 @@ class AXADatepicker extends NoShadowDOM {
   }
 
   validate(value, pure) {
-    const { locale, invaliddatetext, allowedyears } = this;
-    const validDate = parseLocalisedDateIfValid(locale, value);
+    const { invaliddatetext, allowedyears } = this;
+    const validDate = parseLocalisedDateIfValid(value);
     const validYear = date => allowedyears.indexOf(date.getFullYear()) > -1;
     const isValid = validDate && validYear(validDate);
     if (pure) {

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -484,7 +484,7 @@ test('should have correct format at input field', async t => {
     () =>
       document.querySelector(`axa-datepicker[data-test-id="datepicker"]`).value
   );
-  await t.expect(await getInputValue()).eql('14/2/2019');
+  await t.expect(await getInputValue()).eql('14.2.2019');
 });
 
 // React smoke test

--- a/src/components/20-molecules/datepicker/utils/unit.test.js
+++ b/src/components/20-molecules/datepicker/utils/unit.test.js
@@ -1,65 +1,56 @@
 import { parseLocalisedDateIfValid, getAllLocaleMonthsArray } from './date';
 
+// note on date formats: we can new Date(datestring) - which internally uses Date.parse - despite caveats about browser-specific implementation differences by
+// explicitly constructing an unambiguous date string here,
+// cf. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Using_Date.parse()
+// One such safe date format is 'yyyy-mm-ddThh:mm'.
+
 describe('Datepicker utils', () => {
   describe('parseLocalisedDateIfValid', () => {
-    const inputDateObject = new Date('01.02.1999 12:30');
-    const inputDateString = '01/02/1999';
+    const inputDateObject = new Date('1999-02-01T12:30');
+    const inputDateString = '01.02.1999';
 
     it('should return formatted date', () => {
-      expect(parseLocalisedDateIfValid('en', inputDateObject)).toBe('1/2/1999');
+      expect(parseLocalisedDateIfValid(inputDateObject)).toBe('1.2.1999');
     });
     it('should return formatted date (if input date is a string)', () => {
-      expect(parseLocalisedDateIfValid('en', inputDateString)).toStrictEqual(
-        new Date('1/2/1999')
+      expect(parseLocalisedDateIfValid(inputDateString)).toStrictEqual(
+        new Date('1999-02-01T00:00')
       );
-    });
-
-    it('should return formatted date from default language if unsupported locale is given', () => {
-      expect(parseLocalisedDateIfValid('ff', inputDateObject)).toBe('1/2/1999');
-    });
-
-    it('should return formatted date if locale is undefined', () => {
-      expect(parseLocalisedDateIfValid(undefined, inputDateObject)).toBe(
-        '1/2/1999'
-      );
-    });
-
-    it('should return formatted date if locale is null', () => {
-      expect(parseLocalisedDateIfValid(null, inputDateObject)).toBe('1/2/1999');
     });
 
     it('should return formatted date if date is older than unix epoch', () => {
-      const inputDateObjectVeryOld = new Date('01.02.1900 12:30');
-      expect(parseLocalisedDateIfValid('en', inputDateObjectVeryOld)).toBe(
-        '1/2/1900'
+      const inputDateObjectVeryOld = new Date('1900-02-01T12:30');
+      expect(parseLocalisedDateIfValid(inputDateObjectVeryOld)).toBe(
+        '1.2.1900'
       );
     });
     it('should return formatted date if date is older than unix epoch (if input date is a string)', () => {
-      const inputDateStringVeryOld = '1/2/1900';
-      expect(
-        parseLocalisedDateIfValid('en', inputDateStringVeryOld)
-      ).toStrictEqual(new Date('1/2/1900'));
+      const inputDateStringVeryOld = '1.2.1900';
+      expect(parseLocalisedDateIfValid(inputDateStringVeryOld)).toStrictEqual(
+        new Date('1900-02-01T00:00')
+      );
     });
 
     it('should work far far in the future', () => {
-      const inputDateObjectVeryOld = new Date('01.02.9999 12:30');
-      expect(parseLocalisedDateIfValid('en', inputDateObjectVeryOld)).toBe(
-        '1/2/9999'
+      const inputDateObjectVeryOld = new Date('9999-02-01T12:30');
+      expect(parseLocalisedDateIfValid(inputDateObjectVeryOld)).toBe(
+        '1.2.9999'
       );
     });
     it('should work far far in the future (if input date is a string)', () => {
-      const inputDateStringVeryOld = '01/02/9999';
-      expect(
-        parseLocalisedDateIfValid('en', inputDateStringVeryOld)
-      ).toStrictEqual(new Date('01/02/9999'));
+      const inputDateStringVeryOld = '01.02.9999';
+      expect(parseLocalisedDateIfValid(inputDateStringVeryOld)).toStrictEqual(
+        new Date('9999-02-01T00:00')
+      );
     });
 
     it('should return null if date is not given', () => {
-      expect(parseLocalisedDateIfValid('en')).toBe(null);
+      expect(parseLocalisedDateIfValid()).toBe(null);
     });
 
     it('should return null if date is null', () => {
-      expect(parseLocalisedDateIfValid('en', null)).toBe(null);
+      expect(parseLocalisedDateIfValid(null)).toBe(null);
     });
   });
 


### PR DESCRIPTION
Fixes #1845.

# Done is when (DoD):
- [x] Modifications within components are reflected by tests.
- [x] A self-review of the code has been performed.
- [x] The modified component properties have been added to the typescript typings.
- [x] Potential design changes have been reviewed by a designer.
- [x] The modifications are well documented (README.md, etc.) and showcased in the stories.
- [x] The modifications are documented in the code, particularly in hard-to-understand areas (focus on **WHY**).
- [x] The modifications are shortly added to CHANGELOG.md with the issue number.
- [x] The modifications still work in IE.
- [x] The modifications are according to our [Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)
