### PR TITLE
 bugfix/1981_datepicker-positioning

### DIFF
--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.0.2
+
+- Fix: positioning of the datepicker (top/bottom). (#1998)
+
 ## 12.0.0
 
 - breaking change: inputfield formatting is always dd.mm.yyyy irrespective of locale. (#1845)

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -580,21 +580,10 @@ class AXADatepicker extends NoShadowDOM {
   }
 
   handleViewportCheck(baseElem) {
-    const calendar = this.querySelector('.js-datepicker__wrap');
-    if (!calendar) {
-      return;
-    }
-    const bodyRectangle = {
-      top: 0,
-      bottom: document.documentElement.scrollHeight,
-    };
-    const calendarRectangle = calendar.getBoundingClientRect();
-    const calendarBelowPage = calendarRectangle.bottom > bodyRectangle.bottom;
-    const calendarAbovePage = calendarRectangle.top < bodyRectangle.top;
-    const newInverted =
-      calendarBelowPage || (shouldMove(baseElem) && !calendarAbovePage);
-    if (newInverted !== this.inverted) {
-      this.inverted = newInverted;
+    if (shouldMove(baseElem)) {
+      this.inverted = true;
+    } else {
+      this.inverted = false;
     }
   }
 


### PR DESCRIPTION
Fixes #1981 

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [ ] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
