### PR TITLE
Change dd.mm.yyyy => d.m.yyyy dateformat in CHANGELOG.md

### DIFF
--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 12.0.0
 
-- breaking change: inputfield formatting is always dd.mm.yyyy irrespective of locale. (#1845)
+- breaking change: inputfield formatting is always d.m.yyyy irrespective of locale. (#1845)
 
 ## 11.0.0
 


### PR DESCRIPTION
Change documented date format from `dd.mm.yyyy` to `d.m.yyyy` in `CHANGELOG.md`

Because the used date format is indeed like `6.6.2019` and not like `06.06.2019`, so the current documentation could lead to false 
assumptions.

# Screenshot before change

![image](https://user-images.githubusercontent.com/43809369/98517940-fbbac380-226e-11eb-931a-2d03d221a66e.png)


# Merge Checklist
- [ ] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [ ] Tests are sufficient.
- [ ] Modifications still work in IE.
- [ ] Documentation is up to date.
- [ ] Changelog is up to date.
- [ ] Typescript typings for properties are up to date.
- [ ] Designers approved changes or no approval needed.
- [ ] Dependencies to other components still work.
