### PR TITLE
update materials readme with typescript example

### DIFF
--- a/src/components/00-materials/README.md
+++ b/src/components/00-materials/README.md
@@ -12,17 +12,25 @@ npm install @axa-ch/materials
 
 ```js
 import { svg } from 'lit-html';
-import { ArrowRightSvg } from '@axa-ch/materials/icons';
+import { Arrow_forwardSvg } from '@axa-ch/materials/icons';
 
-<span>${svg(ArrowRightSvg)}</span>;
+<span>${svg(Arrow_forwardSvg)}</span>;
 ```
 
 ### React
 
 ```js
-import ArrowRightSvg from '@axa-ch/materials/icons-raw/arrow-right.svg';
+import ArrowForwardSvg from '@axa-ch/materials/icons-raw/arrow-forward.svg';
 
-<ArrowRightSvg />;
+<ArrowForwardSvg />;
+```
+
+### React with Typescript
+
+```js
+import { ReactComponent as ArrowForwardSvg } from '@axa-ch/materials/icons-raw/arrow-forward.svg';
+
+<ArrowForwardSvg />;
 ```
 
 You need to use `SVGR` that takes external SVG files and transforms them into React components with Webpack. It is installed automatically if you use `create-pod-app`.


### PR DESCRIPTION
Fixes #2054

Typings are not needed, but with the import statement that is recommended by the [Create React Team](https://create-react-app.dev/docs/adding-images-fonts-and-files/#adding-svgs) and also seem to use the same methods we already suggest with SVGR.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
