### PR TITLE
axa-datepicker: enforce consistent date format on blur

### DIFF
--- a/jest.ui.config.js
+++ b/jest.ui.config.js
@@ -1,7 +1,15 @@
 module.exports = {
   preset: 'jest-playwright-preset',
+  testEnvironmentOptions: {
+    "jest-playwright": {
+      browsers: ["chromium"],
+      launchOptions: {
+        headless: true,
+      },
+    },
+  },
   testMatch: [
     '<rootDir>/src/**/pw.ui.test.{js,jsx,mjs}',
   ],
-  testTimeout: 15000
+  testTimeout: 30000
 };

--- a/scripts/ui-test-runner.sh
+++ b/scripts/ui-test-runner.sh
@@ -6,7 +6,7 @@ export $(egrep -v '^#' .env | xargs) > /dev/null 2>&1
 
 echo "Running Storybook on address '$TEST_HOST_STORYBOOK_URL' and on port '$TEST_HOST_STORYBOOK_PORT'"
 
-npx start-storybook -p $TEST_HOST_STORYBOOK_PORT -c .storybook -s ./src/static --ci --quiet > /dev/null 2>&1 &
+npx start-storybook -p $TEST_HOST_STORYBOOK_PORT -c .storybook -s ./src/static --ci  &
 npx wait-on $TEST_HOST_STORYBOOK_URL -t 60000
 
 ### Start playwright tests

--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 15.0.0
+
+- format date in inputfield mode with consistent two-digit day and month parts on blur. (#2083)
+
 ## 14.0.0
 
 - Remove `width` property. Instead set the inline-style. #1894.

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -607,7 +607,7 @@ class AXADatepicker extends NoShadowDOM {
       startDate,
       isControlled,
     } = this;
-    const { output, tentative, preset, handleBlur } = options;
+    const { output, tentative, preset, canonicalFormat } = options;
     this._date = overrideDate(_year, _month, _day, startDate);
     const { _date } = this;
     // did the start date get actually overridden via one or more of the
@@ -621,7 +621,7 @@ class AXADatepicker extends NoShadowDOM {
 
     if (output) {
       this.outputdate = this.formatDate(_date, {
-        formatted: handleBlur && !isControlled,
+        formatted: canonicalFormat && !isControlled,
       });
     }
 
@@ -686,7 +686,7 @@ class AXADatepicker extends NoShadowDOM {
     if (isValid) {
       this.initDate(validDate, {
         output: true,
-        handleBlur: options.handleBlur,
+        canonicalFormat: options.canonicalFormat,
       }); // sets this._date
     } else if (value && invaliddatetext) {
       this.error = invaliddatetext;
@@ -773,7 +773,7 @@ class AXADatepicker extends NoShadowDOM {
 
   handleBlur(e) {
     const { input, onBlur } = this;
-    this.validate(input.value, false, { handleBlur: true });
+    this.validate(input.value, false, { canonicalFormat: true });
     onBlur(e);
   }
 
@@ -795,7 +795,10 @@ class AXADatepicker extends NoShadowDOM {
     const cellIndex = parseInt(e.target.dataset.index, 10);
     const date = e.target.dataset.value;
     this.index = cellIndex;
-    const value = this.initDate(new Date(date), { output: true });
+    const value = this.initDate(new Date(date), {
+      output: true,
+      canonicalFormat: true,
+    });
     this.setMonthAndYearItems();
 
     const {

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -295,8 +295,8 @@ class AXADatepicker extends NoShadowDOM {
     }));
   }
 
-  formatDate(date) {
-    return parseLocalisedDateIfValid(date);
+  formatDate(date, options = {}) {
+    return parseLocalisedDateIfValid(date, options);
   }
 
   constructor() {
@@ -598,8 +598,16 @@ class AXADatepicker extends NoShadowDOM {
       this.year = newStartYear;
     }
 
-    const { _year, _month, _day, allowedyears, locale, startDate } = this;
-    const { output, tentative, preset } = options;
+    const {
+      _year,
+      _month,
+      _day,
+      allowedyears,
+      locale,
+      startDate,
+      isControlled,
+    } = this;
+    const { output, tentative, preset, handleBlur } = options;
     this._date = overrideDate(_year, _month, _day, startDate);
     const { _date } = this;
     // did the start date get actually overridden via one or more of the
@@ -612,7 +620,9 @@ class AXADatepicker extends NoShadowDOM {
     this.allowedyears = parseAndFormatAllowedYears(allowedyears, _year);
 
     if (output) {
-      this.outputdate = this.formatDate(_date);
+      this.outputdate = this.formatDate(_date, {
+        formatted: handleBlur && !isControlled,
+      });
     }
 
     const isUserOrApplicationSelected = !tentative && preset;
@@ -664,7 +674,7 @@ class AXADatepicker extends NoShadowDOM {
     }
   }
 
-  validate(value, pure) {
+  validate(value, pure, options = {}) {
     const { invaliddatetext, allowedyears } = this;
     const validDate = parseLocalisedDateIfValid(value);
     const validYear = date => allowedyears.indexOf(date.getFullYear()) > -1;
@@ -674,7 +684,10 @@ class AXADatepicker extends NoShadowDOM {
     }
     this.error = null;
     if (isValid) {
-      this.initDate(validDate, { output: true }); // sets this._date
+      this.initDate(validDate, {
+        output: true,
+        handleBlur: options.handleBlur,
+      }); // sets this._date
     } else if (value && invaliddatetext) {
       this.error = invaliddatetext;
       this._date = null;
@@ -760,7 +773,7 @@ class AXADatepicker extends NoShadowDOM {
 
   handleBlur(e) {
     const { input, onBlur } = this;
-    this.validate(input.value);
+    this.validate(input.value, false, { handleBlur: true });
     onBlur(e);
   }
 

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -859,7 +859,7 @@ test('should submit datepicker correctly in form', async t => {
             and then time for the DOM to stabilize */
     )
     .expect((await Selector('#datepicker-forms-content')).innerText)
-    .eql('date = 29.2.2020 (of 1 submittable elements)');
+    .eql('date = 29.02.2020 (of 1 submittable elements)');
 });
 test('should not submit form if click on arrow buttons', async t => {
   const datepickerForm = await Selector(() =>
@@ -880,7 +880,7 @@ test('should not submit form if click on arrow buttons', async t => {
             and then time for the DOM to stabilize */
     )
     .expect((await Selector('#datepicker-forms-content')).innerText)
-    .notEql('date = 29.2.2020 (of 1 submittable elements)');
+    .notEql('date = 29.02.2020 (of 1 submittable elements)');
 });
 
 fixture('Datepicker with onchange handler').page(

--- a/src/components/20-molecules/datepicker/ui.test.js
+++ b/src/components/20-molecules/datepicker/ui.test.js
@@ -1,6 +1,6 @@
 import { ClientFunction, Selector } from 'testcafe';
 import { DatePickerAccessor } from './test.accessor';
-import { range } from './utils/date';
+import { range, parseLocalisedDateIfValid } from './utils/date';
 
 /* eslint-disable */
 
@@ -423,7 +423,7 @@ test('should write date into input field for input calendars', async t => {
     () =>
       document.querySelector(`axa-datepicker[data-test-id="datepicker"]`).value
   );
-  await t.expect(await getInputValue()).eql('14.2.2019');
+  await t.expect(await getInputValue()).eql('14.02.2019');
 });
 
 test('should change enhanced dropdown title (only on large screens) on month change', async t => {
@@ -455,7 +455,7 @@ test('should have correct format at input field', async t => {
     () =>
       document.querySelector(`axa-datepicker[data-test-id="datepicker"]`).value
   );
-  await t.expect(await getInputValue()).eql('14.2.2019');
+  await t.expect(await getInputValue()).eql('14.02.2019');
 });
 
 fixture('Datepicker - Collapsible Version with it-IT locale').page(
@@ -476,7 +476,7 @@ test('should have correct format at input field', async t => {
     () =>
       document.querySelector(`axa-datepicker[data-test-id="datepicker"]`).value
   );
-  await t.expect(await getInputValue()).eql('14.2.2019');
+  await t.expect(await getInputValue()).eql('14.02.2019');
 });
 
 // React smoke test
@@ -677,7 +677,7 @@ test('should react to programmatic date property changes', async t => {
   await t
     .wait(50)
     .expect(await getInputValue())
-    .eql('27.4.2019');
+    .eql('27.04.2019');
 });
 
 fixture('Datepicker React empty inputfield').page(
@@ -715,8 +715,10 @@ test('should allow month change from default date', async t => {
   const preSelectedYear = allowedYears.includes(currentYear)
     ? currentYear
     : allowedYears[0]; // first entry of allowedyears (see README "year")
-  const currentDateString = `${DAY_TO_SELECT}.${currentMonth +
-    1}.${preSelectedYear}`;
+  const currentDateString = parseLocalisedDateIfValid(
+    new Date(`${preSelectedYear}-0${currentMonth + 1}-0${DAY_TO_SELECT}`),
+    { formatted: true }
+  );
 
   // verify committed date meets expectation
   await t
@@ -748,7 +750,7 @@ test('should allow month change from default date', async t => {
   await datePickerAccessor.selectDayOfCurrentMonth(26);
 
   // verify committed date meets expectation: correct month and year
-  const newDateString = `.${newMonth + 1}.${preSelectedYear}`;
+  const newDateString = `${newMonth + 1}.${preSelectedYear}`;
 
   // assert date input has the correct year and month
   await t

--- a/src/components/20-molecules/datepicker/unit.test.js
+++ b/src/components/20-molecules/datepicker/unit.test.js
@@ -43,12 +43,14 @@ describe('Datepicker unit tests', () => {
 
   describe('initDate()', () => {
     it('should return undefined', () => {
+      AXADatepicker.prototype.state = {};
       expect(AXADatepicker.prototype.initDate(new Date(), {})).toEqual(
         undefined
       );
     });
     it('should set class variables', () => {
       // init values
+      AXADatepicker.prototype.state = {};
       AXADatepicker.prototype._date = null;
       AXADatepicker.prototype.allowedyears = [1900];
       AXADatepicker.prototype.cells = null;
@@ -64,6 +66,7 @@ describe('Datepicker unit tests', () => {
     });
     it('should set class variables if output:true', () => {
       // init values
+      AXADatepicker.prototype.state = {};
       AXADatepicker.prototype.outputdate = null;
       AXADatepicker.prototype._selectedDate = null;
 
@@ -74,6 +77,7 @@ describe('Datepicker unit tests', () => {
     });
     it('should set class variables if tentative:false and preset:true', () => {
       // init values
+      AXADatepicker.prototype.state = {};
       AXADatepicker.prototype._selectedDate = null;
 
       AXADatepicker.prototype.initDate(new Date(), {

--- a/src/components/20-molecules/datepicker/utils/date.js
+++ b/src/components/20-molecules/datepicker/utils/date.js
@@ -79,7 +79,7 @@ const addLeadingZeroes = (rawNumber, numDigits) => {
   return `${leadingZeroesString}${number}`;
 };
 
-const parseLocalisedDateIfValid = (inputValue = '') => {
+const parseLocalisedDateIfValid = (inputValue = '', options = {}) => {
   // passing a Date object asks us to *generate* rather than parse a date format
   if (Object.prototype.toString.call(inputValue) === '[object Date]') {
     // decompose date into parts
@@ -87,7 +87,14 @@ const parseLocalisedDateIfValid = (inputValue = '') => {
     const month = inputValue.getMonth() + 1;
     const day = inputValue.getDate();
     // combine with appropriate separator to format date
-    return [day, month, year].join(DATE_SEPARATOR);
+    const dateParts = options.formatted
+      ? [
+          addLeadingZeroes(day, 2),
+          addLeadingZeroes(month, 2),
+          addLeadingZeroes(year, 4),
+        ]
+      : [day, month, year];
+    return dateParts.join(DATE_SEPARATOR);
   }
 
   // parsing proper: split date string into parts using appropriate separator

--- a/src/components/20-molecules/datepicker/utils/date.js
+++ b/src/components/20-molecules/datepicker/utils/date.js
@@ -88,11 +88,7 @@ const parseLocalisedDateIfValid = (inputValue = '', options = {}) => {
     const day = inputValue.getDate();
     // combine with appropriate separator to format date
     const dateParts = options.formatted
-      ? [
-          addLeadingZeroes(day, 2),
-          addLeadingZeroes(month, 2),
-          addLeadingZeroes(year, 4),
-        ]
+      ? [addLeadingZeroes(day, 2), addLeadingZeroes(month, 2), year]
       : [day, month, year];
     return dateParts.join(DATE_SEPARATOR);
   }


### PR DESCRIPTION
Fixes #2068.
Fixes #2084.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
