### PR TITLE
Use npm ci for our ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,11 +16,11 @@ steps:
   displayName: 'Install Node.js'
 
 - script: |
-    npm install
+    npm ci
   displayName: 'Install (with build included)'
 
 - script: |
-    npm test	
+    npm test
   displayName: 'Test'
 
 - script: |


### PR DESCRIPTION
Use `ci` also for our ci ;) 

Benefits:
- faster: before: 26m26s, after: 19m58s
- harder (must-usage of package.json etc.) for details see here: https://github.com/axa-ch/patterns-library/pull/2093#discussion_r572696026
- scooter! :-) https://www.youtube.com/watch?v=bybCPvY8rk8