### PR TITLE
feat(link): publish mouse event to onClick handler

### DIFF
--- a/src/components/10-atoms/link/CHANGELOG.md
+++ b/src/components/10-atoms/link/CHANGELOG.md
@@ -1,3 +1,8 @@
+## next
+
+- Publish mouse event to onClick handler. This allows the consumer to stopPropagation() of the event.
+  This may be a BREAKING CHANGE if consumer relies on onClick() being called with NO argument.
+
 ## 4.2.1
 
 - Fix: prevent duplicate style attachment. (#1727)

--- a/src/components/10-atoms/link/README.md
+++ b/src/components/10-atoms/link/README.md
@@ -56,3 +56,4 @@ If the variant is `icon`, using the attribute `icon`'s string value as icon name
 ### onClick
 
 On a React-ified component this function-valued attribute can be used as a callback function. Using it will prevent default link navigation.
+Click event object is passed as argument. This allows the consumer to stopPropagation() of the event.

--- a/src/components/10-atoms/link/index.js
+++ b/src/components/10-atoms/link/index.js
@@ -89,7 +89,7 @@ class AXALink extends LitElement {
         @click="${ev => {
           ev.preventDefault();
           if (typeof this.onClick === 'function') {
-            this.onClick();
+            this.onClick(ev);
           } else {
             window.open(this.href, this.external ? '_blank' : '_top');
           }

--- a/src/components/10-atoms/link/index.react.d.ts
+++ b/src/components/10-atoms/link/index.react.d.ts
@@ -31,7 +31,7 @@ export type SharedProps = {
   external?: boolean;
   className?: string;
   slot?: string;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 };
 
 /**


### PR DESCRIPTION
Publish mouse event to onClick handler.

This allows the consumer to stopPropagation of the event.

# Merge Checklist:
- [ ] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [ ] Tests are sufficient.
- [ ] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [ ] Designers approved changes or no approval needed.
- [ ] Dependencies to other components still work.
