### PR TITLE
fix nullpointer in dropdown, wenn item name absent

### DIFF
--- a/src/components/20-molecules/dropdown/CHANGELOG.md
+++ b/src/components/20-molecules/dropdown/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 9.1.0
 
+- Bugfix: Nullpointer in `item.name.toLowerCase()`.
+
+## 9.1.0
+
 - Minor change: now supports keyboard-operated auto-suggest-style selection of items. (#1247)
 
 ## 9.0.0

--- a/src/components/20-molecules/dropdown/CHANGELOG.md
+++ b/src/components/20-molecules/dropdown/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 9.1.0
+## 9.1.1
 
 - Bugfix: Nullpointer in `item.name.toLowerCase()`.
 

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -554,7 +554,7 @@ class AXADropdown extends NoShadowDOM {
 
     this._autosuggestDictionary =
       items
-        .filter(item => !item.disabled)
+        .filter(item => !item.disabled && item.name)
         .map((item, index) => {
           // normalize word for purposes of matching
           const word = item.name.toLowerCase();


### PR DESCRIPTION
Aem-Forms had a Nullpointer, because item.name was absent. This makes sure that autosuggestion is ignored if that is the case.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
