### PR TITLE
add types for axa text

### DIFF
--- a/src/components/10-atoms/text/index.react.d.ts
+++ b/src/components/10-atoms/text/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type Variant = 'size-2' | 'size-3' | 'size-4' | 'bold';
+export type Variant = 'size-2' | 'size-3' | 'size-4' | 'bold' | 'semibold';
 
 export interface AXATextProps {
   variant?: Variant;

--- a/src/components/10-atoms/text/story.js
+++ b/src/components/10-atoms/text/story.js
@@ -5,8 +5,7 @@ import './index';
 import readme from './README.md';
 
 const variantOptions = {
-  default: '',
-  'size-1': 'size-1',
+  '[none]': '',
   'size-2': 'size-2',
   'size-3': 'size-3',
   semibold: 'semibold',


### PR DESCRIPTION
Types for react were missing and inaccurate.