### PR TITLE
globalize __VERSION_INFO__ for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -75,7 +75,8 @@
     "DEV": true,
     "fixture": true,
     "test": true,
-    "page": true
+    "page": true,
+    "__VERSION_INFO__": true
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/scripts/create-a-m-o/functions.js
+++ b/scripts/create-a-m-o/functions.js
@@ -327,9 +327,7 @@ describe('${compTitle}', () => {
         this.onClick = () => {};
         // if you depend on *other* axa-XXX components and imported them above,
         // then you declare them as versioned here like this:
-        /* eslint-disable no-undef */
         // defineVersioned([myDependentComponent1, myDependentComponent2, ...], __VERSION_INFO__, this);
-        /* eslint-enable no-undef */
       }
 
       firstUpdated() {
@@ -356,7 +354,6 @@ describe('${compTitle}', () => {
       }
     }
 
-    /* eslint-disable no-undef */
     defineVersioned([${className}], __VERSION_INFO__);
 
     export default ${className};

--- a/src/components/00-materials/scripts/export-svg.js
+++ b/src/components/00-materials/scripts/export-svg.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /* eslint-disable import/no-extraneous-dependencies */
 const fs = require('fs');
 const path = require('path');

--- a/src/components/10-atoms/button-link/index.js
+++ b/src/components/10-atoms/button-link/index.js
@@ -49,9 +49,8 @@ class AXAButtonLink extends InlineStyles {
   constructor() {
     super();
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned([AXAIcon], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   get showIcon() {
@@ -123,7 +122,6 @@ class AXAButtonLink extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAButtonLink], __VERSION_INFO__);
 
 export default AXAButtonLink;

--- a/src/components/10-atoms/carousel/index.js
+++ b/src/components/10-atoms/carousel/index.js
@@ -285,7 +285,6 @@ class AXACarousel extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXACarousel], __VERSION_INFO__);
 
 export default AXACarousel;

--- a/src/components/10-atoms/checkbox/index.js
+++ b/src/components/10-atoms/checkbox/index.js
@@ -265,7 +265,6 @@ class AXACheckbox extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXACheckbox], __VERSION_INFO__);
 
 export default AXACheckbox;

--- a/src/components/10-atoms/fieldset/index.js
+++ b/src/components/10-atoms/fieldset/index.js
@@ -28,7 +28,6 @@ class AXAFieldset extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAFieldset], __VERSION_INFO__);
 
 export default AXAFieldset;

--- a/src/components/10-atoms/heading/index.js
+++ b/src/components/10-atoms/heading/index.js
@@ -60,7 +60,6 @@ class AXAHeading extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAHeading], __VERSION_INFO__);
 
 export default AXAHeading;

--- a/src/components/10-atoms/icon/index.js
+++ b/src/components/10-atoms/icon/index.js
@@ -86,7 +86,6 @@ class AXAIcon extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAIcon], __VERSION_INFO__);
 
 export default AXAIcon;

--- a/src/components/10-atoms/input-file/index.js
+++ b/src/components/10-atoms/input-file/index.js
@@ -45,9 +45,8 @@ class AXAInputFile extends NoShadowDOM {
     super();
 
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned([AXAIcon], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   render() {
@@ -95,7 +94,6 @@ class AXAInputFile extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAInputFile], __VERSION_INFO__);
 
 export default AXAInputFile;

--- a/src/components/10-atoms/input-text/demo.js
+++ b/src/components/10-atoms/input-text/demo.js
@@ -16,9 +16,9 @@ storiesOf('Examples/Input text/Pure HTML', module)
       ev.preventDefault();
       document.getElementById('form-data-details').open = true;
       const $inputDemoForm = document.getElementById('input-demo-form');
-      /* eslint-disable no-undef */
+      // eslint-disable-next-line
       const formData = new FormData($inputDemoForm);
-      /* eslint-disable no-restricted-syntax */
+      // eslint-disable-next-line no-restricted-syntax
       for (const pair of formData.entries()) {
         const container = document.createElement('span');
         container.textContent = `${pair[0]}: ${pair[1]}`;

--- a/src/components/10-atoms/input-text/index.js
+++ b/src/components/10-atoms/input-text/index.js
@@ -80,7 +80,6 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
     this.isPlaceholderInCounter = false;
     this.invalidFormat = false;
 
-    /* eslint-disable no-undef */
     const enrichedVersionInfo = __VERSION_INFO__; // This object is different at webpack and rollup build!
     const commonPopupVersion =
       enrichedVersionInfo['axa-input-text']['axa-popup'];
@@ -95,7 +94,6 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
       enrichedVersionInfo,
       this
     );
-    /* eslint-enable no-undef */
   }
 
   get charsLeft() {
@@ -472,7 +470,6 @@ class AXAInputText extends AXAPopupMixin(NoShadowDOM) {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAInputText], __VERSION_INFO__);
 
 export default AXAInputText;

--- a/src/components/10-atoms/link/index.js
+++ b/src/components/10-atoms/link/index.js
@@ -35,9 +35,8 @@ class AXALink extends LitElement {
   constructor() {
     super();
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned([AXAIcon], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   render() {
@@ -117,7 +116,6 @@ class AXALink extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXALink], __VERSION_INFO__);
 
 export default AXALink;

--- a/src/components/10-atoms/radio/index.js
+++ b/src/components/10-atoms/radio/index.js
@@ -284,7 +284,6 @@ class AXARadio extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXARadio], __VERSION_INFO__);
 
 export default AXARadio;

--- a/src/components/10-atoms/text/index.js
+++ b/src/components/10-atoms/text/index.js
@@ -85,7 +85,6 @@ class AXAText extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAText], __VERSION_INFO__);
 
 export default AXAText;

--- a/src/components/10-atoms/textarea/index.js
+++ b/src/components/10-atoms/textarea/index.js
@@ -292,7 +292,6 @@ class AXATextarea extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXATextarea], __VERSION_INFO__);
 
 export default AXATextarea;

--- a/src/components/10-atoms/toggle-switch/index.js
+++ b/src/components/10-atoms/toggle-switch/index.js
@@ -91,6 +91,5 @@ class AXAToggleSwitch extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAToggleSwitch], __VERSION_INFO__);
 export default AXAToggleSwitch;

--- a/src/components/20-molecules/cookie-disclaimer/index.js
+++ b/src/components/20-molecules/cookie-disclaimer/index.js
@@ -36,9 +36,8 @@ class AXACookieDisclaimer extends LitElement {
   constructor() {
     super();
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned([AXAContainer, AXAButton], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   firstUpdated() {
@@ -110,7 +109,6 @@ class AXACookieDisclaimer extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXACookieDisclaimer], __VERSION_INFO__);
 
 export default AXACookieDisclaimer;

--- a/src/components/20-molecules/datepicker/index.js
+++ b/src/components/20-molecules/datepicker/index.js
@@ -313,9 +313,8 @@ class AXADatepicker extends NoShadowDOM {
     );
 
     // ensure we use the versioned variant of axa-dropdown internally
-    /* eslint-disable no-undef */
+
     defineVersioned([AXADropdown], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   // throttle re-rendering to once per frame (too many updates with default microtask timing before...)
@@ -877,7 +876,6 @@ class AXADatepicker extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXADatepicker], __VERSION_INFO__);
 
 export default AXADatepicker;

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -587,7 +587,6 @@ class AXADropdown extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXADropdown], __VERSION_INFO__);
 
 export default AXADropdown;

--- a/src/components/20-molecules/file-upload/index.js
+++ b/src/components/20-molecules/file-upload/index.js
@@ -107,7 +107,6 @@ class AXAFileUpload extends LitElement {
     this.globalErrorMessage = '';
     this.showAddMoreInputFile = '';
 
-    // eslint-disable-next-line no-undef
     defineVersioned([AXAInputFile], __VERSION_INFO__, this);
   }
 
@@ -609,7 +608,6 @@ class AXAFileUpload extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAFileUpload], __VERSION_INFO__);
 
 export default AXAFileUpload;

--- a/src/components/20-molecules/footer-small/index.js
+++ b/src/components/20-molecules/footer-small/index.js
@@ -37,9 +37,8 @@ class AXAFooterSmall extends InlineStyles {
   constructor() {
     super();
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned([AXAContainer], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   // Parent class InlineStyles needs a static method to retrieve styles.
@@ -152,7 +151,6 @@ class AXAFooterSmall extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAFooterSmall], __VERSION_INFO__);
 
 export default AXAFooterSmall;

--- a/src/components/20-molecules/policy-features/index.js
+++ b/src/components/20-molecules/policy-features/index.js
@@ -51,7 +51,6 @@ class AXAPolicyFeatures extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAPolicyFeatures], __VERSION_INFO__);
 
 export default AXAPolicyFeatures;

--- a/src/components/20-molecules/popup/index.js
+++ b/src/components/20-molecules/popup/index.js
@@ -4,9 +4,8 @@ import { defineVersioned } from '../../../utils/component-versioning';
 
 export * from './popup-mixin';
 
-/* eslint-disable no-undef */
 const axaPopupVersion = __VERSION_INFO__;
-/* eslint-enable no-undef */
+
 const commonVersion = axaPopupVersion['axa-popup']['axa-popup'];
 const axaPopupButtonVersion = {
   [AXAPopupButton.tagName]: { [AXAPopupButton.tagName]: commonVersion },

--- a/src/components/20-molecules/stepper/index.js
+++ b/src/components/20-molecules/stepper/index.js
@@ -86,6 +86,5 @@ class AXAStepper extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAStepper], __VERSION_INFO__);
 export default AXAStepper;

--- a/src/components/20-molecules/top-content-bar/index.js
+++ b/src/components/20-molecules/top-content-bar/index.js
@@ -45,13 +45,12 @@ class AXATopContentBar extends InlineStyles {
   constructor() {
     super();
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned(
       [AXAButton, AXAButtonLink, AXAContainer],
       __VERSION_INFO__,
       this
     );
-    /* eslint-enable no-undef */
   }
 
   firstUpdated() {
@@ -127,7 +126,6 @@ class AXATopContentBar extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXATopContentBar], __VERSION_INFO__);
 
 export default AXATopContentBar;

--- a/src/components/30-organisms/commercial-hero-banner/index.js
+++ b/src/components/30-organisms/commercial-hero-banner/index.js
@@ -33,9 +33,7 @@ class AXACommercialHeroBanner extends InlineStyles {
     super();
     applyDefaults(this);
 
-    /* eslint-disable no-undef */
     defineVersioned([AXAContainer], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   // Parent class InlineStyles needs a static method to retrive styles
@@ -92,7 +90,6 @@ class AXACommercialHeroBanner extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXACommercialHeroBanner], __VERSION_INFO__);
 
 export default AXACommercialHeroBanner;

--- a/src/components/30-organisms/container/index.js
+++ b/src/components/30-organisms/container/index.js
@@ -24,7 +24,6 @@ class AXAContainer extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAContainer], __VERSION_INFO__);
 
 export default AXAContainer;

--- a/src/components/30-organisms/footer/index.js
+++ b/src/components/30-organisms/footer/index.js
@@ -60,9 +60,7 @@ class AXAFooter extends InlineStyles {
     this._accordionActiveIndex = -1;
     this.slotsNotPrepared = true;
 
-    /* eslint-disable no-undef */
     defineVersioned([AXAContainer], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   firstUpdated() {
@@ -387,7 +385,6 @@ class AXAFooter extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAFooter], __VERSION_INFO__);
 
 export default AXAFooter;

--- a/src/components/30-organisms/modal/index.js
+++ b/src/components/30-organisms/modal/index.js
@@ -85,7 +85,6 @@ class AXAModal extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXAModal], __VERSION_INFO__);
 
 export default AXAModal;

--- a/src/components/30-organisms/table-sortable/index.js
+++ b/src/components/30-organisms/table-sortable/index.js
@@ -43,9 +43,8 @@ class AXATableSortable extends LitElement {
       sensitivity: 'variant',
     });
     this.lastIndex = -1;
-    /* eslint-disable no-undef */
+
     defineVersioned([AXATable], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   static get tagName() {
@@ -353,7 +352,6 @@ class AXATableSortable extends LitElement {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXATableSortable], __VERSION_INFO__);
 
 export default AXATableSortable;

--- a/src/components/30-organisms/table/index.js
+++ b/src/components/30-organisms/table/index.js
@@ -57,7 +57,6 @@ class AXATable extends NoShadowDOM {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXATable], __VERSION_INFO__);
 
 export default AXATable;

--- a/src/components/30-organisms/testimonials/index.js
+++ b/src/components/30-organisms/testimonials/index.js
@@ -43,9 +43,8 @@ class AXATestimonials extends InlineStyles {
 
     // default values props
     applyDefaults(this);
-    /* eslint-disable no-undef */
+
     defineVersioned([AXAContainer, AXACarousel], __VERSION_INFO__, this);
-    /* eslint-enable no-undef */
   }
 
   firstUpdated() {
@@ -106,7 +105,6 @@ class AXATestimonials extends InlineStyles {
   }
 }
 
-/* eslint-disable no-undef */
 defineVersioned([AXATestimonials], __VERSION_INFO__);
 
 export default AXATestimonials;


### PR DESCRIPTION
Removes a lot of eslint ignores.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
