### PR TITLE
make release script not having conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch-components": "lerna run watch --parallel",
     "setup-npm-links": "node scripts/setup-npm-link.js",
     "postinstall": "lerna bootstrap --hoist && cross-env NODE_ENV=production npm run build-components && lerna run --parallel genPackagelock",
-    "release": "npm whoami && npx lerna clean && npm ci && npm run test && lerna version --exact && cross-env NODE_ENV=production npm run build-components && lerna publish from-package && git clean -dfxq -e .idea -e .vscode && npm install",
+    "release": "npm whoami && npx lerna clean && npm ci && npm run test && lerna version --exact && cross-env NODE_ENV=production npm run build-components && lerna publish from-package && git clean -dfxq -e .idea -e .vscode && npm install && git add * && git commit -m 'release: update package locks' && git push",
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006 -s src/static",
     "build-storybook": "build-storybook -s ./src/static",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch-components": "lerna run watch --parallel",
     "setup-npm-links": "node scripts/setup-npm-link.js",
     "postinstall": "lerna bootstrap --hoist && cross-env NODE_ENV=production npm run build-components && lerna run --parallel genPackagelock",
-    "release": "npm whoami && npx lerna clean && npm ci && npm run test && lerna version --exact && cross-env NODE_ENV=production npm run build-components && lerna publish from-package && git clean -dfxq -e .idea -e .vscode && npm install && git add * && git commit -m 'release: update package locks' && git push",
+    "release": "sh scripts/release.sh",
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006 -s src/static",
     "build-storybook": "build-storybook -s ./src/static",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch-components": "lerna run watch --parallel",
     "setup-npm-links": "node scripts/setup-npm-link.js",
     "postinstall": "lerna bootstrap --hoist && cross-env NODE_ENV=production npm run build-components && lerna run --parallel genPackagelock",
-    "release": "npm whoami && npx lerna clean && npm ci && npm run test && lerna version --exact && cross-env NODE_ENV=production npm run build-components && lerna publish from-package",
+    "release": "npm whoami && npx lerna clean && npm ci && npm run test && lerna version --exact && cross-env NODE_ENV=production npm run build-components && lerna publish from-package && git clean -dfxq -e .idea -e .vscode && npm install",
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006 -s src/static",
     "build-storybook": "build-storybook -s ./src/static",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+npm whoami
+npx lerna clean
+npm ci
+npm run test
+npx lerna version --exact
+npx cross-env NODE_ENV=production npm run build-components
+lerna publish from-package
+git clean -dfxq -e .idea -e .vscode
+npm install
+git add *
+git commit -m 'release: update package locks'
+git push


### PR DESCRIPTION
Our release script always leaves behind some waste (package-locks that are not properly updated). Upcoming feature branches have to bleed for this problem. This PR makes sure that this never happens again. This approach removes the cumbersome situation with merge conflicts afterwards.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch/patterns-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
