### PR TITLE
re-add usage for file-upload

### DIFF
--- a/src/components/20-molecules/file-upload/README.md
+++ b/src/components/20-molecules/file-upload/README.md
@@ -17,6 +17,28 @@ A component used for uploading files in forms.
 - All images are compressed and .png are converted to .jpeg.
 - There will be a thumbnail for all images selected. For other types (for now only .pdf) an icon will represent the file.
 
+## Request uploaded files:
+
+```js
+const { files } = document.querySelector('axa-file-upload');
+
+if (files.length > 0) {
+  files.map(file => {
+    const reader = new FileReader();
+
+    reader.onload = file => {
+      // success
+    };
+
+    reader.onerror = evt => {
+      // error
+    };
+
+    reader.readAsDataURL(file);
+  });
+}
+```
+
 ## Properties
 
 ### Variant


### PR DESCRIPTION
Someone asked how they can use the file upload component. It was missing from the docs, but I readded it.