### PR TITLE
add props to axa-table

### DIFF
--- a/src/components/30-organisms/table/index.react.d.ts
+++ b/src/components/30-organisms/table/index.react.d.ts
@@ -2,6 +2,8 @@ import React from 'react';
 
 export interface AXATableProps {
   className?: string;
+  innerscroll?: number;
+  maxheight?: number;
 }
 
 declare function createAXATable(


### PR DESCRIPTION
Props were functioning, but they have been forgotten for the react case.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
