### PR TITLE
Keyvisual-CTA more space between checkmarks

### DIFF
--- a/src/components/30-organisms/commercial-hero-banner/child.scss
+++ b/src/components/30-organisms/commercial-hero-banner/child.scss
@@ -31,6 +31,13 @@ axa-commercial-hero-banner {
 
   .checkmark-text {
     margin-left: 10px;
+    padding-top: 4px;
+    padding-bottom: 8px;
+
+    @include breakpoint($mediaquery-xs-up) {
+      padding-top: 0;
+      padding-bottom: 12px;
+    }
   }
 
   header > p {


### PR DESCRIPTION
Fixes #

12px added between checkmarks on Keyvisual CTA component as on the design.
With simple padding-bottom:12px on XS screen it looks bad
<img width="367" alt="Screenshot 2021-10-18 at 12 04 40" src="https://user-images.githubusercontent.com/37440641/137711882-cae26026-13f9-46b9-a209-2c09b49e5dda.png">
so for XS screen I've set 
```
padding-top:4px; 
padding-bottom:8px;
```
to make the text aligned with the icon.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Modifications still work in IE.
- [ ] Documentation is up to date.
- [ ] Changelog is up to date.
- [ ] Typescript typings for properties are up to date.
- [ ] Designers approved changes or no approval needed.
- [ ] Dependencies to other components still work.
