### PR TITLE
remove no longer needed IE11 checklist point

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@ Fixes #
 # Merge Checklist:
 - [ ] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
 - [ ] Tests are sufficient.
-- [ ] Modifications still work in IE.
 - [ ] Documentation is up to date.
 - [ ] Changelog is up to date.
 - [ ] Typescript typings for properties are up to date.


### PR DESCRIPTION
IE11 is not longer supported in less than a week from now.
