### PR TITLE
Fix broken storybook pages after latest lit migration

### DIFF
--- a/src/components/00-materials/story.js
+++ b/src/components/00-materials/story.js
@@ -1,6 +1,7 @@
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 import { html, render } from 'lit';
 import { repeat } from 'lit/directives/repeat';
+import { unsafeHTML } from 'lit/directives/unsafe-html';
 import '../10-atoms/heading';
 import '../10-atoms/text';
 import changelog from './CHANGELOG.md';
@@ -295,7 +296,7 @@ export const IconsAndImages = () => {
             </axa-text>
             <div class="materials__icon-container">
               ${repeat(icons.slice(0, assetsToRenderNext), i =>
-                html([mapToIconItem(i)])
+                unsafeHTML(mapToIconItem(i))
               )}
             </div>
           </div>
@@ -306,7 +307,7 @@ export const IconsAndImages = () => {
             </axa-text>
             <div class="materials__images-container">
               ${repeat(images.slice(0, assetsToRenderNext / 2), i =>
-                html([mapToIconItem(i, 'materials__single-image')])
+                unsafeHTML(mapToIconItem(i, 'materials__single-image'))
               )}
             </div>
           </div>

--- a/src/other/pages/showcases/axa-ch-main/navbar.js
+++ b/src/other/pages/showcases/axa-ch-main/navbar.js
@@ -1,9 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { html, svg } from 'lit';
-
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html';
 import axaLogo from '@axa-ch/materials/images/axa-logo.svg';
 
-const logo = svg([axaLogo]);
+const logo = unsafeHTML(axaLogo);
 
 const style = html`
   <style>


### PR DESCRIPTION
Fixes #2269.

To understand these fixes, refer to https://github.com/axa-ch-webhub-cloud/pattern-library/pull/2218/commits/3179f7bef8eaf849fe681f4dadc2e110bbb80158: these are just more of the same.

See also https://lit.dev/docs/api/directives/#unsafeHTML and the warning in https://lit.dev/docs/api/templates/#svg.

How to test: http://localhost:6006/?path=/story/pages-axa--axa and http://localhost:6006/?path=/story/brand-elements-icons-and-images--icons-and-images work locally.

And https://axa-ch-webhub-cloud.github.io/plib-feature/bugfix/broken-storybook-pages/?path=/story/pages-axa--axa works in the cloud.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
