### PR TITLE
WEBHUB-1346 Betreuungshinweis - close icon

### DIFF
--- a/src/components/30-organisms/modal/CHANGELOG.md
+++ b/src/components/30-organisms/modal/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.1
 
-- Fix: inverted desktop and mobile close icons for `noheader` size option #2293
+- Fix: Inverted desktop and mobile close icons for `noheader` size option. #2293
 
 ## 3.1.0
 

--- a/src/components/30-organisms/modal/CHANGELOG.md
+++ b/src/components/30-organisms/modal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Fix: inverted desktop and mobile close icons for `noheader` size option #2293
+
 ## 3.1.0
 
 - Add a `noheader` option. #2292

--- a/src/components/30-organisms/modal/index.scss
+++ b/src/components/30-organisms/modal/index.scss
@@ -138,10 +138,13 @@
       right: 9px;
       z-index: 1;
 
-      @include breakpoint($mediaquery-xs-up) {
-        svg {
-          color: $color-prim-white;
-          filter: drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.8));
+      svg {
+        color: $color-prim-white;
+        filter: drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.8));
+
+        @include breakpoint($mediaquery-xs-up) {
+          color: $color-axa-blue;
+          filter: unset;
         }
       }
     }

--- a/src/components/30-organisms/modal/package.json
+++ b/src/components/30-organisms/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/modal",
-  "version": "3.1.1",
+  "version": "3.1.0",
   "description": "The modal component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/modal#readme",

--- a/src/components/30-organisms/modal/package.json
+++ b/src/components/30-organisms/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/modal",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The modal component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/modal#readme",


### PR DESCRIPTION
Fixes #

The white close icon should be displayed on mobile screen while the standard blue icon should be displayed on desktop screen. The white close icon is needed on mobile screen because of the possible dark background images.
This is the expected behaviour  : 
<img width="445" alt="Screenshot 2022-06-20 at 11 19 07" src="https://user-images.githubusercontent.com/37440641/174570404-538e8f3d-aa08-4dd6-8b54-86bb339cbd22.png">


# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
