### PR TITLE
WEBHUB-1346 Betreuungshinweis - hide vertical scrollbar

### DIFF
--- a/src/components/30-organisms/modal/CHANGELOG.md
+++ b/src/components/30-organisms/modal/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 3.1.2
-
-- Hide the vertical scrollbar for `noheader` size option.
-
 ## 3.1.1
 
 - Fix: Inverted desktop and mobile close icons for `noheader` size option. #2293
+- Hide the vertical scrollbar for `noheader` size option.
 
 ## 3.1.0
 

--- a/src/components/30-organisms/modal/CHANGELOG.md
+++ b/src/components/30-organisms/modal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+
+- Hide the vertical scrollbar for `noheader` size option.
+
 ## 3.1.1
 
 - Fix: Inverted desktop and mobile close icons for `noheader` size option. #2293

--- a/src/components/30-organisms/modal/index.scss
+++ b/src/components/30-organisms/modal/index.scss
@@ -131,6 +131,15 @@
     &--noheader {
       border-radius: $spacing-2;
       padding: 0;
+
+      @include breakpoint($mediaquery-xs-up) {
+        overflow-y: scroll;
+        scrollbar-width: none;
+
+        &::-webkit-scrollbar {
+          display: none;
+        }
+      }
     }
 
     .o-modal__upper-close-container-button {

--- a/src/components/30-organisms/modal/index.scss
+++ b/src/components/30-organisms/modal/index.scss
@@ -132,7 +132,7 @@
       border-radius: $spacing-2;
       padding: 0;
 
-      @include breakpoint($mediaquery-xs-up) {
+      @media (min-width: $breakpoint-xs) {
         overflow-y: scroll;
         scrollbar-width: none;
 


### PR DESCRIPTION
Fixes #

Hides the vertical scrollbar for "noheader" modal. The content is still scrollable but the scrollbar is not visible.
This scrollbar is not even needed for "noheader" modal since the div inside of the content will be scrollable.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
