### PR TITLE
Release

### DIFF
--- a/src/components/00-materials/package-lock.json
+++ b/src/components/00-materials/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/materials",
-      "version": "16.0.0",
+      "version": "16.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "lit": "^2.2.1"

--- a/src/components/00-materials/package-lock.json
+++ b/src/components/00-materials/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/materials",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/00-materials/package.json
+++ b/src/components/00-materials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/materials",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "The materials component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/00-materials/#readme",

--- a/src/components/10-atoms/button-link/package-lock.json
+++ b/src/components/10-atoms/button-link/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/button-link",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -77,19 +77,19 @@
   },
   "dependencies": {
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/10-atoms/button-link/package-lock.json
+++ b/src/components/10-atoms/button-link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/button-link",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/button-link/package.json
+++ b/src/components/10-atoms/button-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/button-link",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The button-link component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/button#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/icon": "8.0.0",
+    "@axa-ch/icon": "8.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/10-atoms/button/package-lock.json
+++ b/src/components/10-atoms/button/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/button",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -77,19 +77,19 @@
   },
   "dependencies": {
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/10-atoms/button/package-lock.json
+++ b/src/components/10-atoms/button/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/button",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/button/package.json
+++ b/src/components/10-atoms/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/button",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "The button component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/button#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/icon": "8.0.0",
+    "@axa-ch/icon": "8.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/10-atoms/carousel/package-lock.json
+++ b/src/components/10-atoms/carousel/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/carousel",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/carousel/package-lock.json
+++ b/src/components/10-atoms/carousel/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/carousel",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/carousel/package.json
+++ b/src/components/10-atoms/carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/carousel",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The carousel component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/carousel#readme",

--- a/src/components/10-atoms/checkbox/package-lock.json
+++ b/src/components/10-atoms/checkbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/checkbox",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/checkbox/package-lock.json
+++ b/src/components/10-atoms/checkbox/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/checkbox",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/checkbox/package.json
+++ b/src/components/10-atoms/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/checkbox",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The checkbox component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/checkbox#readme",

--- a/src/components/10-atoms/fieldset/package-lock.json
+++ b/src/components/10-atoms/fieldset/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/fieldset",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/fieldset/package-lock.json
+++ b/src/components/10-atoms/fieldset/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/fieldset",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/fieldset/package.json
+++ b/src/components/10-atoms/fieldset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/fieldset",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The fieldset component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/fieldset#readme",

--- a/src/components/10-atoms/heading/package-lock.json
+++ b/src/components/10-atoms/heading/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/heading",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/heading/package-lock.json
+++ b/src/components/10-atoms/heading/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/heading",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/heading/package.json
+++ b/src/components/10-atoms/heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/heading",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The heading component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/heading#readme",

--- a/src/components/10-atoms/icon/package-lock.json
+++ b/src/components/10-atoms/icon/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/icon",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/icon/package-lock.json
+++ b/src/components/10-atoms/icon/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/icon",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/10-atoms/icon/package.json
+++ b/src/components/10-atoms/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/icon",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "The icon component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/icon#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/10-atoms/input-file/package-lock.json
+++ b/src/components/10-atoms/input-file/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/input-file",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -77,19 +77,19 @@
   },
   "dependencies": {
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/10-atoms/input-file/package-lock.json
+++ b/src/components/10-atoms/input-file/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/input-file",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/input-file/package.json
+++ b/src/components/10-atoms/input-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/input-file",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The input-file component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/input-file#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/icon": "8.0.0",
+    "@axa-ch/icon": "8.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/10-atoms/input-text/package-lock.json
+++ b/src/components/10-atoms/input-text/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/input-text",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/input-text/package-lock.json
+++ b/src/components/10-atoms/input-text/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/input-text",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/popup": "5.0.0",
+        "@axa-ch/popup": "5.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/popup": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/popup/-/popup-5.0.0.tgz",
-      "integrity": "sha512-8Np8G73w+OPbqWL6W7Smpl1Fw4qLljmTqrS48rcqUuUw81kZDzs6Ui8MOs332IYmLbrfElcqQUlaCUpJdh6Meg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/popup/-/popup-5.0.1.tgz",
+      "integrity": "sha512-+1n/elKzttGCEB3FbZzSXYv2RMqNPsmQX4kk8rqZZe7eYCqnmcDVw02NdI9JirghChZaLyMJpdKQs3l4T4N8dQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
@@ -77,19 +77,19 @@
   },
   "dependencies": {
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/popup": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/popup/-/popup-5.0.0.tgz",
-      "integrity": "sha512-8Np8G73w+OPbqWL6W7Smpl1Fw4qLljmTqrS48rcqUuUw81kZDzs6Ui8MOs332IYmLbrfElcqQUlaCUpJdh6Meg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/popup/-/popup-5.0.1.tgz",
+      "integrity": "sha512-+1n/elKzttGCEB3FbZzSXYv2RMqNPsmQX4kk8rqZZe7eYCqnmcDVw02NdI9JirghChZaLyMJpdKQs3l4T4N8dQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }

--- a/src/components/10-atoms/input-text/package.json
+++ b/src/components/10-atoms/input-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/input-text",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The input-text component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/input-text#readme",
@@ -30,7 +30,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/popup": "5.0.0",
+    "@axa-ch/popup": "5.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/10-atoms/link/package-lock.json
+++ b/src/components/10-atoms/link/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/link",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/link/package-lock.json
+++ b/src/components/10-atoms/link/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/link",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -77,19 +77,19 @@
   },
   "dependencies": {
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/10-atoms/link/package.json
+++ b/src/components/10-atoms/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/link",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The link component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/src/components/10-atoms/link/README.md",
@@ -30,7 +30,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/icon": "8.0.0",
+    "@axa-ch/icon": "8.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/10-atoms/progress-bar/package-lock.json
+++ b/src/components/10-atoms/progress-bar/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@axa-ch/progress-bar",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/components/10-atoms/progress-bar/package.json
+++ b/src/components/10-atoms/progress-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/progress-bar",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The progress-bar component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/progress-bar#readme",

--- a/src/components/10-atoms/radio/package-lock.json
+++ b/src/components/10-atoms/radio/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/radio",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/radio/package-lock.json
+++ b/src/components/10-atoms/radio/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/radio",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/radio/package.json
+++ b/src/components/10-atoms/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/radio",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The radio-button component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/radio#readme",

--- a/src/components/10-atoms/spinner/package-lock.json
+++ b/src/components/10-atoms/spinner/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@axa-ch/spinner",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/components/10-atoms/spinner/package.json
+++ b/src/components/10-atoms/spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/spinner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The spinner component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/spinner#readme",

--- a/src/components/10-atoms/text/package-lock.json
+++ b/src/components/10-atoms/text/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/text",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/text/package-lock.json
+++ b/src/components/10-atoms/text/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/text",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/text/package.json
+++ b/src/components/10-atoms/text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/text",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The text component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/text#readme",

--- a/src/components/10-atoms/textarea/package-lock.json
+++ b/src/components/10-atoms/textarea/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/textarea",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/textarea/package-lock.json
+++ b/src/components/10-atoms/textarea/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/textarea",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/textarea/package.json
+++ b/src/components/10-atoms/textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/textarea",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The textarea component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/textarea#readme",

--- a/src/components/10-atoms/toggle-switch/package-lock.json
+++ b/src/components/10-atoms/toggle-switch/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/toggle-switch",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/10-atoms/toggle-switch/package-lock.json
+++ b/src/components/10-atoms/toggle-switch/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/toggle-switch",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Copyright 2021 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/10-atoms/toggle-switch/package.json
+++ b/src/components/10-atoms/toggle-switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/toggle-switch",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The toggle-switch component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/10-atoms/toggle-switch#readme",

--- a/src/components/20-molecules/accordion/package.json
+++ b/src/components/20-molecules/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/accordion",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The accordion component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/accordion#readme",
@@ -26,7 +26,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/cookie-disclaimer/package-lock.json
+++ b/src/components/20-molecules/cookie-disclaimer/package-lock.json
@@ -6,48 +6,48 @@
   "packages": {
     "": {
       "name": "@axa-ch/cookie-disclaimer",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/button": "8.0.0",
-        "@axa-ch/container": "5.0.0",
+        "@axa-ch/button": "8.0.1",
+        "@axa-ch/container": "5.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/button": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.0.tgz",
-      "integrity": "sha512-oPzgg0tbZu5u7MIsVWuDAv9mRMCwTvV+W7g2ofvfzgMXdv5kkMyAza91+Rc76/OuBz+S/t2Bddqb1SICuPSSug==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.1.tgz",
+      "integrity": "sha512-/ci9jGW8sZWBS7lpIy5RqOF3gG/AHQGaSGCuTcBc0mWGVMInc17RMvkwzL8Xi28XLL6GrDH/pQh5D1V3mInFsw==",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -97,38 +97,38 @@
   },
   "dependencies": {
     "@axa-ch/button": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.0.tgz",
-      "integrity": "sha512-oPzgg0tbZu5u7MIsVWuDAv9mRMCwTvV+W7g2ofvfzgMXdv5kkMyAza91+Rc76/OuBz+S/t2Bddqb1SICuPSSug==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.1.tgz",
+      "integrity": "sha512-/ci9jGW8sZWBS7lpIy5RqOF3gG/AHQGaSGCuTcBc0mWGVMInc17RMvkwzL8Xi28XLL6GrDH/pQh5D1V3mInFsw==",
       "requires": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/cookie-disclaimer/package-lock.json
+++ b/src/components/20-molecules/cookie-disclaimer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/cookie-disclaimer",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/cookie-disclaimer/package.json
+++ b/src/components/20-molecules/cookie-disclaimer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/cookie-disclaimer",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The cookie-disclaimer component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/cookie-disclaimer#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/button": "8.0.0",
-    "@axa-ch/container": "5.0.0",
+    "@axa-ch/button": "8.0.1",
+    "@axa-ch/container": "5.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/datepicker/package-lock.json
+++ b/src/components/20-molecules/datepicker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/datepicker",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/datepicker/package-lock.json
+++ b/src/components/20-molecules/datepicker/package-lock.json
@@ -6,30 +6,30 @@
   "packages": {
     "": {
       "name": "@axa-ch/datepicker",
-      "version": "17.0.0",
+      "version": "17.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/dropdown": "11.0.0",
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/dropdown": "11.0.1",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "date-fns": "^2.28.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/dropdown": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/dropdown/-/dropdown-11.0.0.tgz",
-      "integrity": "sha512-IC6ET0XuuTUWW1wblfA3LiKI1pLQrf8NZSBYVFSMRKz6W1HsvZUd1haZLv11DWjrZfe9sgrGbCjYlvjy6LgiwQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/dropdown/-/dropdown-11.0.1.tgz",
+      "integrity": "sha512-EeRIHbwIQDh5qxxMSlXmUv0e1v28s9VMn5B5Ua1aGHLQ4u75y6KuxNA5qcCEhgs2dSmcIP2uo7RonLNAWhKMrA==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -91,19 +91,19 @@
   },
   "dependencies": {
     "@axa-ch/dropdown": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/dropdown/-/dropdown-11.0.0.tgz",
-      "integrity": "sha512-IC6ET0XuuTUWW1wblfA3LiKI1pLQrf8NZSBYVFSMRKz6W1HsvZUd1haZLv11DWjrZfe9sgrGbCjYlvjy6LgiwQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/dropdown/-/dropdown-11.0.1.tgz",
+      "integrity": "sha512-EeRIHbwIQDh5qxxMSlXmUv0e1v28s9VMn5B5Ua1aGHLQ4u75y6KuxNA5qcCEhgs2dSmcIP2uo7RonLNAWhKMrA==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/datepicker/package.json
+++ b/src/components/20-molecules/datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/datepicker",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "The datepicker component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/src/components/20-molecules/datepicker#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/dropdown": "11.0.0",
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/dropdown": "11.0.1",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "date-fns": "^2.28.0",
     "lit": "^2.2.1"

--- a/src/components/20-molecules/dropdown/package-lock.json
+++ b/src/components/20-molecules/dropdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/dropdown",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/dropdown/package-lock.json
+++ b/src/components/20-molecules/dropdown/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/dropdown",
-      "version": "11.0.0",
+      "version": "11.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/dropdown/package.json
+++ b/src/components/20-molecules/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/dropdown",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "The dropdown component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/src/components/20-molecules/dropdown#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/file-upload/package-lock.json
+++ b/src/components/20-molecules/file-upload/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/file-upload",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/file-upload/package-lock.json
+++ b/src/components/20-molecules/file-upload/package-lock.json
@@ -6,40 +6,40 @@
   "packages": {
     "": {
       "name": "@axa-ch/file-upload",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/input-file": "7.0.0",
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/input-file": "7.0.1",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "blueimp-canvas-to-blob": "^3.29.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/input-file": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/input-file/-/input-file-7.0.0.tgz",
-      "integrity": "sha512-9WB9LLJc4otwMaPZ8nCnWQclO0/y0ATbRPbVi2YD+AiKx0NslT7eMhhmPhsVr8kwjfCgvtsXyFJHcAQSW14dJQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/input-file/-/input-file-7.0.1.tgz",
+      "integrity": "sha512-xrMO136ebMtX2txjts/j3cH6Fnp+MzJYk1Jli06yP667DsLWuTJRuwDNdfUKqlfb7pua+JuIQb8q1IVGLAw9Uw==",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -94,29 +94,29 @@
   },
   "dependencies": {
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/input-file": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/input-file/-/input-file-7.0.0.tgz",
-      "integrity": "sha512-9WB9LLJc4otwMaPZ8nCnWQclO0/y0ATbRPbVi2YD+AiKx0NslT7eMhhmPhsVr8kwjfCgvtsXyFJHcAQSW14dJQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/input-file/-/input-file-7.0.1.tgz",
+      "integrity": "sha512-xrMO136ebMtX2txjts/j3cH6Fnp+MzJYk1Jli06yP667DsLWuTJRuwDNdfUKqlfb7pua+JuIQb8q1IVGLAw9Uw==",
       "requires": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/file-upload/package.json
+++ b/src/components/20-molecules/file-upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/file-upload",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The file-upload component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/file-upload#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/input-file": "7.0.0",
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/input-file": "7.0.1",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "blueimp-canvas-to-blob": "^3.29.0",
     "lit": "^2.2.1"

--- a/src/components/20-molecules/footer-small/package-lock.json
+++ b/src/components/20-molecules/footer-small/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/footer-small",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/container": "5.0.0",
+        "@axa-ch/container": "5.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
@@ -68,9 +68,9 @@
   },
   "dependencies": {
     "@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"

--- a/src/components/20-molecules/footer-small/package-lock.json
+++ b/src/components/20-molecules/footer-small/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/footer-small",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/footer-small/package.json
+++ b/src/components/20-molecules/footer-small/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/footer-small",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "The footer-small component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/src/components/20-molecules/footer-small/README.md",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/container": "5.0.0",
+    "@axa-ch/container": "5.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/input-phone/package-lock.json
+++ b/src/components/20-molecules/input-phone/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@axa-ch/input-phone",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/src/components/20-molecules/input-phone/package.json
+++ b/src/components/20-molecules/input-phone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/input-phone",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The input-phone component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/input-phone#readme",
@@ -26,8 +26,8 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/dropdown": "11.0.0",
-    "@axa-ch/input-text": "6.0.0",
+    "@axa-ch/dropdown": "11.0.1",
+    "@axa-ch/input-text": "6.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/list/package-lock.json
+++ b/src/components/20-molecules/list/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@axa-ch/list",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/components/20-molecules/list/package.json
+++ b/src/components/20-molecules/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/list",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The list component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/list#readme",

--- a/src/components/20-molecules/policy-features/package-lock.json
+++ b/src/components/20-molecules/policy-features/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/policy-features",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/policy-features/package-lock.json
+++ b/src/components/20-molecules/policy-features/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/policy-features",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/20-molecules/policy-features/package.json
+++ b/src/components/20-molecules/policy-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/policy-features",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The policy-features component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/policy-features#readme",

--- a/src/components/20-molecules/popup/package-lock.json
+++ b/src/components/20-molecules/popup/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/popup",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/popup/package-lock.json
+++ b/src/components/20-molecules/popup/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/popup",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/popup/package.json
+++ b/src/components/20-molecules/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/popup",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The popup component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/popup#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/stepper/package-lock.json
+++ b/src/components/20-molecules/stepper/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/stepper",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/stepper/package-lock.json
+++ b/src/components/20-molecules/stepper/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/stepper",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Copyright 2020 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/stepper/package.json
+++ b/src/components/20-molecules/stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/stepper",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The stepper component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/stepper#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/20-molecules/top-content-bar/package-lock.json
+++ b/src/components/20-molecules/top-content-bar/package-lock.json
@@ -6,60 +6,60 @@
   "packages": {
     "": {
       "name": "@axa-ch/top-content-bar",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/button": "8.0.0",
-        "@axa-ch/button-link": "7.0.0",
-        "@axa-ch/container": "5.0.0",
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/button": "8.0.1",
+        "@axa-ch/button-link": "7.0.1",
+        "@axa-ch/container": "5.0.1",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/button": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.0.tgz",
-      "integrity": "sha512-oPzgg0tbZu5u7MIsVWuDAv9mRMCwTvV+W7g2ofvfzgMXdv5kkMyAza91+Rc76/OuBz+S/t2Bddqb1SICuPSSug==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.1.tgz",
+      "integrity": "sha512-/ci9jGW8sZWBS7lpIy5RqOF3gG/AHQGaSGCuTcBc0mWGVMInc17RMvkwzL8Xi28XLL6GrDH/pQh5D1V3mInFsw==",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/button-link": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/button-link/-/button-link-7.0.0.tgz",
-      "integrity": "sha512-Cj5lne+CVuEvbompngmggJvdeIWB7uNdCHXEJDfRFdCNwnLBBVkQmSu9LEyCNGWmvyYGMpdCv218AcbxnGHvuw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/button-link/-/button-link-7.0.1.tgz",
+      "integrity": "sha512-mm+bEBQYrpPDzOQ0HHB+h+fJ1wVevDJwAlJZCzMWo60kKTw3mBR4y9YnmIA0qbOIwGHteObXUWfolyNGfup25g==",
       "dependencies": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "dependencies": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -109,48 +109,48 @@
   },
   "dependencies": {
     "@axa-ch/button": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.0.tgz",
-      "integrity": "sha512-oPzgg0tbZu5u7MIsVWuDAv9mRMCwTvV+W7g2ofvfzgMXdv5kkMyAza91+Rc76/OuBz+S/t2Bddqb1SICuPSSug==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/button/-/button-8.0.1.tgz",
+      "integrity": "sha512-/ci9jGW8sZWBS7lpIy5RqOF3gG/AHQGaSGCuTcBc0mWGVMInc17RMvkwzL8Xi28XLL6GrDH/pQh5D1V3mInFsw==",
       "requires": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/button-link": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/button-link/-/button-link-7.0.0.tgz",
-      "integrity": "sha512-Cj5lne+CVuEvbompngmggJvdeIWB7uNdCHXEJDfRFdCNwnLBBVkQmSu9LEyCNGWmvyYGMpdCv218AcbxnGHvuw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/button-link/-/button-link-7.0.1.tgz",
+      "integrity": "sha512-mm+bEBQYrpPDzOQ0HHB+h+fJ1wVevDJwAlJZCzMWo60kKTw3mBR4y9YnmIA0qbOIwGHteObXUWfolyNGfup25g==",
       "requires": {
-        "@axa-ch/icon": "8.0.0",
+        "@axa-ch/icon": "8.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/icon": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.0.tgz",
-      "integrity": "sha512-8y+AXgOwwfoz5jmRk1PFddOtEyVJj6YOGbaxnMXqCSG76+ZPCJI3BeN4p6QBs4nRcq1c4k4xnv0V2xvHuMAS/g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/icon/-/icon-8.0.1.tgz",
+      "integrity": "sha512-Yc3IbtPGTrUA0yKAVQ7hXtzz1LZtOIvLHSGnKnhQnmfU8myylObT1fY+fg8incqGOSX4BHXIVFWyN0Fzy/7RBQ==",
       "requires": {
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/20-molecules/top-content-bar/package-lock.json
+++ b/src/components/20-molecules/top-content-bar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/top-content-bar",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/20-molecules/top-content-bar/package.json
+++ b/src/components/20-molecules/top-content-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/top-content-bar",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The top-content-bar component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/20-molecules/top-content-bar#readme",
@@ -27,10 +27,10 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/button": "8.0.0",
-    "@axa-ch/button-link": "7.0.0",
-    "@axa-ch/container": "5.0.0",
-    "@axa-ch/icon": "8.0.0",
+    "@axa-ch/button": "8.0.1",
+    "@axa-ch/button-link": "7.0.1",
+    "@axa-ch/container": "5.0.1",
+    "@axa-ch/icon": "8.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/30-organisms/commercial-hero-banner/package-lock.json
+++ b/src/components/30-organisms/commercial-hero-banner/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/commercial-hero-banner",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/30-organisms/commercial-hero-banner/package-lock.json
+++ b/src/components/30-organisms/commercial-hero-banner/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/commercial-hero-banner",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/container": "5.0.0",
+        "@axa-ch/container": "5.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
@@ -68,9 +68,9 @@
   },
   "dependencies": {
     "@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"

--- a/src/components/30-organisms/commercial-hero-banner/package.json
+++ b/src/components/30-organisms/commercial-hero-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/commercial-hero-banner",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The commercial-hero-banner component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/commercial-hero-banner#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/container": "5.0.0",
+    "@axa-ch/container": "5.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/30-organisms/container/package-lock.json
+++ b/src/components/30-organisms/container/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/container",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/30-organisms/container/package-lock.json
+++ b/src/components/30-organisms/container/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/container",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/30-organisms/container/package.json
+++ b/src/components/30-organisms/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/container",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The container component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/container#readme",

--- a/src/components/30-organisms/footer/package-lock.json
+++ b/src/components/30-organisms/footer/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/footer",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/container": "5.0.0",
-        "@axa-ch/materials": "16.0.0",
+        "@axa-ch/container": "5.0.1",
+        "@axa-ch/materials": "16.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "dependencies": {
         "lit": "^2.2.1"
       }
@@ -77,18 +77,18 @@
   },
   "dependencies": {
     "@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/materials": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.0.tgz",
-      "integrity": "sha512-93/hwA8D71o0W0FWzklrV7JsyJd/KPWN1zcYjGYC0hVXP0u+1FbpMOCzSeb8+qbwFIECYtzDQPJTclWQpeTnlQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/materials/-/materials-16.0.1.tgz",
+      "integrity": "sha512-hEpb0WZk74AzNxJnnmj9qIZntKPKAocVB1IMzH+CBm3q9M/KHl9YaasZbErERtRW5FT4vmjwrz3hJs1WbdHU5Q==",
       "requires": {
         "lit": "^2.2.1"
       }

--- a/src/components/30-organisms/footer/package-lock.json
+++ b/src/components/30-organisms/footer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/footer",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/30-organisms/footer/package.json
+++ b/src/components/30-organisms/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/footer",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The footer component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/footer#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/container": "5.0.0",
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/container": "5.0.1",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/30-organisms/modal/package-lock.json
+++ b/src/components/30-organisms/modal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@axa-ch/modal",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/components/30-organisms/modal/package.json
+++ b/src/components/30-organisms/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/modal",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The modal component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/modal#readme",
@@ -26,7 +26,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/materials": "16.0.0",
+    "@axa-ch/materials": "16.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/30-organisms/table-sortable/package-lock.json
+++ b/src/components/30-organisms/table-sortable/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/table-sortable",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/30-organisms/table-sortable/package-lock.json
+++ b/src/components/30-organisms/table-sortable/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "name": "@axa-ch/table-sortable",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/table": "5.0.0",
+        "@axa-ch/table": "5.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/table": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/table/-/table-5.0.0.tgz",
-      "integrity": "sha512-xbqmWEeqxapWzDQ07+eDB6k+nBuQMK2BJPe6CFLTgmFqNMDJ9ig4KkjR0BGRxOwjoZMiG7BVdaVYgDQZr8CxVg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/table/-/table-5.0.1.tgz",
+      "integrity": "sha512-/25fkZeB26JBoD+c5TjWClX6VZcTRYuHuJ42eV7oZcv/8SnNDGj31pcDMO9sBBQcCnVRblQki8zNCWM+JfsUUw==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
@@ -68,9 +68,9 @@
   },
   "dependencies": {
     "@axa-ch/table": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/table/-/table-5.0.0.tgz",
-      "integrity": "sha512-xbqmWEeqxapWzDQ07+eDB6k+nBuQMK2BJPe6CFLTgmFqNMDJ9ig4KkjR0BGRxOwjoZMiG7BVdaVYgDQZr8CxVg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/table/-/table-5.0.1.tgz",
+      "integrity": "sha512-/25fkZeB26JBoD+c5TjWClX6VZcTRYuHuJ42eV7oZcv/8SnNDGj31pcDMO9sBBQcCnVRblQki8zNCWM+JfsUUw==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"

--- a/src/components/30-organisms/table-sortable/package.json
+++ b/src/components/30-organisms/table-sortable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/table-sortable",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The table-sortable component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/table-sortable#readme",
@@ -27,7 +27,7 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/table": "5.0.0",
+    "@axa-ch/table": "5.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }

--- a/src/components/30-organisms/table/package-lock.json
+++ b/src/components/30-organisms/table/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/table",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/30-organisms/table/package-lock.json
+++ b/src/components/30-organisms/table/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@axa-ch/table",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
         "@skatejs/val": "^0.4.0",

--- a/src/components/30-organisms/table/package.json
+++ b/src/components/30-organisms/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/table",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The table component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/table#readme",

--- a/src/components/30-organisms/testimonials/package-lock.json
+++ b/src/components/30-organisms/testimonials/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/testimonials",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/30-organisms/testimonials/package-lock.json
+++ b/src/components/30-organisms/testimonials/package-lock.json
@@ -6,28 +6,28 @@
   "packages": {
     "": {
       "name": "@axa-ch/testimonials",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Copyright 2019 AXA Versicherungen AG",
       "dependencies": {
-        "@axa-ch/carousel": "5.0.0",
-        "@axa-ch/container": "5.0.0",
+        "@axa-ch/carousel": "5.0.1",
+        "@axa-ch/container": "5.0.1",
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/carousel": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/carousel/-/carousel-5.0.0.tgz",
-      "integrity": "sha512-QAsELlVAt/U5dzFNE5QEMltdqkILntnt+Eph9rOjso/0cIyWhKE3m8rbBc0BD8a2e3n8F2KeLaFXsOyKw5+k2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/carousel/-/carousel-5.0.1.tgz",
+      "integrity": "sha512-UaxgRxihXIPqfL5Wcu+EvbzZFp18gYwW/11beQi3VXPP2PDIxRcmWyWQ0bsYk6ihDZ2DrHLIPEoS58hf1hC4nA==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "node_modules/@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "dependencies": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
@@ -78,18 +78,18 @@
   },
   "dependencies": {
     "@axa-ch/carousel": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/carousel/-/carousel-5.0.0.tgz",
-      "integrity": "sha512-QAsELlVAt/U5dzFNE5QEMltdqkILntnt+Eph9rOjso/0cIyWhKE3m8rbBc0BD8a2e3n8F2KeLaFXsOyKw5+k2w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/carousel/-/carousel-5.0.1.tgz",
+      "integrity": "sha512-UaxgRxihXIPqfL5Wcu+EvbzZFp18gYwW/11beQi3VXPP2PDIxRcmWyWQ0bsYk6ihDZ2DrHLIPEoS58hf1hC4nA==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"
       }
     },
     "@axa-ch/container": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.0.tgz",
-      "integrity": "sha512-R6GjEtv3CTHJEy6E7HyZLKODPNuz2BxrGtQDc3FQTh2no6pd6FBvrznutGRKkkv7DhkhmI8r1Thu9JEZqJp3yQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@axa-ch/container/-/container-5.0.1.tgz",
+      "integrity": "sha512-BMA6OPHlfR9jcMAaEl2Eag5WQr8LhR2xU0luJHKnuvu9aFTb6i6u6qgh34cDiO9hgvl0qZTZzzErfeZcrF/39g==",
       "requires": {
         "@skatejs/val": "^0.4.0",
         "lit": "^2.2.1"

--- a/src/components/30-organisms/testimonials/package.json
+++ b/src/components/30-organisms/testimonials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-ch/testimonials",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "The testimonials component for the AXA Pattern Library",
   "author": "Pattern Warriors",
   "homepage": "https://github.com/axa-ch-webhub-cloud/pattern-library/tree/develop/src/components/30-organisms/testimonials#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/axa-ch-webhub-cloud/pattern-library/issues"
   },
   "dependencies": {
-    "@axa-ch/carousel": "5.0.0",
-    "@axa-ch/container": "5.0.0",
+    "@axa-ch/carousel": "5.0.1",
+    "@axa-ch/container": "5.0.1",
     "@skatejs/val": "^0.4.0",
     "lit": "^2.2.1"
   }


### PR DESCRIPTION
Release accordion
#2290
#2279
#2260

Release dropdown
#2270

publish:
 - @axa-ch/materials@16.0.1
 - @axa-ch/button@8.0.1
 - @axa-ch/button-link@7.0.1
 - @axa-ch/carousel@5.0.1
 - @axa-ch/checkbox@7.0.1
 - @axa-ch/fieldset@6.0.1
 - @axa-ch/heading@5.0.1
 - @axa-ch/icon@8.0.1
 - @axa-ch/input-file@7.0.1
 - @axa-ch/input-text@6.0.1
 - @axa-ch/link@7.0.1
 - @axa-ch/progress-bar@3.0.1
 - @axa-ch/radio@5.0.1
 - @axa-ch/spinner@3.0.1
 - @axa-ch/text@6.0.1
 - @axa-ch/textarea@5.0.1
 - @axa-ch/toggle-switch@4.0.1
 - @axa-ch/accordion@1.0.1
 - @axa-ch/cookie-disclaimer@6.0.1
 - @axa-ch/datepicker@17.0.1
 - @axa-ch/dropdown@11.0.1
 - @axa-ch/file-upload@7.0.1
 - @axa-ch/footer-small@7.0.1
 - @axa-ch/input-phone@2.0.1
 - @axa-ch/list@3.0.1
 - @axa-ch/policy-features@5.0.1
 - @axa-ch/popup@5.0.1
 - @axa-ch/stepper@3.0.1
 - @axa-ch/top-content-bar@6.0.1
 - @axa-ch/commercial-hero-banner@6.0.1
 - @axa-ch/container@5.0.1
 - @axa-ch/footer@6.0.1
 - @axa-ch/modal@4.0.1
 - @axa-ch/table@5.0.1
 - @axa-ch/table-sortable@5.0.1
 - @axa-ch/testimonials@5.0.1

# Merge Checklist:
- [ ] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [ ] Tests are sufficient.
- [ ] Documentation is up to date.
- [ ] Changelog is up to date.
- [ ] Typescript typings for properties are up to date.
- [ ] Designers approved changes or no approval needed.
- [ ] Dependencies to other components still work.
