### PR TITLE
Allow button-link with long texts to be externally styled w.r.t width, adapting its height accordingly

### DIFF
--- a/src/components/10-atoms/button-link/CHANGELOG.md
+++ b/src/components/10-atoms/button-link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.1
+
+- Fix bug preventing height adaptation with long texts and externally restricted width. #2234
+
 ## 7.0.0
 
 - Support for IE11 has been discontinued. Therefore, we no longer transpile the code with Babel, the codebase is based on ES2019.

--- a/src/components/10-atoms/button-link/index.scss
+++ b/src/components/10-atoms/button-link/index.scss
@@ -46,8 +46,6 @@
     align-items: center;
     text-align: center;
     min-height: 36px;
-    // IE11 workaround
-    height: 25px;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
Fixes #2234.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
