### PR TITLE
Fixes/remove ie fallbacks

### DIFF
--- a/src/components/20-molecules/list/index.js
+++ b/src/components/20-molecules/list/index.js
@@ -68,22 +68,6 @@ class AXAList extends InlineStyles {
         li.style.backgroundImage = `url('data:image/svg+xml;charset=UTF-8,${this.icon}')`;
       });
     }
-
-    /**
-     * Fallback for IE11.
-     * This was the best way to handle IE11 compatibility, as there would not
-     * have been a way without drastically increasing the amount of DOM nodes
-     * and complexity for the user. Approved by our designers.
-     */
-    if (document.documentMode) {
-      if (this.variant === 'ordered') {
-        this.shadowRoot.querySelector('.m-list').style.listStyleType =
-          'decimal';
-        this.shadowRoot.querySelector('.m-list').style.marginLeft = '16px';
-      } else {
-        this.shadowRoot.querySelector('.m-list').style.listStyleType = 'disc';
-      }
-    }
   }
 }
 

--- a/src/components/30-organisms/footer/index.scss
+++ b/src/components/30-organisms/footer/index.scss
@@ -43,16 +43,6 @@
     @media (min-width: $breakpoint-xs) {
       display: flex;
       grid-area: links;
-
-      // IE11 workaround
-      -ms-grid-row: 1;
-      -ms-grid-column: 1;
-    }
-
-    @media (min-width: $breakpoint-md) {
-      // IE11 workaround
-      -ms-grid-row: 1;
-      -ms-grid-column: 1;
     }
   }
 
@@ -62,26 +52,8 @@
   }
 
   &__social-media {
-    // IE11 workaround: This breakpoint will make sure, that everything in it
-    // is IE10+ exclusive
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-      @media (min-width: $breakpoint-md) {
-        margin-left: 100px;
-      }
-    }
-
     @media (min-width: $breakpoint-xs) {
       grid-area: social;
-
-      // IE11 workaround
-      -ms-grid-row: 2;
-      -ms-grid-column: 1;
-    }
-
-    @media (min-width: $breakpoint-md) {
-      // IE11 workaround
-      -ms-grid-row: 1;
-      -ms-grid-column: 2;
     }
 
     &-title {
@@ -95,8 +67,6 @@
       margin: 0;
       text-indent: 0;
       list-style-type: none;
-      padding: 0;
-
       display: flex;
       flex-wrap: wrap;
       padding: 15px 20px;
@@ -110,14 +80,12 @@
       }
 
       @media (min-width: $breakpoint-xs) {
-        margin: 0;
         text-indent: 0;
         list-style-type: none;
-        padding: 0;
+        padding: 15px 0 0 0;
 
         display: flex;
         flex-wrap: wrap;
-        padding-top: 15px;
 
         margin-left: -10px;
 
@@ -234,9 +202,8 @@
         padding-top: 10px;
         width: 330px;
 
-        // IE11 workaround (use 'unset'-property for those two elements)
-        background-color: $color-dark-indigo;
-        max-height: 1000px !important;
+        background-color: unset;
+        max-height: unset;
 
         &--short {
           width: 165px;


### PR DESCRIPTION
Remove ie11 fallbacks.

I have to say that footer css is so strange. I checked if kinda working seems okay.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
