### PR TITLE
Bugfix/webhub 2210 fix dropdown default title selectability

### DIFF
--- a/src/components/20-molecules/datepicker/CHANGELOG.md
+++ b/src/components/20-molecules/datepicker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.1.6
+
+Fix bug with embedded dropdown, which allowed selecting Choose month/year. #2416
+
 ## 17.1.5
 
 Re-release after fixing component-versioning bug.

--- a/src/components/20-molecules/dropdown/CHANGELOG.md
+++ b/src/components/20-molecules/dropdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.0.4
+
+Fix bug that made defaulttitle option to be selectable on native. #2416
+
 ## 12.0.3
 
 Re-release after fixing component-versioning bug.

--- a/src/components/20-molecules/dropdown/index.js
+++ b/src/components/20-molecules/dropdown/index.js
@@ -95,7 +95,7 @@ const contentItemsMapper =
 
 const defaultTitleIfNeeded = (title, anotherSelection) =>
   title
-    ? [{ name: title, _disable: true, selected: !anotherSelection, value: '' }]
+    ? [{ name: title, _disabled: true, selected: !anotherSelection, value: '' }]
     : [];
 
 // CE

--- a/src/components/20-molecules/input-phone/CHANGELOG.md
+++ b/src/components/20-molecules/input-phone/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.13
+
+Fix bug with embedded dropdown. #2416
+
 ## 2.0.12
 
 Re-release after fixing component-versioning bug.


### PR DESCRIPTION
Fixes #2416.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
