### PR TITLE
Fix axa top content bar props declaration

### DIFF
--- a/src/components/20-molecules/top-content-bar/CHANGELOG.md
+++ b/src/components/20-molecules/top-content-bar/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.1
+- Add missing values for variant type definition.
+- Add missing type definition for onClose.
+
 ## 6.2.0
 
 Update package scope, registry and repository URL. #2423

--- a/src/components/20-molecules/top-content-bar/README.md
+++ b/src/components/20-molecules/top-content-bar/README.md
@@ -9,9 +9,11 @@ There is also the possibility to add child elements.
 
 ### Variant
 
-| Attribute           | Details                                        |
-| ------------------- | ---------------------------------------------- |
-| `variant="warning"` | Show a red top content bar as a warning banner |
+| Attribute             | Details                                        |
+| -------------------   | ---------------------------------------------- |
+| `variant="warning"`   | Show a red top content bar as a warning banner |
+| `variant="success"`   | Show a green top content bar as a success banner |
+| `variant="attention"` | Show a yellow top content bar as a attention banner |
 
 ### ctatext
 

--- a/src/components/20-molecules/top-content-bar/index.react.d.ts
+++ b/src/components/20-molecules/top-content-bar/index.react.d.ts
@@ -13,6 +13,7 @@ export interface AXATopContentBarProps {
   className?: string;
   children?: React.ReactNode;
   onClick?: () => void;
+  onClose?: () => void;
 }
 
 declare function createAXATopContentBar(

--- a/src/components/20-molecules/top-content-bar/index.react.d.ts
+++ b/src/components/20-molecules/top-content-bar/index.react.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type Variant = 'warning';
+export type Variant = 'default' | 'warning' | 'success' | 'attention';
 
 export interface AXATopContentBarProps {
   variant?: Variant;


### PR DESCRIPTION
Fixes #2444
Fix type declaration for AXATopContentBarProps.

# Merge Checklist:
- [x] Code selfreview has been performed ([Best Practices](https://github.com/axa-ch-webhub-cloud/pattern-library/blob/develop/CONTRIBUTION.md#best-practices)).
- [x] Tests are sufficient.
- [x] Documentation is up to date.
- [x] Changelog is up to date.
- [x] Typescript typings for properties are up to date.
- [x] Designers approved changes or no approval needed.
- [x] Dependencies to other components still work.
